### PR TITLE
glob: make globstar (**) work and never recurse through symlinks (closes #7)

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -17,6 +17,7 @@
 #include <sys/wait.h>
 
 #include "gnash/glob.hpp"
+#include "glob.h"
 #include "strmatch.h"
 
 namespace gnash::core {
@@ -901,7 +902,10 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
     pattern += c;
   }
   if (sh_.opt_noglob || !magic) return {field};
-  auto matches = gnash::glob::glob(pattern, 0);
+  int gflags = 0;
+  auto gs = sh_.shopt_opts.find("globstar");  // `shopt -s globstar' enables **
+  if (gs != sh_.shopt_opts.end() && gs->second) gflags |= GX_GLOBSTAR;
+  auto matches = gnash::glob::glob(pattern, gflags);
   if (matches.empty()) {
     auto it = sh_.shopt_opts.find("nullglob");
     if (it != sh_.shopt_opts.end() && it->second) return {};  // nullglob: remove word

--- a/libglob/src/glob.cpp
+++ b/libglob/src/glob.cpp
@@ -28,6 +28,15 @@ bool is_dir(const std::string &path) {
   return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
 }
 
+// Like is_dir, but does NOT follow symlinks: a symlink to a directory is not a
+// directory here.  Used by the globstar descent so `**' never recurses through
+// a symlinked directory -- matching bash, and avoiding infinite recursion on a
+// self-referential or cyclic symlink.
+bool is_dir_nofollow(const std::string &path) {
+  struct stat st;
+  return lstat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 bool path_exists(const std::string &path) {
   struct stat st;
   return lstat(path.c_str(), &st) == 0;
@@ -76,7 +85,7 @@ void collect_dirs(const std::string &base, std::vector<std::string> &out, bool m
     if (nm == "." || nm == "..") continue;
     if (nm[0] == '.' && !matchdot) continue;
     std::string full = base + nm;
-    if (is_dir(full)) subs.push_back(full + "/");
+    if (is_dir_nofollow(full)) subs.push_back(full + "/");  // don't descend symlinks
   }
   closedir(d);
   std::sort(subs.begin(), subs.end());


### PR DESCRIPTION
Closes #7.

Two coupled problems:
1. **globstar was a no-op.** The `globstar` shopt was accepted but never consulted — the sole glob call site (`expand.cpp`) passed no flags, so `GX_GLOBSTAR` was never set and `shopt -s globstar; echo **/x` did not recurse (`**` behaved like `*`), diverging from bash.
2. **The globstar descent followed symlinks.** `collect_dirs` decided what to recurse into with `stat()` (follows symlinks, no cycle guard), so enabling globstar over a self-referential/cyclic directory symlink would recurse without bound.

Both must land together: wiring globstar without the symlink fix would *introduce* the infinite recursion.

### Change
- Wire the `globstar` shopt through to `GX_GLOBSTAR` at the glob call site, so `**` matches across directory levels as in bash.
- Add `is_dir_nofollow` (`lstat`) and use it for the descent decision, so a symlinked directory is *matched* but not *descended* — matching bash and terminating on cycles.

### Verification (against bash 5.3.9)
- Functional: `**`, `**/*.txt`, `a/**/*.txt`, `**/` all produce output **identical** to bash; without `globstar`, `**` stays non-recursive (also identical).
- Safe: a directory containing self-referential (`ln -s .`) and parent (`ln -s ..`) symlinks terminates promptly under `**` (no SIGSEGV/hang).
- Symlink-not-descended: `**/deep.txt` finds only the real `realdir/deep.txt`, not via a `linkdir -> realdir` symlink — matching bash.
- `glob_test` + full `ctest` pass 17/17; clean `-DGNASH_WERROR=ON` build.
