### PR TITLE
csh: expand word-initial tilde (fixes #27)

### DIFF
--- a/core/src/csh.cpp
+++ b/core/src/csh.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <memory>
+#include <pwd.h>
 #include <string>
 #include <vector>
 #include <sys/stat.h>
@@ -319,11 +320,35 @@ struct Interp {
     return var_ptr(n) != nullptr || std::getenv(n.c_str()) != nullptr;
   }
 
+  // Expand a word-initial, unquoted tilde: ~, ~/path, ~user, ~user/path.
+  // ~ / ~/... use the csh `home` variable ($HOME, then the passwd entry as a
+  // fallback); ~user/... uses that user's home from the passwd database.  A
+  // word not beginning with ~, or a ~ we cannot resolve, is returned verbatim.
+  std::string tilde_expand(const std::string &w) {
+    if (w.empty() || w[0] != '~') return w;
+    size_t slash = w.find('/');
+    std::string name = w.substr(1, (slash == std::string::npos ? w.size() : slash) - 1);
+    std::string home;
+    if (name.empty()) {
+      home = var_str("home");
+      if (home.empty()) { const char *h = std::getenv("HOME"); if (h) home = h; }
+      if (home.empty()) { struct passwd *pw = getpwuid(getuid()); if (pw) home = pw->pw_dir; }
+    } else {
+      struct passwd *pw = getpwnam(name.c_str());
+      if (pw) home = pw->pw_dir;
+    }
+    if (home.empty()) return w;  // unknown user: leave untouched, as csh does
+    return home + (slash == std::string::npos ? std::string() : w.substr(slash));
+  }
+
   // -- expansion --
   // Expand one raw word into zero or more fields.  When do_glob is false the
   // fields are returned verbatim (used for switch/case patterns, which are
   // globbing patterns to match against, not filenames to expand).
-  void expand_word(const std::string &w, std::vector<std::string> &out, bool do_glob = true) {
+  void expand_word(const std::string &raw, std::vector<std::string> &out, bool do_glob = true) {
+    // A word-initial unquoted tilde expands to a home directory before any
+    // other substitution; a quoted or non-initial ~ is left alone.
+    const std::string &w = (!raw.empty() && raw[0] == '~') ? tilde_expand(raw) : raw;
     std::string cur;
     bool have = false;
     std::vector<std::string> fields;


### PR DESCRIPTION
## Summary

Under the csh/tcsh personality, `echo ~` and `echo ~/foo` printed a literal `~`. The csh interpreter's `expand_word` handled quotes, `$`, backquotes, escapes, and globbing, but had no tilde handling.

## Fix

Add a `tilde_expand` helper in `core/src/csh.cpp`, applied to a word whose **unquoted first character** is `~`:
- `~` / `~/path` → `$home` (csh `home` variable, then `$HOME`, then the passwd entry)
- `~user` / `~user/path` → that user's home via `getpwnam`

A quoted (`"~"`) or non-word-initial (`a~b`, `x~`) tilde is left untouched, and an unknown `~user` is emitted verbatim — matching csh/tcsh.

## Testing

```
> echo ~            -> /Users/bfox
> echo ~/foo        -> /Users/bfox/foo
> echo ~bfox/x      -> /Users/bfox/x
> echo a~b          -> a~b
> echo "~"          -> ~
> set home=/tmp/h; echo ~  -> /tmp/h
```

`run_diff_csh` and the lexer/parser/arith unit tests pass.

Fixes #27