### PR TITLE
version: single source of truth (1.1.0); export $GNASH_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(gnash
-  VERSION 0.1.0
+  VERSION 1.1.0
   DESCRIPTION "A modular C++ reimplementation of bash 5.3"
   LANGUAGES C CXX)
 
@@ -48,6 +48,9 @@ target_include_directories(gnash_common INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/compat)
 target_compile_features(gnash_common INTERFACE cxx_std_20)
+# Single source of truth for the gnash version (from project() above), available
+# to the code as the GNASH_VERSION string macro.
+target_compile_definitions(gnash_common INTERFACE GNASH_VERSION="${PROJECT_VERSION}")
 
 # ---------------------------------------------------------------------------
 # Libraries, lowest-dependency-first.  See the approved plan for the full

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -221,6 +221,7 @@ void configure_persona(Shell &sh, const std::string &personality, const std::str
     sh.persona = Shell::Persona::Csh;
   else sh.persona = Shell::Persona::Bash;
   sh.set("GNASH_PERSONALITY", personality);
+  sh.set("GNASH_VERSION", GNASH_VERSION);  // gnash's own version, regardless of persona
 
   std::string mach = "unknown";
   struct utsname u;
@@ -312,7 +313,7 @@ int main(int argc, char **argv) {
       } else if (lo == "personality") {
         personality_flag = !val.empty() ? val : (idx + 1 < args.size() ? args[++idx] : "");
       } else if (lo == "version") {
-        std::printf("gnash, version 0.1 (bash-compatible reimplementation)\n");
+        std::printf("gnash, version " GNASH_VERSION " (bash-compatible reimplementation)\n");
         return 0;
       } else if (lo == "help") {
         std::printf("usage: %s [options] [script [args]]\n", prefix.c_str());

--- a/core/src/prompt.cpp
+++ b/core/src/prompt.cpp
@@ -196,7 +196,22 @@ std::string expand_prompt(Shell &sh, const std::string &ps) {
         out += (s == std::string::npos) ? a0 : a0.substr(s + 1);
         break;
       }
-      case 'v': case 'V': out += "0.1"; break;
+      case 'v': case 'V': {
+        // bash's \v is the shell version (major.minor); \V adds the patchlevel.
+        // Reflect the emulated bash version; fall back to gnash's own version.
+        std::string bv = sh.get("BASH_VERSION");  // e.g. "5.3.0(1)-release"
+        if (bv.empty()) { out += GNASH_VERSION; break; }
+        size_t cut = bv.find_first_of("(-");
+        std::string num = (cut == std::string::npos) ? bv : bv.substr(0, cut);  // "5.3.0"
+        if (c == 'v') {
+          size_t d1 = num.find('.');
+          size_t d2 = (d1 == std::string::npos) ? std::string::npos : num.find('.', d1 + 1);
+          out += (d2 == std::string::npos) ? num : num.substr(0, d2);  // "5.3"
+        } else {
+          out += num;  // "5.3.0"
+        }
+        break;
+      }
       case 't': case 'T': case '@': case 'A': {
         std::time_t now = std::time(nullptr);
         std::tm tmv;

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -150,7 +150,7 @@ extern "C" char **gnash_attempted_completion(const char *text, int start, int en
 // emulating and that shell's version -- then redraw the prompt and input line.
 extern "C" int gnash_display_shell_version(int /*count*/, int /*key*/) {
   FILE *o = rl_outstream ? rl_outstream : stdout;
-  std::string line = "gnash, version 0.1";
+  std::string line = "gnash, version " GNASH_VERSION;
   if (g_notify_shell) {
     Shell &sh = *g_notify_shell;
     std::string mach = sh.get("MACHTYPE");
@@ -163,7 +163,7 @@ extern "C" int gnash_display_shell_version(int /*count*/, int /*key*/) {
       case Shell::Persona::Ash: break;  // ash advertises no version
       default: pver = sh.get("BASH_VERSION"); break;  // Bash / gnash
     }
-    line = "gnash, version 0.1 (" + mach + ")";
+    line = "gnash, version " GNASH_VERSION " (" + mach + ")";
     if (!pname.empty()) {
       line += ", personality " + pname;
       if (!pver.empty()) line += " " + pver;


### PR DESCRIPTION
`C-x C-v` (and `--version`, and the `\v`/`\V` prompt escapes) reported `gnash, version 0.1`, but releases are at 1.1.0 — the version was hardcoded in several places and the CMake `project()` version was never bumped.

### Change
- **Single source of truth:** the CMake `project(gnash VERSION 1.1.0)` is now injected as a `GNASH_VERSION` compile definition (via `gnash_common`), used by `--version`, the `C-x C-v` display-shell-version line, and the `\v`/`\V` prompt escapes. Future releases only bump the number in `CMakeLists.txt`.
- **`$GNASH_VERSION`:** exported as a shell variable (gnash's own version) in every persona.
- **`\v`/`\V`:** now report the emulated bash version — `\v` → `5.3`, `\V` → `5.3.0` — matching bash's semantics (they previously showed the fixed `0.1`).

### Verification
- `gnash --version` → `gnash, version 1.1.0 (bash-compatible reimplementation)`.
- `echo $GNASH_VERSION` → `1.1.0` (bash and zsh personas).
- `C-x C-v` → `gnash, version 1.1.0 (arm64-apple-darwin25.5.0), personality gnash 5.3.0(1)-release`.
- Prompt `\v|\V`: gnash → `5.3|5.3.0`; real bash 5.3.9 → `5.3|5.3.9` (gnash's `\v` matches; `\V` reflects gnash's declared BASH_VERSION 5.3.0).
- Full `ctest` 17/17; clean `-DGNASH_WERROR=ON` build.
