### PR TITLE
zsh: true-to-zsh word splitting and bare-array expansion (fixes #29)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -66,6 +66,9 @@ class Shell {
                      std::vector<std::pair<std::string, std::string>> &pairs) const;
   void array_set(const std::string &n, const std::string &sub, const std::string &v);
   int array_count(const std::string &n) const;
+  // True when NAME holds an indexed or associative array (not a scalar); used
+  // by the zsh personality, where a bare `$array' expands to all its elements.
+  bool is_array(const std::string &n) const;
   // Assign name=(elements...); each element is (optional explicit subscript, value).
   void array_assign(const std::string &n,
                     const std::vector<std::pair<std::optional<std::string>, std::string>> &elems,

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -277,7 +277,10 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       std::string res = sh_.run_and_capture(inner, &st);
       sh_.last_status = st;
       sh_.note_cmdsub(st);
-      for (char c : res) { out += c; mask += qm; }
+      // '4' marks command-substitution output, which zsh word-splits (unlike
+      // parameter expansion); double-quoted, it is not split.
+      char cm = dq ? '1' : '4';
+      for (char c : res) { out += c; mask += cm; }
       i = end + 1;
       return;
     }
@@ -294,7 +297,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       std::string res = sh_.run_and_capture_inproc(inner, &st);
       sh_.last_status = st;
       sh_.note_cmdsub(st);
-      for (char c : res) { out += c; mask += qm; }
+      char cm = dq ? '1' : '4';  // command output: zsh-splittable (see $(...) above)
+      for (char c : res) { out += c; mask += cm; }
       i = end + 1;
       return;
     }
@@ -451,6 +455,26 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     out += '$';
     mask += qm;
     i += 1;
+    return;
+  }
+  // zsh: a bare `$array' expands to every element, not just element 0.  Unquoted
+  // it yields one word per element (like `${array[@]}'); double-quoted it joins
+  // the elements with the first IFS character (like `"${array[*]}"').
+  if (sh_.is_zsh() && sh_.is_array(name)) {
+    std::vector<std::string> items = sh_.array_values(name);
+    if (dq) {
+      std::string is = sh_.ifs();
+      std::string joiner = is.empty() ? std::string() : std::string(1, is[0]);
+      for (size_t k = 0; k < items.size(); k++) {
+        if (k) for (char c : joiner) { out += c; mask += '1'; }
+        for (char c : items[k]) { out += c; mask += '1'; }
+      }
+    } else {
+      for (size_t k = 0; k < items.size(); k++) {
+        if (k) { out += FIELD_SEP; mask += '0'; }
+        for (char c : items[k]) { out += c; mask += '0'; }
+      }
+    }
     return;
   }
   bool set = false;
@@ -837,7 +861,7 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
       int st = 0;
       std::string res = sh_.run_and_capture(inner, &st);
       sh_.note_cmdsub(st);
-      for (char ch : res) { out += ch; mask += '0'; }
+      for (char ch : res) { out += ch; mask += '4'; }  // command output: zsh-splittable
       i = (j < text.size()) ? j + 1 : j;
     } else {
       // Literal (unquoted, not from expansion): mask '2' -- glob-active like an
@@ -853,6 +877,17 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
 std::vector<std::pair<std::string, std::string>> Expander::split_ifs(const std::string &s,
                                                                      const std::string &mask) {
   std::string ifs = sh_.ifs();
+  // Mask legend for IFS splitting:
+  //   '0' parameter/array/positional expansion output -- IFS-split in bash, but
+  //       NOT in zsh (zsh leaves `$var' and array elements un-split);
+  //   '4' command-substitution output ($(...)/`...`) -- IFS-split in both bash
+  //       and zsh (zsh word-splits command substitution even with the default
+  //       SH_WORD_SPLIT off);
+  //   '1' quoted, '2' literal -- never IFS-split.
+  // FIELD_SEP (array/`$@' element boundary) is always a hard split for any
+  // unquoted expansion output, in either shell.
+  bool zsh = sh_.is_zsh();
+  auto splittable = [&](char m) { return m == '4' || (m == '0' && !zsh); };
   std::vector<std::pair<std::string, std::string>> fields;
   std::string cur, curm;
   bool have = false;
@@ -862,18 +897,18 @@ std::vector<std::pair<std::string, std::string>> Expander::split_ifs(const std::
   size_t i = 0;
   while (i < s.size()) {
     char c = s[i];
-    // Only expansion output (mask '0') is IFS-split; quoted ('1') and literal
-    // ('2') text is never split, even when it contains IFS characters.
-    bool q = mask[i] != '0';
+    // Quoted ('1') and literal ('2') text is never split, even when it contains
+    // IFS characters; '0'/'4' expansion output is (subject to the rule above).
+    bool q = mask[i] == '1' || mask[i] == '2';
     if (!q && c == FIELD_SEP) {
       flush();
       i++;
       continue;
     }
-    if (!q && is_ifs(c)) {
+    if (splittable(mask[i]) && is_ifs(c)) {
       if (is_ws(c)) {
         if (have) flush();
-        while (i < s.size() && mask[i] == '0' && is_ifs(s[i]) && is_ws(s[i])) i++;
+        while (i < s.size() && splittable(mask[i]) && is_ifs(s[i]) && is_ws(s[i])) i++;
       } else {
         flush();
         i++;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -365,6 +365,13 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   if (k == 0) v.value = val;
 }
 
+bool Shell::is_array(const std::string &n_in) const {
+  std::string n = deref(n_in);
+  auto it = vars.find(n);
+  return it != vars.end() &&
+         (it->second.kind == VarKind::Indexed || it->second.kind == VarKind::Assoc);
+}
+
 int Shell::array_count(const std::string &n_in) const {
   {
     std::vector<std::pair<std::string, std::string>> vp;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,17 @@ if(BASH_EXECUTABLE AND TCSH_EXECUTABLE)
             $<TARGET_FILE:gnash> ${TCSH_EXECUTABLE})
 endif()
 
+# Differential execution check for the zsh personality vs a reference zsh,
+# covering the expansion behaviors (word splitting, bare-array expansion) where
+# zsh diverges from bash.
+find_program(ZSH_EXECUTABLE zsh)
+if(BASH_EXECUTABLE AND ZSH_EXECUTABLE)
+  add_test(
+    NAME run_diff_zsh
+    COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/harness/run_diff_zsh.sh
+            $<TARGET_FILE:gnash> ${ZSH_EXECUTABLE})
+endif()
+
 # ---------------------------------------------------------------------------
 # Conformance harness self-check.
 #

--- a/tests/harness/run_diff_zsh.sh
+++ b/tests/harness/run_diff_zsh.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Brian J. Fox
+# Licensed under GPLv2 with the GPLv2-AI Exception.
+
+# run_diff_zsh.sh GNASH ZSH
+#
+# Differential execution for gnash's zsh personality: run each script under
+# gnash (in its zsh persona) and under a reference zsh, comparing stdout and
+# exit status.  These scripts exercise the expansion behaviors where zsh
+# diverges from bash -- word splitting and bare-array expansion -- so gnash's
+# zsh persona must match real zsh exactly.
+#
+# GNASH should be a `zsh'-named symlink to the gnash binary, or the gnash
+# binary itself (then run with --personality=zsh).
+set -u
+
+gnash=${1:?usage: run_diff_zsh.sh GNASH ZSH}
+zsh=${2:-/bin/zsh}
+
+tmp=$(mktemp /tmp/gnash_zsh.XXXXXX)
+trap 'rm -f "$tmp"' EXIT
+
+# Hard wall-clock cap so a runaway script can't hang the suite.
+cap() { perl -e 'alarm 8; exec @ARGV' "$@"; }
+
+run_gnash() {
+  case $(basename "$gnash") in
+    zsh) cap "$gnash" "$tmp" </dev/null ;;
+    *)   cap "$gnash" --personality=zsh "$tmp" </dev/null ;;
+  esac
+}
+
+# Each script prints results with visible delimiters so any word-splitting
+# difference shows up in the compared output.
+scripts=(
+  # unquoted scalar does not word-split under zsh
+  'v="a b c"; printf "[%s]" $v; echo'
+  # double-quoted scalar is one word (same as bash)
+  'v="a b c"; printf "[%s]" "$v"; echo'
+  # unquoted command substitution does not word-split
+  's=$(echo p q r); printf "[%s]" $s; echo'
+  'printf "[%s]" $(echo x y z); echo'
+  # bare array expands to all elements, one word each
+  'a=(one two three); printf "[%s]" $a; echo'
+  # double-quoted bare array joins elements with the first IFS char
+  'a=(one two three); printf "[%s]" "$a"; echo'
+  # elements that contain spaces stay intact (no secondary split)
+  'b=("x y" z); printf "[%s]" $b; echo'
+  # empty scalar is removed from an unquoted list
+  'e=""; printf "[%s]" A $e B; echo'
+  # a for-loop over a bare array iterates once per element
+  'a=(one two three); for w in $a; do printf "<%s>" "$w"; done; echo'
+  # a for-loop over an unquoted scalar iterates once (no split)
+  'v="a b c"; for w in $v; do printf "<%s>" "$w"; done; echo'
+  # non-whitespace IFS is not used to split unquoted expansions
+  'IFS=:; p="1:2:3"; printf "[%s]" $p; echo'
+  # braced array forms are unchanged
+  'a=(one two three); printf "[%s]" "${a[@]}"; echo'
+  'a=(one two three); printf "[%s]" "${a[*]}"; echo'
+  'a=(one two three); echo ${#a[@]}'
+  # ${var:-default} and other operators still work
+  'echo ${nope:-fallback}'
+  'v=hello; echo ${v/l/L}; echo ${#v}'
+  # positional parameters keep their (bash-compatible) behavior
+  'set -- p1 p2 p3; printf "[%s]" $@; echo; printf "[%s]" "$*"; echo'
+)
+
+fails=0
+for s in "${scripts[@]}"; do
+  printf '%s\n' "$s" > "$tmp"
+  g_out=$(run_gnash 2>/dev/null); g_rc=$?
+  z_out=$(cap "$zsh" -f "$tmp" </dev/null 2>/dev/null); z_rc=$?
+  if [ "$g_out" != "$z_out" ] || [ "$g_rc" != "$z_rc" ]; then
+    echo "MISMATCH: $s" >&2
+    echo "  gnash (rc=$g_rc): $g_out" >&2
+    echo "  zsh   (rc=$z_rc): $z_out" >&2
+    fails=$((fails + 1))
+  fi
+done
+
+if [ $fails -eq 0 ]; then
+  echo "run_diff_zsh: all ${#scripts[@]} scripts match zsh"
+  exit 0
+fi
+echo "run_diff_zsh: $fails mismatch(es)" >&2
+exit 1


### PR DESCRIPTION
## Summary

Makes `--personality=zsh` follow zsh's expansion rules instead of bash's defaults. Verified against a reference zsh.

| Case | before | now / zsh |
|------|--------|-----------|
| unquoted scalar `$v` (v="a b c") | `a` `b` `c` | `a b c` (one word) |
| unquoted `$(echo a b c)` | `a` `b` `c` | `a` `b` `c` (still splits!) |
| `x=$(echo a b c); $x` | `a` `b` `c` | `a b c` (var, no split) |
| bare `$array` | first element | all elements, one word each |
| `"$array"` | first element | elements joined by IFS[0] |
| `a=("x y" z); $a` | `x` | `x y` `z` (no secondary split) |

## The key nuance

zsh has `SH_WORD_SPLIT` **off** by default, so **parameter expansion** (`$var`, `${...}`, arrays, `$@`) is **not** IFS word-split. But zsh **does** word-split **command substitution** (`$(...)`, backticks) -- a distinction bash doesn't make (bash splits both).

Implemented with a new mask value `'4'` for command-substitution output ("splittable in both shells"); parameter/array output keeps `'0'` ("splittable under bash only"). `split_ifs` honors the difference; `FIELD_SEP` array/`$@` boundaries still split in both shells.

## Changes

- `core/src/expand.cpp` -- `split_ifs` mask rules; `$(...)`, `${ cmd; }`, and backtick output marked `'4'`; bare `$array` (zsh) expands to all elements.
- `core/src/shell.cpp` / `shell.hpp` -- `Shell::is_array()`.
- `tests/harness/run_diff_zsh.sh` + `tests/CMakeLists.txt` -- new `run_diff_zsh` differential test (gnash zsh persona vs reference zsh).

All gated on `is_zsh()`; bash/ksh/ash unchanged. `run_diff` (bash), `run_diff_csh`, and the unit suite all pass; `run_diff_zsh` passes.

## Deferred (own follow-up)

1-based array indexing (`${a[1]}` / `$a[1]` = first element, `$a[-1]`, `$a[1,3]`) and zsh brace-free subscripts / expansion flags (`$#a`, `${=v}`, `${(f)v}`). These need coordinated read/write index translation that interacts with bash's own arrays (`BASH_REMATCH`, `mapfile` origin, `BASH_ARGV`), so they belong in a separate change.

Fixes #29
