### PR TITLE
repl: C-c aborts the running command instead of killing the shell (closes #5)

### DIFF
--- a/compat/strmatch.h
+++ b/compat/strmatch.h
@@ -24,6 +24,12 @@ extern "C" {
 /* Match STRING against PATTERN, returning 0 on match, FNM_NOMATCH otherwise. */
 extern int strmatch (char *pattern, char *string, int flags);
 
+/* Set (non-zero) or clear (zero) the flag that makes an in-progress strmatch()
+   bail out with FNM_NOMATCH.  Called from the shell's SIGINT handler so a
+   runaway extended-pattern match can be interrupted.  Async-signal-safe (it
+   only stores a sig_atomic_t). */
+extern void strmatch_set_interrupt (int state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/include/gnash/core/executor.hpp
+++ b/core/include/gnash/core/executor.hpp
@@ -33,9 +33,12 @@ class Executor {
   int run_cond(const CondCommand *c);
   int run_arith(const ArithCommand *c);
 
-  // True if a break/continue/return/exit is unwinding the stack.
+  // True if a break/continue/return/exit -- or an interactive C-c -- is
+  // unwinding the stack.  Honoring g_sigint_received here makes every run()
+  // short-circuit, so a runaway command aborts back to the REPL prompt.
   bool unwinding() const {
-    return sh_.break_count || sh_.continue_count || sh_.returning || sh_.exiting;
+    return sh_.break_count || sh_.continue_count || sh_.returning ||
+           sh_.exiting || g_sigint_received;
   }
 };
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -6,6 +6,7 @@
 #ifndef GNASH_CORE_SHELL_HPP
 #define GNASH_CORE_SHELL_HPP
 
+#include <csignal>
 #include <map>
 #include <optional>
 #include <set>
@@ -15,6 +16,11 @@
 #include "gnash/core/ast.hpp"
 
 namespace gnash::core {
+
+// Set by the interactive SIGINT handler (repl.cpp) when C-c is pressed while a
+// command is executing.  The executor's unwinding() check honors it, so the
+// running command aborts and the loop reprompts instead of the shell dying.
+extern volatile std::sig_atomic_t g_sigint_received;
 
 enum class VarKind { Scalar, Indexed, Assoc };
 

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -8,6 +8,7 @@
 // Multi-line constructs (unterminated quotes, `if'/`for' without their closers,
 // here-documents, trailing `\') are continued with the PS2 prompt.
 
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
@@ -23,9 +24,20 @@
 #include "readline/history.h"
 #include "readline/readline.h"
 
+extern "C" void strmatch_set_interrupt(int);
+
 namespace gnash::core {
 
 namespace {
+// SIGINT while a command is executing (interactive): record it and nudge the
+// pattern matcher to bail.  The executor's unwinding() check aborts the running
+// command so the loop reprompts instead of the shell being killed.  Both stores
+// are async-signal-safe.
+void interactive_sigint_handler(int) {
+  g_sigint_received = 1;
+  strmatch_set_interrupt(1);
+}
+
 bool trailing_backslash(const std::string &s) {
   int n = 0;
   for (auto it = s.rbegin(); it != s.rend() && *it == '\\'; ++it) n++;
@@ -156,6 +168,20 @@ int run_interactive(Shell &sh) {
   if (sh.is_zsh()) rl_highlight_function = gnash_zsh_highlight;
 
   while (!sh.exiting) {
+    // Catch SIGINT during command execution so C-c aborts the running command
+    // and reprompts, rather than killing the shell.  (readline saves/restores
+    // this around its own handler while reading a line.)  Re-asserted each
+    // iteration, but never over a user INT trap -- so `trap ... INT' keeps
+    // working and `trap - INT' cleanly restores this default next prompt.
+    if (sh.traps.find("INT") == sh.traps.end()) {
+      struct sigaction sa;
+      std::memset(&sa, 0, sizeof sa);
+      sigemptyset(&sa.sa_mask);
+      sa.sa_flags = SA_RESTART;
+      sa.sa_handler = interactive_sigint_handler;
+      sigaction(SIGINT, &sa, nullptr);
+    }
+
     sh.reap_jobs(true);      // report any finished background jobs
     sh.run_pending_traps();  // deliver signals received while at the prompt
 
@@ -216,7 +242,15 @@ int run_interactive(Shell &sh) {
     if (interrupted) continue;  // reprompt with PS1, discarding the partial command
 
     if (input.find_first_not_of(" \t\n") != std::string::npos) add_history(input.c_str());
+    g_sigint_received = 0;  // start the command uninterrupted
+    strmatch_set_interrupt(0);
     sh.run_string(input);
+    if (g_sigint_received) {  // C-c aborted the command mid-run: reprompt cleanly
+      g_sigint_received = 0;
+      strmatch_set_interrupt(0);
+      sh.last_status = 130;  // 128 + SIGINT, as bash reports
+      std::fputc('\n', stderr);
+    }
     sh.command_number++;  // \# advances for the next prompt
   }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -169,6 +169,10 @@ bool Shell::virtual_array(const std::string &name,
   return false;
 }
 
+// C-c during command execution (interactive): the handler installed by the REPL
+// sets this, and the executor's unwinding() check aborts the running command.
+volatile std::sig_atomic_t g_sigint_received = 0;
+
 namespace {
 volatile sig_atomic_t g_trap_pending[NSIG];
 

--- a/libglob/src/smatch.cpp
+++ b/libglob/src/smatch.cpp
@@ -10,18 +10,24 @@
 // simplified to C/ASCII ordering; wide-character matching is a later addition.
 
 #include <cctype>
+#include <csignal>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
 
 #include "strmatch.h"
 
+// Set from the shell's SIGINT handler (async-signal-safe: a single sig_atomic_t
+// store) so a long-running match bails out promptly with FNM_NOMATCH.  File
+// scope with C linkage so the setter is reachable from the shell core.
+static volatile std::sig_atomic_t interrupt_state = 0;
+static volatile std::sig_atomic_t terminating_signal = 0;
+
+extern "C" void strmatch_set_interrupt(int state) { interrupt_state = state ? 1 : 0; }
+
 namespace {
 
 using UC = unsigned char;
-
-int interrupt_state = 0;
-int terminating_signal = 0;
 
 struct SmEnds {
   UC *pattern;


### PR DESCRIPTION
Closes #5.

Investigating the matcher's dead `interrupt_state` flag turned up a broader, reproducible bug: **interactively, C-c during any in-process work killed the whole shell** instead of aborting the command and reprompting. Verified with a pty driver — gnash died 0/3, bash survived 3/3 — for both an infinite loop (`while :; do :; done`) and a runaway extended-pattern match. SIGINT during command execution simply had its default disposition.

### Fix
Install a SIGINT handler for the duration of command execution whose flag is honored by the executor's existing `unwinding()` check — so the running command unwinds cleanly back to the REPL (no `longjmp`; C++ destructors run). The REPL prints a newline and reports status **130**. The matcher's previously-dead `interrupt_state` is wired to the same handler (`strmatch_set_interrupt`) so a runaway match bails promptly.

- Not installed over a user `INT` trap; re-asserted each prompt so `trap - INT` restores it.
- Interactive-only: non-interactive scripts keep the default disposition (the handler is never installed; `g_sigint_received` stays 0, so `unwinding()` is unchanged there).

### Verification (pty driver, 3× each)
- Infinite loop + runaway match: gnash now **survives C-c 3/3** and reprompts (was 0/3), matching bash 5.3.9.
- `$?` after interrupt is `130`; C-c at an empty prompt still works; a normal command runs afterward.
- `trap … INT` still fires; `trap … INT` then `trap - INT` then C-c still aborts cleanly (self-heal).
- Full `ctest` passes 17/17 (excluding the pre-existing `parse_diff` env timeout). Clean `-DGNASH_WERROR=ON` build.
