### PR TITLE
zsh: implement global (alias -g) and suffix (alias -s) aliases

### DIFF
--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -27,9 +27,13 @@ struct ParseResult {
 // Parse a complete program.
 ParseResult parse(const std::string &input);
 
-// Parse with alias expansion applied to command-position words first.
+// Parse with alias expansion applied first: regular aliases in command position,
+// zsh global aliases (`alias -g') anywhere, and zsh suffix aliases (`alias -s').
+// The global/suffix maps are empty outside the zsh personality.
 ParseResult parse_with_aliases(const std::string &input,
-                               const std::map<std::string, std::string> &aliases);
+                               const std::map<std::string, std::string> &aliases,
+                               const std::map<std::string, std::string> &global_aliases = {},
+                               const std::map<std::string, std::string> &suffix_aliases = {});
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -85,6 +85,8 @@ class Shell {
   std::map<std::string, bool> shopt_opts;     // `shopt' option states
   std::set<std::string> disabled_builtins;    // `enable -n': builtins turned off
   std::map<std::string, std::string> aliases;  // `alias': name -> expansion
+  std::map<std::string, std::string> global_aliases;  // zsh `alias -g': expand anywhere
+  std::map<std::string, std::string> suffix_aliases;  // zsh `alias -s ext=cmd'
   std::map<std::string, std::string> completions;  // `complete': name -> spec string
   struct CallFrame { int line; std::string func; std::string source; };
   std::vector<CallFrame> call_stack;          // `caller': active function calls

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1720,10 +1720,25 @@ static std::string alias_quote(const std::string &v) {
 
 int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
   size_t i = 1;
-  if (i < argv.size() && (argv[i] == "-p")) i++;
+  char kind = 0;  // 0 = regular; 'g' = global, 's' = suffix (zsh `alias -g'/`-s')
+  while (i < argv.size() && argv[i].size() >= 2 && argv[i][0] == '-' && argv[i] != "--") {
+    if (argv[i] == "-p") { i++; continue; }
+    if (sh.is_zsh() && argv[i] == "-g") { kind = 'g'; i++; continue; }
+    if (sh.is_zsh() && argv[i] == "-s") { kind = 's'; i++; continue; }
+    break;
+  }
+  if (i < argv.size() && argv[i] == "--") i++;
+  auto &table = (kind == 'g') ? sh.global_aliases : (kind == 's') ? sh.suffix_aliases : sh.aliases;
+  // Regular aliases list bash-style (`alias name=value'); zsh's global/suffix
+  // list as `name=value'.
+  auto show = [&](const std::string &n, const std::string &v) {
+    if (kind == 0)
+      std::printf("alias %s=%s\n", n.c_str(), alias_quote(v).c_str());
+    else
+      std::printf("%s=%s\n", n.c_str(), alias_quote(v).c_str());
+  };
   if (i >= argv.size()) {
-    for (const auto &kv : sh.aliases)
-      std::printf("alias %s=%s\n", kv.first.c_str(), alias_quote(kv.second).c_str());
+    for (const auto &kv : table) show(kv.first, kv.second);
     return 0;
   }
   int st = 0;
@@ -1731,26 +1746,49 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
     const std::string &a = argv[i];
     auto eq = a.find('=');
     if (eq == std::string::npos) {
-      auto it = sh.aliases.find(a);
-      if (it != sh.aliases.end())
-        std::printf("alias %s=%s\n", it->first.c_str(), alias_quote(it->second).c_str());
+      auto it = table.find(a);
+      if (it != table.end())
+        show(it->first, it->second);
       else {
         std::fflush(stdout);
         std::fprintf(stderr, "%salias: %s: not found\n", sh.err_prefix().c_str(), a.c_str());
         st = 1;
       }
     } else {
-      sh.aliases[a.substr(0, eq)] = a.substr(eq + 1);
+      table[a.substr(0, eq)] = a.substr(eq + 1);
     }
   }
   return st;
 }
 
 int bi_unalias(Shell &sh, const std::vector<std::string> &argv) {
-  if (argv.size() > 1 && argv[1] == "-a") { sh.aliases.clear(); return 0; }
+  // zsh's unalias has `-a' (all) and `-s' (suffix aliases), but NOT `-g': a
+  // global alias is removed by plain `unalias name' (regular and global share
+  // the name lookup).
+  size_t i = 1;
+  bool all = false, suffix = false;
+  while (i < argv.size() && argv[i].size() >= 2 && argv[i][0] == '-' && argv[i] != "--") {
+    if (argv[i] == "-a") { all = true; i++; continue; }
+    if (sh.is_zsh() && argv[i] == "-s") { suffix = true; i++; continue; }
+    break;
+  }
+  if (all) {
+    sh.aliases.clear();
+    sh.global_aliases.clear();
+    sh.suffix_aliases.clear();
+    return 0;
+  }
   int st = 0;
-  for (size_t i = 1; i < argv.size(); i++) {
-    if (sh.aliases.erase(argv[i]) == 0) {
+  for (; i < argv.size(); i++) {
+    bool removed;
+    if (suffix) {
+      removed = sh.suffix_aliases.erase(argv[i]) > 0;
+    } else {
+      bool r = sh.aliases.erase(argv[i]) > 0;         // remove from both regular
+      bool g = sh.global_aliases.erase(argv[i]) > 0;  // and global (they may coexist)
+      removed = r || g;
+    }
+    if (!removed) {
       std::fprintf(stderr, "%sunalias: %s: not found\n", sh.err_prefix().c_str(), argv[i].c_str());
       st = 1;
     }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -880,8 +880,10 @@ struct Parser {
 // alias body's tokens; a body ending in blank makes the following word eligible
 // too, and a word is not re-expanded within its own expansion.
 static void expand_alias_tokens(std::vector<Token> &toks,
-                                const std::map<std::string, std::string> &aliases) {
-  if (aliases.empty()) return;
+                                const std::map<std::string, std::string> &aliases,
+                                const std::map<std::string, std::string> &global_aliases,
+                                const std::map<std::string, std::string> &suffix_aliases) {
+  if (aliases.empty() && global_aliases.empty() && suffix_aliases.empty()) return;
   static const std::set<std::string> kw = {
       "if", "then", "else", "elif", "do", "done", "{", "}", "while", "until",
       "for", "case", "select", "fi", "esac", "!", "time", "function"};
@@ -898,6 +900,32 @@ static void expand_alias_tokens(std::vector<Token> &toks,
     const std::string text = toks[i].text;
     bool quoted = toks[i].quoted;
     if (!quoted && kw.count(text)) { cmd_pos = true; next_also = false; i++; continue; }
+    // zsh global aliases (`alias -g') expand in ANY word position.
+    if (!quoted && global_aliases.count(text) && !active.count(text)) {
+      active.insert(text);
+      guard++;
+      std::vector<Token> rep = tokenize(global_aliases.at(text));
+      if (!rep.empty() && rep.back().type == Tok::Eof) rep.pop_back();
+      toks.erase(toks.begin() + static_cast<long>(i));
+      toks.insert(toks.begin() + static_cast<long>(i), rep.begin(), rep.end());
+      continue;  // reprocess from i: the body may contain operators (| > ...)
+    }
+    // zsh suffix aliases (`alias -s ext=cmd'): a bare `file.ext' in command
+    // position, whose `ext' has a suffix alias and which is not itself an alias,
+    // runs `cmd file.ext'.
+    if ((cmd_pos || next_also) && !quoted && !suffix_aliases.empty() && !aliases.count(text)) {
+      size_t dot = text.rfind('.');
+      if (dot != std::string::npos && dot + 1 < text.size()) {
+        auto sit = suffix_aliases.find(text.substr(dot + 1));
+        if (sit != suffix_aliases.end()) {
+          guard++;
+          std::vector<Token> cmd = tokenize(sit->second);
+          if (!cmd.empty() && cmd.back().type == Tok::Eof) cmd.pop_back();
+          toks.insert(toks.begin() + static_cast<long>(i), cmd.begin(), cmd.end());
+          continue;  // reprocess from i: the inserted command is now cmd_pos
+        }
+      }
+    }
     if ((cmd_pos || next_also) && !quoted && aliases.count(text) && !active.count(text)) {
       const std::string &val = aliases.at(text);
       active.insert(text);
@@ -935,9 +963,11 @@ ParseResult parse(const std::string &input) {
 }
 
 ParseResult parse_with_aliases(const std::string &input,
-                               const std::map<std::string, std::string> &aliases) {
+                               const std::map<std::string, std::string> &aliases,
+                               const std::map<std::string, std::string> &global_aliases,
+                               const std::map<std::string, std::string> &suffix_aliases) {
   std::vector<Token> toks = tokenize(input);
-  expand_alias_tokens(toks, aliases);
+  expand_alias_tokens(toks, aliases, global_aliases, suffix_aliases);
   Parser p(std::move(toks));
   return p.run();
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -563,8 +563,10 @@ int Shell::run_string(const std::string &script) {
   bool expand_al = interactive;
   auto eit = shopt_opts.find("expand_aliases");
   if (eit != shopt_opts.end() && eit->second) expand_al = true;
-  ParseResult r = (expand_al && !aliases.empty()) ? parse_with_aliases(script, aliases)
-                                                  : parse(script);
+  bool have_aliases = !aliases.empty() || !global_aliases.empty() || !suffix_aliases.empty();
+  ParseResult r = (expand_al && have_aliases)
+                      ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases)
+                      : parse(script);
   if (!r.ok) {
     std::fprintf(stderr, "gnash: syntax error: %s\n", r.error.c_str());
     last_status = 2;

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -28,6 +28,26 @@ static void ok(const std::string &in, const char *want) {
   }
 }
 
+// Parse `in` with the given regular/global/suffix alias tables; assert the
+// expanded result renders to `want`.
+static void alias_ok(const std::string &in,
+                     const std::map<std::string, std::string> &reg,
+                     const std::map<std::string, std::string> &glob,
+                     const std::map<std::string, std::string> &suf, const char *want) {
+  core::ParseResult r = core::parse_with_aliases(in, reg, glob, suf);
+  if (!r.ok) {
+    std::fprintf(stderr, "FAIL alias parse(%s): error: %s\n", in.c_str(), r.error.c_str());
+    failures++;
+    return;
+  }
+  std::string got = core::to_string(r.command.get());
+  if (got != want) {
+    std::fprintf(stderr, "FAIL alias parse(%s): got \"%s\", wanted \"%s\"\n", in.c_str(),
+                 got.c_str(), want);
+    failures++;
+  }
+}
+
 // Assert that `in` is a syntax error.
 static void bad(const std::string &in) {
   core::ParseResult r = core::parse(in);
@@ -110,6 +130,15 @@ int main() {
   bad("( a");                  // unclosed subshell
   bad("case x in a) b;;");     // missing esac
   bad("for; do x; done");      // missing variable
+
+  // -- alias expansion: regular (command position), zsh global (any position),
+  //    zsh suffix (file.ext -> cmd file.ext) --
+  alias_ok("ll -a", {{"ll", "ls -l"}}, {}, {}, "ls -l -a");            // regular
+  alias_ok("echo a P b", {}, {{"P", "| wc"}}, {}, "echo a | wc b");     // global, mid-command
+  alias_ok("cmd G", {}, {{"G", "| grep x"}}, {}, "cmd | grep x");       // global at end
+  alias_ok("echo P", {}, {}, {}, "echo P");                            // no tables: unchanged
+  alias_ok("readme.md", {}, {}, {{"md", "less"}}, "less readme.md");    // suffix
+  alias_ok("a.txt b.txt", {}, {}, {{"txt", "cat"}}, "cat a.txt b.txt"); // suffix only in cmd pos
 
   if (failures == 0) {
     std::printf("all parser tests passed\n");


### PR DESCRIPTION
Makes the zsh personality's alias support more complete by adding the two zsh-specific alias kinds it was missing. (bash/gnash/ksh personalities are unaffected — the `-g`/`-s` flags are zsh-only.)

### Global aliases — `alias -g`
Expand in **any** word position, not just command position:
```
alias -g L='| less'
ls -la L            # runs: ls -la | less
alias -g NE='2>/dev/null'
grep foo * NE       # runs: grep foo * 2>/dev/null
```

### Suffix aliases — `alias -s`
A bare `file.ext` in command position runs `cmd file.ext`:
```
alias -s txt=less
notes.txt           # runs: less notes.txt
```

### Details
- New `global_aliases` / `suffix_aliases` tables, populated only via the zsh-only `-g`/`-s` flags.
- Expansion added to the parser's alias pass (`expand_alias_tokens`): globals expand everywhere; a suffix-matching filename in command position gets the command prepended. Uses the same interactive/`expand_aliases` gate as regular aliases.
- `unalias` matches zsh exactly: plain `unalias name` removes a regular **or** global alias, `unalias -s` removes a suffix alias, `-a` clears all; there is **no** `unalias -g` (zsh errors on it — verified).
- Listing: `alias -g` / `alias -s` print `name=value` (zsh style); regular `alias` keeps the bash-style `alias name=value`.

### Verification
- Compared **behavior-for-behavior against zsh 5.9** (interactive pty): global expansion mid-command, suffix execution, `alias -s` listing, and plain-`unalias` removing a global alias all match.
- `parser_test` covers the expansion (regular/global/suffix rendering); bash persona rejects `-g`.
- Full `ctest` 17/17; differential vs bash 5.3.15 still 161/161 (no bash-persona change); clean `-DGNASH_WERROR=ON`.

Note: the linked ChatGPT discussion is JS-rendered so I couldn't read it directly, but global + suffix aliases are the canonical bash-vs-zsh alias differences. If it covered something else (e.g. zsh's `name=value` listing format for *regular* aliases, or `alias -m` glob matching), say so and I'll fold it in.
