### PR TITLE
parser: bound recursion depth to prevent stack-overflow segfault (closes #4)

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -58,6 +58,21 @@ struct Parser {
   bool ok = true;
   explicit Parser(const std::string &str) : s(str) {}
 
+  // Bound recursion so a deeply nested expression -- e.g. thousands of nested
+  // parentheses or unary operators in $(( ... )) -- fails to parse instead of
+  // overflowing the call stack and crashing the shell.  Far above any real use.
+  int rec_depth = 0;
+  static constexpr int kMaxDepth = 1000;
+  struct DepthGuard {
+    Parser &p;
+    bool allowed;
+    explicit DepthGuard(Parser &pp) : p(pp) {
+      allowed = (++p.rec_depth <= kMaxDepth);
+      if (!allowed) p.ok = false;
+    }
+    ~DepthGuard() { --p.rec_depth; }
+  };
+
   void skip() { while (pos < s.size() && std::isspace(static_cast<unsigned char>(s[pos]))) pos++; }
   char peek() { skip(); return pos < s.size() ? s[pos] : '\0'; }
   bool eat(const char *op) {
@@ -229,6 +244,8 @@ struct Parser {
     return base;
   }
   NodeP unary() {
+    DepthGuard g(*this);
+    if (!g.allowed) return mk(K::Num);  // too deep: bail with a placeholder
     skip();
     if (eat("++")) return preincr(K::PreInc);
     if (eat("--")) return preincr(K::PreDec);

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -81,6 +81,23 @@ struct Parser {
 
   explicit Parser(std::vector<Token> t) : toks(std::move(t)) {}
 
+  // Recursion-depth guard: deeply nested constructs -- e.g. thousands of nested
+  // `(...)' subshells, `if's, or `[[ (...) ]]' -- would otherwise overflow the
+  // C++ call stack and crash the process.  The cap is far above any real script
+  // (bash tolerates a few thousand levels before it, too, segfaults); on excess
+  // we report a syntax error and unwind cleanly instead of faulting.
+  std::size_t nest_depth = 0;
+  static constexpr std::size_t kMaxNesting = 1000;
+  struct NestGuard {
+    Parser &p;
+    bool ok;
+    explicit NestGuard(Parser &pp) : p(pp) {
+      ok = (++p.nest_depth <= kMaxNesting);
+      if (!ok) p.fail("maximum nesting depth exceeded");
+    }
+    ~NestGuard() { --p.nest_depth; }
+  };
+
   const Token &cur() const { return toks[i]; }
   const Token &peek(std::size_t k) const {
     std::size_t j = i + k;
@@ -353,6 +370,8 @@ struct Parser {
 
   // -- commands ------------------------------------------------------------
   CommandPtr parse_command(std::initializer_list<const char *> stops) {
+    NestGuard g(*this);
+    if (!g.ok) return nullptr;
     if (is(Tok::Lparen)) {
       if (cur().glued && peek(1).type == Tok::Lparen) return parse_arith_command();
       return parse_subshell();
@@ -618,6 +637,8 @@ struct Parser {
 
   void cond_primary(std::string &e) {
     if (err) return;
+    NestGuard g(*this);
+    if (!g.ok) return;
     if (is(Tok::Lparen)) {
       e += "( ";
       advance();
@@ -685,6 +706,8 @@ struct Parser {
   }
 
   void cond_not(std::string &e) {
+    NestGuard g(*this);
+    if (!g.ok) return;
     if (reserved("!")) {
       e += "! ";
       advance();


### PR DESCRIPTION
Closes #4.

Deeply nested constructs recursed without limit and overflowed the C++ call stack, crashing the shell with SIGSEGV (around 7500–10000 levels). bash 5.3 also segfaults on such input, but per the directive to fail gracefully rather than crash, gnash now caps nesting.

### Change
A nesting cap of **1000** — far above any real script, well below the crash threshold — added to both parsers:
- **Command / conditional parser** (`parse_command` and the `cond_*` chain): reports `gnash: syntax error: maximum nesting depth exceeded` and unwinds cleanly.
- **Arithmetic expression parser** (`arith.cpp` `unary()`): bails with a placeholder, handled like any other malformed `$(( ))` expression.

### Verification
Previously-crashing inputs (all confirmed SIGSEGV → now graceful, no crash):
- `(((…)))` 20000-deep subshells → syntax error
- `if…then…fi` 20000-deep → syntax error
- `[[ ((…)) ]]` / `[[ !!…!! ]]` deep → syntax error
- `$(( ((…)) ))` 50000-deep → returns `0`, rc 0

Normal nesting is unchanged and verified identical to bash 5.3.9 (`$(( ((((3+4)))) * 2 ))`, right-assoc `2**3**2`, nested subshells/if/`[[ ]]`, etc.). Full `ctest` passes 17/17 (excluding the pre-existing `parse_diff` environment timeout, unrelated to this change). Clean `-DGNASH_WERROR=ON` build.
