### PR TITLE
glob: enable ** recursive globbing for the zsh persona and $zsh_globbing

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -903,8 +903,13 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
   }
   if (sh_.opt_noglob || !magic) return {field};
   int gflags = 0;
-  auto gs = sh_.shopt_opts.find("globstar");  // `shopt -s globstar' enables **
-  if (gs != sh_.shopt_opts.end() && gs->second) gflags |= GX_GLOBSTAR;
+  // `**' recursive globbing is on under `shopt -s globstar', and -- because zsh
+  // enables it by default -- whenever the personality is zsh or the `zsh_globbing'
+  // variable is set to a non-null value.
+  auto gs = sh_.shopt_opts.find("globstar");
+  bool globstar = (gs != sh_.shopt_opts.end() && gs->second) || sh_.is_zsh() ||
+                  !sh_.get("zsh_globbing").empty();
+  if (globstar) gflags |= GX_GLOBSTAR;
   auto matches = gnash::glob::glob(pattern, gflags);
   if (matches.empty()) {
     auto it = sh_.shopt_opts.find("nullglob");


### PR DESCRIPTION
zsh enables recursive `**` globbing by default. gnash already implements the operator (`GX_GLOBSTAR`, reached via `shopt -s globstar`); this turns it on automatically for the zsh personality, and for anyone who sets a `zsh_globbing` variable.

### Change
In `Expander::glob_field`, `**` recursion is now enabled when **any** of:
- `shopt -s globstar` (as before), or
- the personality is **zsh**, or
- the `zsh_globbing` variable is set to a **non-null** value (empty/unset does not enable it).

### Verification (vs real zsh)
Over a nested tree (`top.txt`, `a/1.txt`, `a/b/2.txt`, `a/b/c/3.txt`):
- zsh persona `echo **/*.txt` → `a/1.txt a/b/2.txt a/b/c/3.txt top.txt` — **identical to `/bin/zsh`**.
- bash persona `**/*.txt` → `a/1.txt` only (non-recursive, unchanged).
- bash persona with `zsh_globbing=1` → recurses; with `zsh_globbing=` (null) → does not.
- `shopt -s globstar` still works in the bash persona.
- A self-referential directory symlink terminates safely under `**` (descent uses `lstat`, no cycle).

Full `ctest` passes 17/17 (excluding the pre-existing `parse_diff` env timeout); clean `-DGNASH_WERROR=ON` build.
