### PR TITLE
readline: don't escape ~ when completing filenames

### DIFF
--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -63,8 +63,10 @@ const char *word_break_chars() {
 // ---- filename quoting -----------------------------------------------------
 // Shell metacharacters (and whitespace) that must be backslash-escaped so a
 // completed filename is read as a single word.  Path/word-safe characters
-// (`/', `.', `-', `_', `:', `@', `,', `+', `%') are deliberately left alone.
-const char *filename_specials() { return " \t\n\\'\"`$&;|<>()[]{}*?!~#="; }
+// (`/', `.', `-', `_', `:', `@', `,', `+', `%') are deliberately left alone --
+// and so is `~', which is only special at the very start of a word (tilde
+// expansion), not within a completed filename.
+const char *filename_specials() { return " \t\n\\'\"`$&;|<>()[]{}*?!#="; }
 
 // Backslash-escape those characters in a filename completion before inserting.
 std::string quote_filename(const std::string &s) {


### PR DESCRIPTION
`~` is only special at the start of a word (tilde expansion), not inside a completed filename, so escaping it in completion results was unnecessary. Removed `~` from the filename-quoting set; whitespace and the other shell metacharacters are still escaped. Shared quoting path, so this applies to all personalities.

Verified: a file `v~1.txt` now completes to `v~1.txt` (no backslash), while `a b~c.txt` still escapes the space (`a\ b~c.txt`). readline_complete_test + full ctest pass; clean `-DGNASH_WERROR=ON`.