### PR TITLE
release: bump version to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(gnash
-  VERSION 1.1.0
+  VERSION 1.2.0
   DESCRIPTION "A modular C++ reimplementation of bash 5.3"
   LANGUAGES C CXX)
 


### PR DESCRIPTION
Bumps the project version to 1.2.0 for the next release (new since 1.1.0: full zsh tab completion, zsh `**` globbing, and the version single-source-of-truth). Single-line change to `CMakeLists.txt`; `GNASH_VERSION` flows from it.