### PR TITLE
exec: don't kill an interactive shell when the command can't be executed

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2296,11 +2296,26 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       std::vector<char *> cargv;
       for (size_t i = 1; i < argv.size(); i++) cargv.push_back(const_cast<char *>(argv[i].c_str()));
       cargv.push_back(nullptr);
+      std::fflush(nullptr);
       execvp(cargv[0], cargv.data());
-      std::fprintf(stderr, "gnash: exec: %s: not found\n", argv[1].c_str());
-      _exit(127);
+      // exec failed to run the command.  Report it, then behave like bash: an
+      // interactive shell (or one with `shopt -s execfail') stays alive and
+      // returns failure; a non-interactive shell exits.
+      int code = (errno == EACCES) ? 126 : 127;
+      if (errno == ENOENT && argv[1].find('/') == std::string::npos)
+        std::fprintf(stderr, "%sexec: %s: not found\n", sh.err_prefix().c_str(), argv[1].c_str());
+      else
+        std::fprintf(stderr, "%sexec: %s: %s\n", sh.err_prefix().c_str(), argv[1].c_str(),
+                     std::strerror(errno));
+      auto ef = sh.shopt_opts.find("execfail");
+      bool execfail = ef != sh.shopt_opts.end() && ef->second;
+      if (sh.interactive || execfail)
+        st = code;
+      else
+        _exit(code);
+    } else {
+      st = 0;
     }
-    st = 0;
   } else {
     return false;
   }


### PR DESCRIPTION
### Bug
Running `exec gnash --login --personality=bash` (or any `exec <cmd>` where the command isn't found on PATH) **killed the interactive shell**. The `exec` builtin called `_exit(127)` unconditionally whenever `execvp` failed.

### bash behavior
When `exec` can't run the command, a **non-interactive** shell exits, but an **interactive** shell prints the error and returns failure (stays at the prompt). `shopt -s execfail` makes even a non-interactive shell return failure instead of exiting.

### Fix (`core/src/builtins.cpp`)
On `execvp` failure the builtin now reports the error (`not found`, or the `strerror` for e.g. a permission problem), then:
- interactive shell, or `execfail` set → return failure (127, or 126 for `EACCES`) and keep running;
- non-interactive shell → `_exit` as before.

The `execfail` shopt (already registered) is now honored.

### Verification
- Interactive: `exec zzz_no_such_command` → prints `exec: zzz…: not found`, `$?` is `127`, shell survives.
- Non-interactive: `gnash -c 'exec missing; echo NOTREACHED'` → error, exit 127, `NOTREACHED` not printed.
- `exec <real command>` still replaces the shell.
- Full `ctest` 17/17; clean `-DGNASH_WERROR=ON` build.
