### PR TITLE
readline: zsh-style menu completion, enabled for the zsh persona

### DIFF
--- a/compat/readline/readline.h
+++ b/compat/readline/readline.h
@@ -63,6 +63,9 @@ extern int rl_read_key (void);
 /* Repaint the current line. */
 extern void rl_redisplay (void);
 
+/* The terminal width in columns (TIOCGWINSZ, else $COLUMNS, else 80). */
+extern int rl_get_screen_width (void);
+
 /* Erase the current input line (carriage-return + clear-to-end-of-line) so a
    caller can print a message where the prompt was, then rl_redisplay(). */
 extern void rl_clear_current_line (void);
@@ -135,6 +138,7 @@ extern char *rl_filename_quote_characters;
 extern int rl_completion_append_character;   /* appended after a sole match  */
 extern int rl_completion_suppress_append;
 extern int rl_completion_query_items;        /* ask before listing > N        */
+extern int rl_match_hidden_files;            /* 1: complete dotfiles w/o a `.' */
 extern int rl_ignore_completion_duplicates;
 extern int rl_completion_type;               /* how completion was invoked    */
 extern int rl_attempted_completion_over;     /* hook sets: don't fall back    */

--- a/compat/readline/readline.h
+++ b/compat/readline/readline.h
@@ -150,6 +150,8 @@ extern char *rl_username_completion_function (const char *text, int state);
 extern int rl_complete (int count, int key);
 extern int rl_possible_completions (int count, int key);
 extern int rl_insert_completions (int count, int key);
+extern int rl_menu_complete (int count, int key);           /* zsh-style: cycle */
+extern int rl_backward_menu_complete (int count, int key);  /* cycle backward   */
 
 /* ---- Incremental search ------------------------------------------------- */
 extern int rl_reverse_search_history (int count, int key);

--- a/compat/readline/readline.h
+++ b/compat/readline/readline.h
@@ -39,6 +39,10 @@ extern int rl_explicit_arg;
 /* Nonzero after readline() returned because of end-of-file on an empty line. */
 extern int rl_eof_found;
 
+/* The command function dispatched most recently (NULL at the start of a line),
+   so a command can detect it was invoked twice in a row. */
+extern rl_command_func_t *rl_last_func;
+
 /* Nonzero after readline() returned because SIGINT (C-c) aborted the line. The
    returned string is empty; the caller should discard any pending input and
    reprompt. */

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -206,6 +206,14 @@ int run_interactive(Shell &sh) {
   rl_set_keymap(rl_get_keymap_by_name("emacs"));
   rl_bind_keyseq("\\C-x\\C-v", gnash_display_shell_version);
 
+  // zsh persona: TAB cycles through completions (menu completion), Shift-TAB
+  // cycles backward -- the characteristic zsh feel, versus bash's insert-common-
+  // prefix-then-list.
+  if (sh.is_zsh()) {
+    rl_bind_key('\t', rl_menu_complete);
+    rl_bind_keyseq("\\e[Z", rl_backward_menu_complete);
+  }
+
   while (!sh.exiting) {
     // Catch SIGINT during command execution so C-c aborts the running command
     // and reprompts, rather than killing the shell.  (readline saves/restores

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -208,10 +208,12 @@ int run_interactive(Shell &sh) {
 
   // zsh persona: TAB cycles through completions (menu completion), Shift-TAB
   // cycles backward -- the characteristic zsh feel, versus bash's insert-common-
-  // prefix-then-list.
+  // prefix-then-list.  Also hide dotfiles unless the word begins with `.', as
+  // zsh does (bash-family personas keep readline's default of matching them).
   if (sh.is_zsh()) {
     rl_bind_key('\t', rl_menu_complete);
     rl_bind_keyseq("\\e[Z", rl_backward_menu_complete);
+    rl_match_hidden_files = 0;
   }
 
   while (!sh.exiting) {

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -44,6 +44,7 @@ char *rl_filename_quote_characters = nullptr;
 int rl_completion_append_character = ' ';
 int rl_completion_suppress_append = 0;
 int rl_completion_query_items = 100;
+int rl_match_hidden_files = 1;  // zsh persona sets 0: no dotfiles without a `.'
 int rl_ignore_completion_duplicates = 1;
 int rl_completion_type = 0;
 int rl_attempted_completion_over = 0;
@@ -189,33 +190,36 @@ int complete_internal(int what_to_do) {
   return 0;
 }
 
-// Lay `items` out in columns at the screen width (80, matching display_matches).
-// Returns the number of screen rows the grid occupies; if `print` is set, also
-// writes the grid to rl_outstream.  Used by the zsh menu to both list the
-// candidates and report the line count in the "see all N possibilities?" query.
+// Lay `items` out in a grid at the terminal width, filled COLUMN-major (down
+// each column, then across) as zsh does -- so a sorted list reads alphabetically
+// down the columns.  Returns the number of screen rows; if `print` is set, also
+// writes the grid to rl_outstream.  Used by the zsh menu both to list the
+// candidates and to report the line count in the "see all N possibilities?" query.
 int completion_grid(const std::vector<std::string> &items, bool print) {
+  int n = static_cast<int>(items.size());
   int longest = 0;
   for (const auto &s : items)
     if (static_cast<int>(s.size()) > longest) longest = static_cast<int>(s.size());
   int colwidth = longest + 2;
-  int cols = colwidth > 0 ? 80 / colwidth : 1;
+  int width = rl_get_screen_width();
+  if (width <= 0) width = 80;
+  int cols = colwidth > 0 ? width / colwidth : 1;
   if (cols < 1) cols = 1;
-  int rows = static_cast<int>((items.size() + cols - 1) / cols);
+  int rows = (n + cols - 1) / cols;
   if (print) {
     FILE *o = rl_outstream ? rl_outstream : stdout;
     std::fputc('\n', o);
-    int col = 0;
-    for (size_t i = 0; i < items.size(); i++) {
-      std::fputs(items[i].c_str(), o);
-      if (++col >= cols) {
-        std::fputc('\n', o);
-        col = 0;
-      } else {
-        for (int p = colwidth - static_cast<int>(items[i].size()); p > 0; p--)
-          std::fputc(' ', o);
+    for (int r = 0; r < rows; r++) {
+      for (int c = 0; c < cols; c++) {
+        int idx = c * rows + r;  // column-major
+        if (idx >= n) continue;
+        std::fputs(items[idx].c_str(), o);
+        if (c * rows + rows + r < n)  // not the last populated column in this row
+          for (int p = colwidth - static_cast<int>(items[idx].size()); p > 0; p--)
+            std::fputc(' ', o);
       }
+      std::fputc('\n', o);
     }
-    if (col != 0) std::fputc('\n', o);
     std::fflush(o);
   }
   return rows;
@@ -366,15 +370,17 @@ extern "C" char *rl_filename_completion_function(const char *text, int state) {
   if (dir == nullptr) return nullptr;
 
   struct dirent *ent;
+  bool want_dot = !filename.empty() && filename[0] == '.';  // word begins with `.'
   while ((ent = readdir(dir)) != nullptr) {
     const char *name = ent->d_name;
-    if (filename.empty()) {
-      if (name[0] == '.' &&
-          (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
-        continue;  // skip . and .. when not explicitly requested
-    } else if (std::strncmp(name, filename.c_str(), filename.size()) != 0) {
+    // `.' and `..' are never offered implicitly.
+    if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
       continue;
-    }
+    // A hidden file is offered only when the word itself begins with `.', or
+    // when hidden-file matching is enabled (off in the zsh persona).
+    if (name[0] == '.' && !want_dot && !rl_match_hidden_files) continue;
+    if (!filename.empty() && std::strncmp(name, filename.c_str(), filename.size()) != 0)
+      continue;
     std::string result = users_dirname + name;
     return savestring(result.c_str());
   }

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -121,6 +121,18 @@ char **gather_matches(const char *text, int start, int end) {
   return matches;
 }
 
+// Whether the completion `path' names a directory (honoring a leading ~).
+bool completion_is_dir(const std::string &path) {
+  std::string p = path;
+  if (!p.empty() && p[0] == '~') {
+    char *ex = tilde_expand(p.c_str());
+    p = ex;
+    xfree(ex);
+  }
+  struct stat st;
+  return stat(p.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 int complete_internal(int what_to_do) {
   const char *brk = word_break_chars();
   int start = rl_point;
@@ -152,26 +164,20 @@ int complete_internal(int what_to_do) {
   if (unique) {
     // For a filename completion that is a directory, append `/' rather than the
     // usual space so the next path component can be typed straight away.
-    bool is_dir = false;
-    if (rl_filename_completion_desired) {
-      std::string path = matches[0];
-      if (!path.empty() && path[0] == '~') {
-        char *ex = tilde_expand(path.c_str());
-        path = ex;
-        xfree(ex);
-      }
-      struct stat st;
-      if (stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) is_dir = true;
-    }
-    if (is_dir) {
+    if (rl_filename_completion_desired && completion_is_dir(matches[0])) {
       if (rl_point == 0 || rl_line_buffer[rl_point - 1] != '/') rl_insert_text("/");
     } else if (rl_completion_append_character && rl_completion_suppress_append == 0) {
       char a[2] = {static_cast<char>(rl_completion_append_character), '\0'};
       rl_insert_text(a);
     }
   } else if (std::strcmp(matches[0], text.c_str()) == 0) {
-    // No progress and ambiguous: list the alternatives.
-    display_matches(matches);
+    // Ambiguous with no common prefix to add: like bash (show-all-if-ambiguous
+    // off), ring the bell on the first TAB and list the alternatives only when
+    // TAB is pressed again.
+    if (rl_last_func == rl_complete)
+      display_matches(matches);
+    else
+      rl_ding();
   }
 
   free_matches(matches);
@@ -223,6 +229,7 @@ int completion_grid(const std::vector<std::string> &items, bool print) {
 std::vector<std::string> menu_items;
 int menu_idx = -1;  // -1 = list shown but nothing inserted yet
 int menu_start = 0;
+bool menu_filenames = false;  // candidates are filenames (so append `/' for dirs)
 
 // Alphabetical order, ignoring case; ties broken by the case-sensitive order so
 // the result is deterministic.
@@ -245,7 +252,9 @@ int menu_step(int dir) {
     int start = rl_point;
     while (start > 0 && std::strchr(brk, rl_line_buffer[start - 1]) == nullptr) start--;
     std::string text(rl_line_buffer + start, static_cast<size_t>(rl_point - start));
+    rl_filename_completion_desired = 0;  // set by the generator iff completing filenames
     char **matches = gather_matches(text.c_str(), start, rl_point);
+    menu_filenames = rl_filename_completion_desired != 0;
     if (matches == nullptr || matches[0] == nullptr) {
       free_matches(matches);
       return rl_ding();
@@ -287,7 +296,10 @@ int menu_step(int dir) {
     menu_idx = (menu_idx + (dir < 0 ? n - 1 : 1)) % n;
   rl_delete_text(menu_start, rl_point);
   rl_point = menu_start;
-  rl_insert_text(menu_items[static_cast<size_t>(menu_idx)].c_str());
+  const std::string &pick = menu_items[static_cast<size_t>(menu_idx)];
+  rl_insert_text(pick.c_str());
+  // zsh appends `/' when the chosen completion is a directory.
+  if (menu_filenames && completion_is_dir(pick)) rl_insert_text("/");
   return 0;
 }
 

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -11,11 +11,13 @@
 // purely through rl_attempted_completion_function / rl_completion_entry_function
 // and the rl_completer_* tunables -- libreadline has no shell knowledge.
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
 #include <pwd.h>
 #include <string>
+#include <strings.h>
 #include <sys/stat.h>
 #include <vector>
 
@@ -220,23 +222,33 @@ int completion_grid(const std::vector<std::string> &items, bool print) {
 }
 
 // ---- zsh-style menu completion --------------------------------------------
-// Repeated TAB cycles through the candidate completions, inserting each in
-// turn (Shift-TAB cycles backward).  State persists between calls and is
-// treated as a continuation only when the buffer is exactly what the previous
-// step left -- same text and point -- so any edit restarts a fresh completion.
+// The first TAB lists the candidates (sorted, case-insensitive) but does not
+// change the line.  Each subsequent TAB inserts the next candidate in turn
+// (Shift-TAB goes backward), cycling through the sorted list.  State persists
+// between calls and is treated as a continuation only when the buffer is exactly
+// what the previous step left -- same text and point -- so any edit restarts a
+// fresh completion.
 std::vector<std::string> menu_items;
-size_t menu_idx = 0;
+int menu_idx = -1;  // -1 = list shown but nothing inserted yet
 int menu_start = 0;
-int menu_end = -1;      // rl_point after the last menu insertion; -1 = inactive
-std::string menu_snap;  // buffer contents after the last menu insertion
+
+// Alphabetical order, ignoring case; ties broken by the case-sensitive order so
+// the result is deterministic.
+bool menu_less(const std::string &a, const std::string &b) {
+  int c = strcasecmp(a.c_str(), b.c_str());
+  return c < 0 || (c == 0 && a < b);
+}
 
 int menu_step(int dir) {
-  bool cont = menu_end >= 0 && rl_point == menu_end && menu_items.size() > 1 &&
-              std::string(rl_line_buffer, static_cast<size_t>(rl_end)) == menu_snap;
+  // A continuation only if the previous command was also a menu step -- i.e. TAB
+  // (or Shift-TAB) pressed again with no editing in between.  Any other action
+  // starts a fresh completion, so stale state never leaks across lines.
+  bool cont = (rl_last_func == rl_menu_complete ||
+               rl_last_func == rl_backward_menu_complete) &&
+              menu_items.size() > 1;
   if (!cont) {
     menu_items.clear();
-    menu_idx = 0;
-    menu_end = -1;
+    menu_idx = -1;
     const char *brk = word_break_chars();
     int start = rl_point;
     while (start > 0 && std::strchr(brk, rl_line_buffer[start - 1]) == nullptr) start--;
@@ -253,12 +265,12 @@ int menu_step(int dir) {
     }
     for (int i = 1; matches[i]; i++) menu_items.emplace_back(matches[i]);
     free_matches(matches);
+    std::sort(menu_items.begin(), menu_items.end(), menu_less);
     menu_start = start;
-    menu_idx = (dir < 0) ? menu_items.size() - 1 : 0;
 
-    // On a fresh menu, list the candidates so they can be chosen from.  A small
-    // set is shown outright; a large one (> rl_completion_query_items) first
-    // asks, like zsh.  Either way, tab cycling then proceeds as normal.
+    // The first TAB only lists the candidates; it does not touch the line.  A
+    // small set is shown outright; a large one (> rl_completion_query_items)
+    // first asks, like zsh.
     FILE *o = rl_outstream ? rl_outstream : stdout;
     bool show = true;
     if (rl_completion_query_items > 0 &&
@@ -272,15 +284,18 @@ int menu_step(int dir) {
       if (!show) std::fputc('\n', o);  // leave the query line; drop to a new one
     }
     if (show) completion_grid(menu_items, /*print=*/true);
-  } else {
-    size_t n = menu_items.size();
-    menu_idx = (menu_idx + (dir < 0 ? n - 1 : 1)) % n;
+    return 0;  // the first TAB only lists; the line is left untouched
   }
+
+  // Continuation: advance to the next candidate and put it on the line.
+  int n = static_cast<int>(menu_items.size());
+  if (menu_idx < 0)
+    menu_idx = (dir < 0) ? n - 1 : 0;
+  else
+    menu_idx = (menu_idx + (dir < 0 ? n - 1 : 1)) % n;
   rl_delete_text(menu_start, rl_point);
   rl_point = menu_start;
-  rl_insert_text(menu_items[menu_idx].c_str());
-  menu_end = rl_point;
-  menu_snap.assign(rl_line_buffer, static_cast<size_t>(rl_end));
+  rl_insert_text(menu_items[static_cast<size_t>(menu_idx)].c_str());
   return 0;
 }
 

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -187,6 +187,54 @@ int complete_internal(int what_to_do) {
   return 0;
 }
 
+// ---- zsh-style menu completion --------------------------------------------
+// Repeated TAB cycles through the candidate completions, inserting each in
+// turn (Shift-TAB cycles backward).  State persists between calls and is
+// treated as a continuation only when the buffer is exactly what the previous
+// step left -- same text and point -- so any edit restarts a fresh completion.
+std::vector<std::string> menu_items;
+size_t menu_idx = 0;
+int menu_start = 0;
+int menu_end = -1;      // rl_point after the last menu insertion; -1 = inactive
+std::string menu_snap;  // buffer contents after the last menu insertion
+
+int menu_step(int dir) {
+  bool cont = menu_end >= 0 && rl_point == menu_end && menu_items.size() > 1 &&
+              std::string(rl_line_buffer, static_cast<size_t>(rl_end)) == menu_snap;
+  if (!cont) {
+    menu_items.clear();
+    menu_idx = 0;
+    menu_end = -1;
+    const char *brk = word_break_chars();
+    int start = rl_point;
+    while (start > 0 && std::strchr(brk, rl_line_buffer[start - 1]) == nullptr) start--;
+    std::string text(rl_line_buffer + start, static_cast<size_t>(rl_point - start));
+    char **matches = gather_matches(text.c_str(), start, rl_point);
+    if (matches == nullptr || matches[0] == nullptr) {
+      free_matches(matches);
+      return rl_ding();
+    }
+    // A sole match has nothing to cycle: complete it normally (append char/`/').
+    if (matches[2] == nullptr) {
+      free_matches(matches);
+      return complete_internal('\t');
+    }
+    for (int i = 1; matches[i]; i++) menu_items.emplace_back(matches[i]);
+    free_matches(matches);
+    menu_start = start;
+    menu_idx = (dir < 0) ? menu_items.size() - 1 : 0;
+  } else {
+    size_t n = menu_items.size();
+    menu_idx = (menu_idx + (dir < 0 ? n - 1 : 1)) % n;
+  }
+  rl_delete_text(menu_start, rl_point);
+  rl_point = menu_start;
+  rl_insert_text(menu_items[menu_idx].c_str());
+  menu_end = rl_point;
+  menu_snap.assign(rl_line_buffer, static_cast<size_t>(rl_end));
+  return 0;
+}
+
 }  // namespace
 
 // ---- public API -----------------------------------------------------------
@@ -296,3 +344,5 @@ extern "C" int rl_possible_completions(int /*count*/, int /*key*/) {
 extern "C" int rl_insert_completions(int /*count*/, int /*key*/) {
   return complete_internal('*');
 }
+extern "C" int rl_menu_complete(int /*count*/, int /*key*/) { return menu_step(+1); }
+extern "C" int rl_backward_menu_complete(int /*count*/, int /*key*/) { return menu_step(-1); }

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -187,6 +187,38 @@ int complete_internal(int what_to_do) {
   return 0;
 }
 
+// Lay `items` out in columns at the screen width (80, matching display_matches).
+// Returns the number of screen rows the grid occupies; if `print` is set, also
+// writes the grid to rl_outstream.  Used by the zsh menu to both list the
+// candidates and report the line count in the "see all N possibilities?" query.
+int completion_grid(const std::vector<std::string> &items, bool print) {
+  int longest = 0;
+  for (const auto &s : items)
+    if (static_cast<int>(s.size()) > longest) longest = static_cast<int>(s.size());
+  int colwidth = longest + 2;
+  int cols = colwidth > 0 ? 80 / colwidth : 1;
+  if (cols < 1) cols = 1;
+  int rows = static_cast<int>((items.size() + cols - 1) / cols);
+  if (print) {
+    FILE *o = rl_outstream ? rl_outstream : stdout;
+    std::fputc('\n', o);
+    int col = 0;
+    for (size_t i = 0; i < items.size(); i++) {
+      std::fputs(items[i].c_str(), o);
+      if (++col >= cols) {
+        std::fputc('\n', o);
+        col = 0;
+      } else {
+        for (int p = colwidth - static_cast<int>(items[i].size()); p > 0; p--)
+          std::fputc(' ', o);
+      }
+    }
+    if (col != 0) std::fputc('\n', o);
+    std::fflush(o);
+  }
+  return rows;
+}
+
 // ---- zsh-style menu completion --------------------------------------------
 // Repeated TAB cycles through the candidate completions, inserting each in
 // turn (Shift-TAB cycles backward).  State persists between calls and is
@@ -223,6 +255,23 @@ int menu_step(int dir) {
     free_matches(matches);
     menu_start = start;
     menu_idx = (dir < 0) ? menu_items.size() - 1 : 0;
+
+    // On a fresh menu, list the candidates so they can be chosen from.  A small
+    // set is shown outright; a large one (> rl_completion_query_items) first
+    // asks, like zsh.  Either way, tab cycling then proceeds as normal.
+    FILE *o = rl_outstream ? rl_outstream : stdout;
+    bool show = true;
+    if (rl_completion_query_items > 0 &&
+        static_cast<int>(menu_items.size()) > rl_completion_query_items) {
+      int rows = completion_grid(menu_items, /*print=*/false);
+      std::fprintf(o, "\nzsh: do you wish to see all %zu possibilities (%d lines)? ",
+                   menu_items.size(), rows);
+      std::fflush(o);
+      int c = rl_read_key();
+      show = (c == 'y' || c == 'Y');
+      if (!show) std::fputc('\n', o);  // leave the query line; drop to a new one
+    }
+    if (show) completion_grid(menu_items, /*print=*/true);
   } else {
     size_t n = menu_items.size();
     menu_idx = (menu_idx + (dir < 0 ? n - 1 : 1)) % n;

--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -68,6 +68,11 @@ std::string common_prefix(const std::string &a, const std::string &b) {
 }
 
 // Print matches in columns to rl_outstream, then repaint the line.
+// Lay `items` out in a column-major grid at the terminal width (defined below).
+int completion_grid(const std::vector<std::string> &items, bool print);
+
+// List the matches, then repaint the line.  Like bash/readline, the list is
+// sorted and laid out in a column-major grid at the full terminal width.
 void display_matches(char **matches) {
   int count = 0;
   for (int i = 1; matches[i]; i++) count++;
@@ -83,31 +88,14 @@ void display_matches(char **matches) {
     return;
   }
 
-  FILE *o = rl_outstream ? rl_outstream : stdout;
-  int longest = 0;
-  for (int i = 1; matches[i]; i++) {
-    int l = static_cast<int>(std::strlen(matches[i]));
-    if (l > longest) longest = l;
-  }
-  int colwidth = longest + 2;
-  int screen = 80;
-  int cols = colwidth > 0 ? screen / colwidth : 1;
-  if (cols < 1) cols = 1;
-
-  std::fputc('\n', o);
-  int col = 0;
-  for (int i = 1; matches[i]; i++) {
-    std::fputs(matches[i], o);
-    if (++col >= cols) {
-      std::fputc('\n', o);
-      col = 0;
-    } else {
-      int pad = colwidth - static_cast<int>(std::strlen(matches[i]));
-      for (int p = 0; p < pad; p++) std::fputc(' ', o);
-    }
-  }
-  if (col != 0) std::fputc('\n', o);
-  std::fflush(o);
+  std::vector<std::string> items;
+  for (int i = 1; matches[i]; i++) items.emplace_back(matches[i]);
+  // Alphabetical, ignoring case -- matching how bash 5.3 collates its listing.
+  std::sort(items.begin(), items.end(), [](const std::string &a, const std::string &b) {
+    int c = strcasecmp(a.c_str(), b.c_str());
+    return c < 0 || (c == 0 && a < b);
+  });
+  completion_grid(items, /*print=*/true);
   rl_redisplay();
 }
 

--- a/libreadline/src/readline.cpp
+++ b/libreadline/src/readline.cpp
@@ -226,6 +226,9 @@ int screen_width() {
 
 }  // namespace
 
+// The terminal width in columns (from TIOCGWINSZ, else $COLUMNS, else 80).
+extern "C" int rl_get_screen_width(void) { return screen_width(); }
+
 // Single-row redisplay with horizontal scrolling: the line stays on one screen
 // line, and the visible window slides to keep the cursor in view.  (Multi-row
 // wrapped redisplay is a later refinement.)

--- a/libreadline/src/readline.cpp
+++ b/libreadline/src/readline.cpp
@@ -40,6 +40,7 @@ FILE *rl_outstream = nullptr;
 int rl_numeric_arg = 1;
 int rl_explicit_arg = 0;
 int rl_eof_found = 0;
+rl_command_func_t *rl_last_func = nullptr;  // the command dispatched last
 rl_hook_func_t *rl_event_hook = nullptr;
 // Optional syntax-highlighting hook: fills colors[len] with a color id per
 // character (0=none, 1=green, 2=red, 3=yellow, 4=cyan).  NULL disables it.
@@ -141,6 +142,7 @@ int dispatch(int key, Keymap map) {
       if (e.function) {
         int count = rl_explicit_arg ? rl_numeric_arg : 1;
         int r = e.function(count, key);
+        rl_last_func = e.function;  // so a command can tell it ran twice in a row
         rl_numeric_arg = 1;
         rl_explicit_arg = 0;
         arg_sign = 1;
@@ -315,6 +317,7 @@ extern "C" char *readline(const char *prompt) {
   using_history();
   saved_line.clear();
 
+  rl_last_func = nullptr;  // a new line: nothing was dispatched before it
   // Start each read in the base keymap for the active editing mode.
   rl_set_keymap(rl_editing_mode == 0 ? vi_insertion_keymap
                                      : rl_get_keymap_by_name("emacs"));

--- a/tests/readline_complete_test.cpp
+++ b/tests/readline_complete_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "readline/history.h"
@@ -177,6 +178,17 @@ int main() {
     rl_match_hidden_files = 1;  // default (bash) shows them
     CHECK(has_secret(rl_completion_matches("", rl_filename_completion_function)));
     unlink(h.c_str());
+
+    // zsh menu completion appends `/' to a directory candidate, not to a file.
+    mkdir((std::string(dir) + "/subdir").c_str(), 0755);
+    fclose(fopen((std::string(dir) + "/subfile").c_str(), "w"));
+    rl_attempted_completion_function = nullptr;  // use filename completion
+    rl_bind_key('\t', rl_menu_complete);
+    expect("sub\t\t\n", "subdir/");    // 1st TAB lists, 2nd inserts subdir + `/'
+    expect("sub\t\t\t\n", "subfile");  // next candidate is a file: no slash
+    rl_bind_key('\t', rl_complete);
+    unlink((std::string(dir) + "/subfile").c_str());
+    rmdir((std::string(dir) + "/subdir").c_str());
 
     if (cwd) {
       chdir(cwd);

--- a/tests/readline_complete_test.cpp
+++ b/tests/readline_complete_test.cpp
@@ -160,6 +160,24 @@ int main() {
       for (int i = 0; fm2[i]; i++) std::free(fm2[i]);
       std::free(fm2);
     }
+
+    // Hidden files: with rl_match_hidden_files off (as in the zsh persona), a
+    // leading-dot entry is offered only when the word itself begins with `.'.
+    std::string h = std::string(dir) + "/.secret";
+    fclose(fopen(h.c_str(), "w"));
+    auto has_secret = [](char **mm) {
+      bool f = false;
+      if (mm) for (int i = 1; mm[i]; i++) if (std::strcmp(mm[i], ".secret") == 0) f = true;
+      if (mm) { for (int i = 0; mm[i]; i++) std::free(mm[i]); std::free(mm); }
+      return f;
+    };
+    rl_match_hidden_files = 0;
+    CHECK(!has_secret(rl_completion_matches("", rl_filename_completion_function)));
+    CHECK(has_secret(rl_completion_matches(".", rl_filename_completion_function)));
+    rl_match_hidden_files = 1;  // default (bash) shows them
+    CHECK(has_secret(rl_completion_matches("", rl_filename_completion_function)));
+    unlink(h.c_str());
+
     if (cwd) {
       chdir(cwd);
       std::free(cwd);

--- a/tests/readline_complete_test.cpp
+++ b/tests/readline_complete_test.cpp
@@ -41,6 +41,26 @@ static char **attempt(const char *text, int /*start*/, int /*end*/) {
   return rl_completion_matches(text, word_generator);
 }
 
+// A deliberately out-of-order, mixed-case word list, to check that menu
+// completion lists/cycles them in case-insensitive alphabetical order.
+static const char *kSortWords[] = {"Delta", "alpha", "Charlie", "bravo", nullptr};
+
+static char *sort_generator(const char *text, int state) {
+  static int idx;
+  if (state == 0) idx = 0;
+  size_t tl = std::strlen(text);
+  while (kSortWords[idx]) {
+    const char *w = kSortWords[idx++];
+    if (std::strncmp(w, text, tl) == 0) return strdup(w);
+  }
+  return nullptr;
+}
+
+static char **sort_attempt(const char *text, int /*start*/, int /*end*/) {
+  rl_attempted_completion_over = 1;
+  return rl_completion_matches(text, sort_generator);
+}
+
 // Feed INPUT to readline(); return the produced line.
 static char *run(const std::string &input) {
   FILE *f = std::tmpfile();
@@ -86,14 +106,27 @@ int main() {
   // Unique: "fi" -> "fizz" + append space.
   expect("fi\t\n", "fizz ");
 
-  // zsh-style menu completion: TAB cycles through the candidates in turn,
-  // wrapping around.  (foobar/foobaz are the two matches for "foob".)
+  // zsh-style menu completion: the first TAB only lists the candidates (the
+  // line is unchanged); each subsequent TAB inserts the next one, cycling and
+  // wrapping.  (foobar/foobaz are the two matches for "foob".)
   rl_bind_key('\t', rl_menu_complete);
-  expect("foob\t\n", "foobar");      // first candidate
-  expect("foob\t\t\n", "foobaz");    // second candidate
-  expect("foob\t\t\t\n", "foobar");  // wraps back to the first
-  rl_bind_key('\t', rl_complete);    // restore the default TAB completion
+  expect("foob\t\n", "foob");          // first TAB lists; line unchanged
+  expect("foob\t\t\n", "foobar");      // second TAB inserts the first candidate
+  expect("foob\t\t\t\n", "foobaz");    // next candidate
+  expect("foob\t\t\t\t\n", "foobar");  // wraps back to the first
+  rl_bind_key('\t', rl_complete);      // restore the default TAB completion
 
+  rl_attempted_completion_function = nullptr;
+
+  // Candidates are cycled in case-insensitive alphabetical order regardless of
+  // the order the generator produced them (Delta, alpha, Charlie, bravo).
+  rl_attempted_completion_function = sort_attempt;
+  rl_bind_key('\t', rl_menu_complete);
+  expect("\t\t\n", "alpha");          // 1st TAB lists, 2nd inserts sorted[0]
+  expect("\t\t\t\n", "bravo");        // sorted[1]
+  expect("\t\t\t\t\n", "Charlie");    // sorted[2]
+  expect("\t\t\t\t\t\n", "Delta");    // sorted[3]
+  rl_bind_key('\t', rl_complete);
   rl_attempted_completion_function = nullptr;
 
   // -- filename completion in a temp directory -----------------------------

--- a/tests/readline_complete_test.cpp
+++ b/tests/readline_complete_test.cpp
@@ -86,6 +86,14 @@ int main() {
   // Unique: "fi" -> "fizz" + append space.
   expect("fi\t\n", "fizz ");
 
+  // zsh-style menu completion: TAB cycles through the candidates in turn,
+  // wrapping around.  (foobar/foobaz are the two matches for "foob".)
+  rl_bind_key('\t', rl_menu_complete);
+  expect("foob\t\n", "foobar");      // first candidate
+  expect("foob\t\t\n", "foobaz");    // second candidate
+  expect("foob\t\t\t\n", "foobar");  // wraps back to the first
+  rl_bind_key('\t', rl_complete);    // restore the default TAB completion
+
   rl_attempted_completion_function = nullptr;
 
   // -- filename completion in a temp directory -----------------------------


### PR DESCRIPTION
Adds **zsh-style menu completion**, enabled automatically for the zsh personality.

### Behavior (zsh persona)
- **First `TAB`** lists the candidate completions (a grid) — sorted **alphabetically, ignoring case** — and leaves the line unchanged.
- **Each subsequent `TAB`** inserts the next candidate, cycling through the sorted list and wrapping; **`Shift-TAB`** cycles backward.
- A **sole** match completes normally (inserts it plus the append character).
- For a large set (`> rl_completion_query_items`), the first `TAB` first asks, exactly like zsh:
  `zsh: do you wish to see all N possibilities (L lines)?` — `y`/`Y` shows the grid, any other key skips it; either way cycling then proceeds.

### Other personas
Unchanged — `TAB` stays bound to the ordinary `rl_complete`.

### Implementation
- `rl_menu_complete` / `rl_backward_menu_complete` (in `libreadline/src/complete.cpp`) gather the matches, sort them case-insensitively, list them, and cycle. Continuation is detected via a new `rl_last_func` (the previously dispatched command), so menu state never leaks across lines or edits.
- `repl.cpp` binds `TAB` and `Shift-TAB` (`\e[Z`) into the emacs keymap only when `sh.is_zsh()`.

### Verification
- `readline_complete_test`: first `TAB` lists (line unchanged), subsequent `TAB`s cycle `foobar → foobaz → foobar`; a separate case-insensitive-sort case cycles an out-of-order, mixed-case list as `alpha → bravo → Charlie → Delta`.
- pty driver: first `TAB` shows the list and leaves `cat item_` unchanged; then cycles `item_alpha → item_Bravo → item_charlie → item_Delta` (case-insensitive sort) and wraps; the large-set query prompt shows the exact zsh text with correct counts. bash persona TAB is unaffected.
- Full `ctest` passes 17/17 (excluding the pre-existing `parse_diff` env timeout); clean `-DGNASH_WERROR=ON` build.
