### PR TITLE
repl: fix uninterruptible zsh-highlighter hang on ) } < >

### DIFF
--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -121,6 +121,13 @@ extern "C" void gnash_zsh_highlight(const char *line, int len, int *colors) {
     }
     int start = i;
     while (i < len && std::strchr(" \t;|&(){}<>'\"\n#", line[i]) == nullptr) i++;
+    if (i == start) {
+      // A break character the cases above don't consume (`)', `}', `<', `>').
+      // Skip it so the scan always advances -- otherwise a line containing one
+      // (e.g. completing `Movie (2005)') spins here forever, hanging redisplay.
+      i++;
+      continue;
+    }
     std::string word(line + start, static_cast<size_t>(i - start));
     if (cmd_pos) {
       if (is_assignment_word(word)) continue;  // VAR=val prefix: stays in cmd pos


### PR DESCRIPTION
### Bug
In the **zsh persona**, tab-menuing through directories whose names contain `)` (or `}`, `<`, `>`) — e.g. `Jarhead (2005) [1080p]` — hung the shell **uninterruptibly**.

### Root cause
`gnash_zsh_highlight` scans words with the break set `` " \t;|&(){}<>'\"\n#" ``, but its special-character handler only consumes `; | & ( { \n`. When the scan reaches `)`, `}`, `<`, or `>`, the word-scan loop can't advance (it's a break char) and the word is empty, so the outer `while (i < len)` never advances `i` → infinite loop. Since the highlighter runs inside `rl_redisplay`, C-c can't break it.

### Fix
If the word-scan made no progress (`i == start`), skip that one break character so the scan always advances. One line; the character is simply left uncolored.

### Verification
- Reproduced with the exact `/Volumes/BJF4TB/VIDEO/MOVIES/Jar*` names locally: before, the 2nd TAB (inserting `Jarhead (2005) …`) produced 0 bytes and the shell was dead to C-c; after, every TAB cycles and the shell stays responsive.
- Full `ctest` 17/17; clean `-DGNASH_WERROR=ON` build.

Note: this is required independently of the filename-escaping work (#20) — escaping produces `\(…\)`, which still contains `)`, so the highlighter must not loop on it. Both are needed for completing these names in the zsh persona.
