### PR TITLE
zsh: 1-based array indexing and brace-free subscripts (fixes #31)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -57,6 +57,14 @@ class Expander {
   void expand_dollar(const std::string &text, size_t &i, bool dq, std::string &out,
                      std::string &mask);
 
+  // zsh array subscript on NAME with the raw text SUB (between the brackets):
+  // a single 1-based/negative index, or a `lo,hi' range.  Emits the selected
+  // element(s) into out/mask -- a range yields one word per element (unquoted)
+  // or an IFS-joined word (double-quoted).  Used for `$name[..]' and
+  // `${name[lo,hi]}' under the zsh personality.
+  void emit_zsh_subscript(const std::string &name, const std::string &sub, bool dq,
+                          std::string &out, std::string &mask);
+
   // Split into fields on IFS; each field carries its per-character quote mask
   // so pathname expansion can tell quoted metacharacters from unquoted ones.
   std::vector<std::pair<std::string, std::string>> split_ifs(const std::string &s,

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -69,6 +69,11 @@ class Shell {
   // True when NAME holds an indexed or associative array (not a scalar); used
   // by the zsh personality, where a bare `$array' expands to all its elements.
   bool is_array(const std::string &n) const;
+  // zsh uses 1-based array subscripts (and negative indices counting from the
+  // end).  Under the zsh personality, translate such a subscript on an indexed
+  // array to gnash's internal 0-based index; for scalars, associative arrays,
+  // or any other personality the subscript is returned unchanged.
+  std::string zsh_subscript(const std::string &name, const std::string &sub) const;
   // Assign name=(elements...); each element is (optional explicit subscript, value).
   void array_assign(const std::string &n,
                     const std::vector<std::pair<std::optional<std::string>, std::string>> &elems,

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -350,7 +350,7 @@ long long eval_string(Shell &sh, const std::string &str, int depth, bool *ok) {
 // recursively -- like bash, where `a=b+1; b=3; echo $((a))' yields 4.
 long long ref_get(const Node *n, Ctx &ctx) {
   std::string v;
-  if (n->has_sub) v = ctx.sh.array_get(n->name, n->sub);
+  if (n->has_sub) v = ctx.sh.array_get(n->name, ctx.sh.zsh_subscript(n->name, n->sub));
   else { v = ctx.sh.get(n->name); if (v.empty()) { std::string dv; if (ctx.sh.dynamic_var(n->name, dv)) v = dv; } }
   if (v.empty()) return 0;
   if (ctx.depth > 100) return 0;
@@ -359,7 +359,8 @@ long long ref_get(const Node *n, Ctx &ctx) {
   return o ? r : 0;
 }
 void ref_set(const Node *n, long long val, Ctx &ctx) {
-  if (n->has_sub) ctx.sh.array_set(n->name, n->sub, std::to_string(val));
+  if (n->has_sub)
+    ctx.sh.array_set(n->name, ctx.sh.zsh_subscript(n->name, n->sub), std::to_string(val));
   else ctx.sh.set(n->name, std::to_string(val));
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -217,7 +217,9 @@ parse_array_elems(Expander &ex, const std::string &parenval) {
 
 void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   if (a.sub) {
-    std::string sub = ex.expand_no_split(*a.sub);
+    // zsh array subscripts are 1-based; translate to the internal 0-based index
+    // (a no-op under other personalities / for associative arrays).
+    std::string sub = sh.zsh_subscript(a.name, ex.expand_no_split(*a.sub));
     std::string val = ex.expand_assignment(a.value);
     if (a.append) val = sh.array_get(a.name, sub) + val;
     sh.array_set(a.name, sub, val);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -225,6 +225,46 @@ static bool slice_ref(const std::string &body, std::string &name, char &sel,
   return true;
 }
 
+void Expander::emit_zsh_subscript(const std::string &name, const std::string &sub, bool dq,
+                                  std::string &out, std::string &mask) {
+  // A top-level comma makes this a zsh range `lo,hi' (both 1-based, inclusive,
+  // negatives counting from the end).  Otherwise it is a single index.
+  size_t comma = std::string::npos;
+  for (size_t k = 0; k < sub.size(); k++) {
+    if (sub[k] == '[') { int d = 1; while (++k < sub.size() && d) d += (sub[k]=='[') - (sub[k]==']'); }
+    else if (sub[k] == ',') { comma = k; break; }
+  }
+  if (comma != std::string::npos) {
+    std::vector<std::string> all = sh_.array_values(name);
+    long long n = static_cast<long long>(all.size());
+    bool ok = true;
+    long long lo = eval_arith(sh_, expand_no_split(sub.substr(0, comma)), &ok);
+    long long hi = eval_arith(sh_, expand_no_split(sub.substr(comma + 1)), &ok);
+    if (lo < 0) lo += n + 1;  // -1 == last element (position n)
+    if (hi < 0) hi += n + 1;
+    std::vector<std::string> items;
+    for (long long k = lo; k <= hi; k++)
+      if (k >= 1 && k <= n) items.push_back(all[static_cast<size_t>(k - 1)]);
+    if (dq) {
+      std::string is = sh_.ifs();
+      std::string joiner = is.empty() ? std::string() : std::string(1, is[0]);
+      for (size_t k = 0; k < items.size(); k++) {
+        if (k) for (char c : joiner) { out += c; mask += '1'; }
+        for (char c : items[k]) { out += c; mask += '1'; }
+      }
+    } else {
+      for (size_t k = 0; k < items.size(); k++) {
+        if (k) { out += FIELD_SEP; mask += '0'; }
+        for (char c : items[k]) { out += c; mask += '0'; }
+      }
+    }
+    return;
+  }
+  std::string val = sh_.array_get(name, sh_.zsh_subscript(name, expand_no_split(sub)));
+  char qm = dq ? '1' : '0';
+  for (char c : val) { out += c; mask += qm; }
+}
+
 void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::string &out,
                              std::string &mask) {
   char qm = dq ? '1' : '0';
@@ -308,6 +348,24 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     size_t end = scan_balanced(t, i + 1, '{', '}');
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
+      // zsh: `${a[lo,hi]}' is a 1-based inclusive range.  (A single `${a[i]}'
+      // is handled -- 1-based -- in expand_brace_body.)  Only intercept a bare
+      // name[..] with no trailing operator so ${a[i]:-x} etc. still work.
+      if (sh_.is_zsh() && !body.empty() && body.back() == ']') {
+        size_t lb = body.find('[');
+        if (lb != std::string::npos && lb > 0) {
+          std::string zn = body.substr(0, lb);
+          bool ident = std::isalpha(static_cast<unsigned char>(zn[0])) || zn[0] == '_';
+          for (size_t k = 1; ident && k < zn.size(); k++)
+            ident = std::isalnum(static_cast<unsigned char>(zn[k])) || zn[k] == '_';
+          std::string zsub = body.substr(lb + 1, body.size() - lb - 2);
+          if (ident && sh_.is_array(zn) && zsub.find(',') != std::string::npos) {
+            emit_zsh_subscript(zn, zsub, dq, out, mask);
+            i = end + 1;
+            return;
+          }
+        }
+      }
       char lead, sel;
       std::string aname;
       if (array_ref(body, lead, aname, sel)) {
@@ -445,6 +503,17 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     }
     i += 2;
     return;
+  } else if (n1 == '#' && sh_.is_zsh() && i + 2 < t.size() &&
+             (std::isalpha(static_cast<unsigned char>(t[i + 2])) || t[i + 2] == '_')) {
+    // zsh `$#name': element count for an array, string length for a scalar.
+    size_t j = i + 2;
+    while (j < t.size() && (std::isalnum(static_cast<unsigned char>(t[j])) || t[j] == '_')) j++;
+    std::string nm = t.substr(i + 2, j - (i + 2));
+    std::string cnt = sh_.is_array(nm) ? std::to_string(sh_.array_count(nm))
+                                       : std::to_string(sh_.get(nm).size());
+    for (char c : cnt) { out += c; mask += qm; }
+    i = j;
+    return;
   } else if (n1 == '?' || n1 == '$' || n1 == '!' || n1 == '#' || n1 == '-') {
     name = std::string(1, n1);
     i += 2;
@@ -455,6 +524,20 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     out += '$';
     mask += qm;
     i += 1;
+    return;
+  }
+  // zsh brace-free subscript: `$name[i]' / `$name[lo,hi]' (1-based).  Only for
+  // arrays -- a scalar keeps its bare value (character indexing is not modeled).
+  if (sh_.is_zsh() && !name.empty() &&
+      (std::isalpha(static_cast<unsigned char>(name[0])) || name[0] == '_') &&
+      i < t.size() && t[i] == '[' && sh_.is_array(name)) {
+    size_t s = i + 1, p = i + 1;
+    int d = 1;
+    while (p < t.size() && d) { if (t[p] == '[') d++; else if (t[p] == ']') d--; if (d) p++; }
+    std::string zsub = t.substr(s, p - s);
+    if (p < t.size() && t[p] == ']') p++;
+    emit_zsh_subscript(name, zsub, dq, out, mask);
+    i = p;
     return;
   }
   // zsh: a bare `$array' expands to every element, not just element 0.  Unquoted
@@ -576,10 +659,16 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     if (p < b.size() && b[p] == ']') p++;
   }
 
+  // zsh: `${#a}' on an array is the element count (bash gives the length of
+  // element 0); `${#a[i]}' keeps its meaning (length of that element).
+  if (length && !have_sub && sh.is_zsh() && sh.is_array(name))
+    return std::to_string(sh.array_count(name));
+
   bool set = false;
   std::string val;
   if (have_sub) {
-    val = sh.array_get(name, ex.expand_no_split(sub));
+    // zsh subscripts are 1-based; translate before the (0-based) array read.
+    val = sh.array_get(name, sh.zsh_subscript(name, ex.expand_no_split(sub)));
     set = sh.is_set(name);
   } else {
     val = ex.param_value(name, set);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -372,6 +372,20 @@ bool Shell::is_array(const std::string &n_in) const {
          (it->second.kind == VarKind::Indexed || it->second.kind == VarKind::Assoc);
 }
 
+std::string Shell::zsh_subscript(const std::string &name, const std::string &sub) const {
+  if (!is_zsh()) return sub;
+  std::string n = deref(name);
+  auto it = vars.find(n);
+  // Associative arrays are keyed by string, not position -- never translate.
+  if (it != vars.end() && it->second.kind == VarKind::Assoc) return sub;
+  bool ok = true;
+  long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
+  if (!ok) return sub;              // non-numeric: leave as-is
+  if (k > 0) return std::to_string(k - 1);            // 1-based -> 0-based
+  if (k < 0) return std::to_string(k + array_count(name));  // -1 == last
+  return "-1";                     // zsh has no element 0: force a miss
+}
+
 int Shell::array_count(const std::string &n_in) const {
   {
     std::vector<std::pair<std::string, std::string>> vp;

--- a/tests/harness/run_diff_zsh.sh
+++ b/tests/harness/run_diff_zsh.sh
@@ -63,6 +63,26 @@ scripts=(
   'v=hello; echo ${v/l/L}; echo ${#v}'
   # positional parameters keep their (bash-compatible) behavior
   'set -- p1 p2 p3; printf "[%s]" $@; echo; printf "[%s]" "$*"; echo'
+  # 1-based array indexing
+  'a=(alpha beta gamma delta); echo ${a[1]} ${a[2]}'
+  'a=(alpha beta gamma delta); echo "[${a[0]}]"'
+  # brace-free subscripts
+  'a=(alpha beta gamma delta); echo $a[1] $a[3]'
+  # negative indices count from the end
+  'a=(alpha beta gamma delta); echo $a[-1] $a[-2]'
+  # inclusive ranges, including negative bounds
+  'a=(alpha beta gamma delta); printf "<%s>" $a[2,3]; echo'
+  'a=(alpha beta gamma delta); printf "<%s>" $a[2,-1]; echo'
+  'a=(alpha beta gamma delta); printf "<%s>" $a[-2,-1]; echo'
+  # element count (${#a} and $#a) and scalar length
+  'a=(alpha beta gamma delta); echo ${#a} $#a'
+  'n=hello; echo $#n ${#n}'
+  # 1-based writes
+  'a=(alpha beta gamma delta); a[2]=BETA; printf "<%s>" $a; echo'
+  # 1-based subscripts inside arithmetic
+  'nums=(10 20 30); echo $((nums[1] + nums[3]))'
+  # associative arrays are keyed by string, not translated
+  'typeset -A h; h[key]=val; h[two]=2; echo ${h[key]} ${h[two]}'
 )
 
 fails=0


### PR DESCRIPTION
## Summary

Follow-up to #29/#30. Under `--personality=zsh`, array subscripts are now **1-based** (with negative indices from the end), matching zsh. Verified byte-for-byte against a reference zsh.

| Expression (`a=(alpha beta gamma delta)`) | bash | zsh (now) |
|-------------------------------------------|------|-----------|
| `${a[1]}` | `beta` | `alpha` |
| `${a[0]}` | `alpha` | (empty) |
| `$a[2]` (brace-free) | `alpha[2]` literal | `beta` |
| `$a[-1]` / `$a[-2]` | literal | `delta` / `gamma` |
| `$a[2,3]` / `$a[2,-1]` (ranges) | literal | `beta gamma` / `beta gamma delta` |
| `$#a` / `${#a}` | -- / `4` (len of elem0) | `4` (count) |
| `$#scalar` | -- | string length |
| `a[2]=X` | index 2 | 2nd element |
| `$((a[1]+a[3]))` | 0-based | 1-based |

## Design

- **`Shell::zsh_subscript(name, sub)`** translates a 1-based/negative subscript on an *indexed* array to gnash's internal 0-based index. It is the identity for scalars, associative arrays, and every non-zsh personality. Only the **user-facing** subscript sites route through it — `${a[i]}` read (`expand.cpp`), `a[i]=v` write (`executor.cpp`), and `$((a[i]))` read/write (`arith.cpp`). Internal 0-based callers (`mapfile` origin, `BASH_REMATCH`, `BASH_SOURCE`) stay on the raw path, so bash's own arrays are untouched.
- **Brace-free syntax** in `expand_dollar`: `$name[i]`, `$name[lo,hi]` inclusive ranges (negatives from the end), and `$#name` (element count for arrays, length for scalars). Braced ranges `${a[lo,hi]}` handled too; `${#a}` on an array yields the count.

## Testing

- `run_diff_zsh` extended with indexing / range / count / write / arithmetic / associative-array cases — passes against reference zsh.
- `run_diff` (bash) and `run_diff_csh` pass; bash personality is byte-identical to real bash 5.3.15 (`$a[1]` stays the literal `alpha[1]`, `${a[1]}`=`beta`).
- Full unit suite + parser differential pass.

Fixes #31
