### PR TITLE
personality: switch shell personality at runtime (emulate syntax) (fixes #35)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -170,6 +170,16 @@ class Shell {
   bool is_ash() const { return persona == Persona::Ash; }
   bool is_ksh() const { return persona == Persona::Ksh; }
   bool is_csh() const { return persona == Persona::Csh; }
+  // Select the active personality by name (zsh/sh/dash/ash/ksh.../csh/tcsh/bash,
+  // same mapping as at startup): sets `persona', $GNASH_PERSONALITY, and the
+  // per-shell identity variables ($ZSH_VERSION / $KSH_VERSION / $BASH_VERSION,
+  // ...).  Used both at startup and by the `personality'/`emulate' builtin to
+  // switch personality while the shell is running.
+  void set_personality(const std::string &name);
+  // Per-function-call saved personality for `personality -L' / `emulate -L':
+  // each function call pushes an empty slot; a -L switch records the personality
+  // to restore into the current slot; the slot is restored on function return.
+  std::vector<std::optional<std::string>> persona_restore;
   // csh keeps word-list shell variables in their own namespace (separate from
   // the Bourne `vars'); used only by the csh interpreter (csh.cpp).
   std::map<std::string, std::vector<std::string>> csh_vars;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -952,7 +952,7 @@ static const char *const kBuiltinNames[] = {
     "source", ".", "local", "declare", "typeset", "readonly", "let", "type", "trap",
     "umask", "getopts", "exec", "command", "times", "wait", "jobs", "fg", "bg",
     "disown", "kill", "suspend", "dirs", "pushd", "popd", "mapfile", "readarray",
-    "help", "builtin", "logout", "hash", "shopt", "ulimit", "enable", "caller", "alias", "unalias", "history", "fc", "compgen", "complete", "compopt", "bind", nullptr};
+    "help", "builtin", "logout", "hash", "shopt", "ulimit", "enable", "caller", "alias", "unalias", "history", "fc", "compgen", "complete", "compopt", "bind", "personality", nullptr};
 
 bool is_builtin_name(const std::string &n) {
   for (int i = 0; kBuiltinNames[i]; i++)
@@ -1336,6 +1336,7 @@ static const BuiltinHelp kBuiltinHelp[] = {
     {"enable", "enable [-a] [-dnps] [-f filename] [name ...]", "Enable and disable shell builtins."},
     {"caller", "caller [expr]", "Return the context of the current subroutine call."},
     {"alias", "alias [-p] [name[=value] ... ]", "Define or display aliases."},
+    {"personality", "personality [-lLR] [{bash|zsh|sh|ksh|csh} [-c command]]", "Switch the shell's personality at runtime (zsh `emulate' syntax)."},
     {"unalias", "unalias [-a] name [name ...]", "Remove each NAME from the list of defined aliases."},
     {"history", "history [-c] [-d offset] [n] or history -anrw [filename] or history -ps arg [arg...]", "Display or manipulate the history list."},
     {"fc", "fc [-e ename] [-lnr] [first] [last] or fc -s [pat=rep] [command]", "Display or execute commands from the history list."},
@@ -2128,6 +2129,68 @@ bool command_is_valid(Shell &sh, const std::string &name) {
   return !find_in_path(sh, name).empty();
 }
 
+// personality [ -lLR ] [ NAME [ -c command ] ]   (alias: emulate)
+//
+// Switch the shell's personality at runtime, with syntax identical to zsh's
+// `emulate' builtin.  With no NAME, print the current personality.  `-c command'
+// runs command under NAME then restores the previous personality; `-L' makes
+// the switch local to the enclosing function (restored on return); `-R'/`-l'
+// are accepted (a personality switch is already a full reconfiguration).
+int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
+  static const std::set<std::string> kNames = {
+      "bash", "zsh",   "sh",    "dash",  "ash",  "ksh",
+      "ksh93", "mksh", "pdksh", "rksh",  "csh",  "tcsh"};
+  bool opt_l = false, opt_L = false, opt_R = false;
+  size_t i = 1;
+  for (; i < argv.size(); i++) {
+    const std::string &a = argv[i];
+    if (a == "--") { i++; break; }
+    if (a.size() < 2 || a[0] != '-') break;
+    bool ok = true;
+    for (size_t k = 1; k < a.size(); k++) {
+      if (a[k] == 'l') opt_l = true;
+      else if (a[k] == 'L') opt_L = true;
+      else if (a[k] == 'R') opt_R = true;
+      else { ok = false; break; }
+    }
+    if (!ok) {
+      std::fprintf(stderr, "%s: bad option: %s\n", argv[0].c_str(), a.c_str());
+      return 1;
+    }
+  }
+  (void)opt_R;
+
+  if (i >= argv.size()) {  // no mode -> report the current personality
+    std::printf("%s\n", sh.personality_name.c_str());
+    return 0;
+  }
+
+  std::string mode = argv[i++];
+  if (!kNames.count(mode)) {
+    std::fprintf(stderr, "%s: unknown personality: %s\n", argv[0].c_str(), mode.c_str());
+    return 1;
+  }
+  // Trailing `-c command' (and any other option-flags, which we accept quietly).
+  std::string cmd;
+  bool have_c = false;
+  for (; i < argv.size(); i++) {
+    if (argv[i] == "-c" && i + 1 < argv.size()) { cmd = argv[++i]; have_c = true; }
+  }
+
+  if (have_c) {  // run under MODE, then restore
+    std::string saved = sh.personality_name;
+    sh.set_personality(mode);
+    int st = sh.run_string(cmd);
+    sh.set_personality(saved);
+    return st;
+  }
+  if (opt_L && !sh.persona_restore.empty() && !sh.persona_restore.back())
+    sh.persona_restore.back() = sh.personality_name;  // restore when the function returns
+  sh.set_personality(mode);
+  (void)opt_l;
+  return 0;
+}
+
 bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   if (argv.empty()) return false;
   const std::string &cmd = argv[0];
@@ -2143,7 +2206,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     static const std::set<std::string> kZshNoops = {
         "setopt", "unsetopt", "bindkey", "zstyle", "autoload", "zle", "zmodload",
         "compdef", "compinit", "bashcompinit", "disable", "limit", "unlimit",
-        "ttyctl", "sched", "zcompile", "emulate", "add-zsh-hook", "zrecompile"};
+        "ttyctl", "sched", "zcompile", "add-zsh-hook", "zrecompile"};
     if (kZshNoops.count(cmd)) { if (status) *status = 0; return true; }
   }
 
@@ -2160,6 +2223,9 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   else if (cmd == "export") st = bi_export(sh, argv);
   else if (cmd == "unset") st = bi_unset(sh, argv);
   else if (cmd == "set") st = bi_set(sh, argv);
+  // `personality' is always available; `emulate' is its zsh-mode alias.
+  else if (cmd == "personality" || (cmd == "emulate" && sh.is_zsh()))
+    st = bi_personality(sh, argv);
   else if (cmd == "read") st = bi_read(sh, argv);
   else if (cmd == "test") st = bi_test(sh, argv, false);
   else if (cmd == "[") st = bi_test(sh, argv, true);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -584,7 +584,12 @@ int Executor::run_simple(const SimpleCommand *c) {
       sh_.argframes.emplace_back(argv.begin() + 1, argv.end());
     }
     sh_.push_scope();
+    sh_.persona_restore.push_back(std::nullopt);  // for `personality -L' / `emulate -L'
     status = run(fit->second);
+    if (!sh_.persona_restore.empty()) {
+      if (sh_.persona_restore.back()) sh_.set_personality(*sh_.persona_restore.back());
+      sh_.persona_restore.pop_back();
+    }
     sh_.pop_scope();
     if (pushed_argframe && !sh_.argframes.empty()) sh_.argframes.pop_back();
     sh_.pop_src_frame();

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -210,17 +210,7 @@ void apply_set_o(Shell &sh, const std::string &name, bool set) {
 // Configure the shell's personality (which other shell it behaves as) and the
 // identity variables that differ between shells.
 void configure_persona(Shell &sh, const std::string &personality, const std::string &exec_path) {
-  sh.personality_name = personality;
-  if (personality == "zsh") sh.persona = Shell::Persona::Zsh;
-  else if (personality == "ash" || personality == "dash" || personality == "sh")
-    sh.persona = Shell::Persona::Ash;
-  else if (personality == "ksh" || personality == "ksh93" || personality == "mksh" ||
-           personality == "pdksh" || personality == "rksh")
-    sh.persona = Shell::Persona::Ksh;
-  else if (personality == "csh" || personality == "tcsh")
-    sh.persona = Shell::Persona::Csh;
-  else sh.persona = Shell::Persona::Bash;
-  sh.set("GNASH_PERSONALITY", personality);
+  (void)exec_path;  // read back from $SHELL inside Shell::set_personality
   sh.set("GNASH_VERSION", GNASH_VERSION);  // gnash's own version, regardless of persona
 
   std::string mach = "unknown";
@@ -233,31 +223,9 @@ void configure_persona(Shell &sh, const std::string &personality, const std::str
   }
   sh.set("MACHTYPE", mach);
 
-  if (sh.persona == Shell::Persona::Zsh) {
-    sh.set("ZSH_VERSION", "5.9");
-    sh.set("ZSH_NAME", "zsh");
-  } else if (sh.persona == Shell::Persona::Ksh) {
-    sh.set("KSH_VERSION", "Version AJM 93u+ 2012-08-01");
-  } else if (sh.persona == Shell::Persona::Ash) {
-    // ash is minimal: it advertises no BASH_/ZSH_ identity variables.
-  } else if (sh.persona == Shell::Persona::Csh) {
-    // csh identity ($shell, $version) is set up by the csh interpreter; the
-    // language is different enough that the Bourne BASH_* vars don't apply.
-    sh.set("shell", exec_path);
-  } else {
-    sh.set("BASH", exec_path);
-    sh.set("BASH_VERSION", "5.3.0(1)-release");
-    std::vector<std::pair<std::optional<std::string>, std::string>> vi = {
-        {std::nullopt, "5"}, {std::nullopt, "3"},       {std::nullopt, "0"},
-        {std::nullopt, "1"}, {std::nullopt, "release"}, {std::nullopt, mach}};
-    sh.array_assign("BASH_VERSINFO", vi, false, false);
-    sh.vars["BASH_VERSINFO"].readonly = true;
-    // Default search path for `enable -f' dynamically-loadable builtins.
-    if (!sh.is_set("BASH_LOADABLES_PATH"))
-      sh.set("BASH_LOADABLES_PATH",
-             "/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:"
-             "/usr/pkg/lib/bash:/opt/pkg/lib/bash:.");
-  }
+  // The persona enum + per-shell identity variables; shared with the runtime
+  // `personality'/`emulate' builtin.
+  sh.set_personality(personality);
 }
 
 }  // namespace

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -590,6 +590,46 @@ std::vector<std::string> Shell::environ_block() const {
   return out;
 }
 
+void Shell::set_personality(const std::string &name) {
+  personality_name = name;
+  if (name == "zsh") persona = Persona::Zsh;
+  else if (name == "ash" || name == "dash" || name == "sh") persona = Persona::Ash;
+  else if (name == "ksh" || name == "ksh93" || name == "mksh" || name == "pdksh" ||
+           name == "rksh")
+    persona = Persona::Ksh;
+  else if (name == "csh" || name == "tcsh") persona = Persona::Csh;
+  else persona = Persona::Bash;
+  set("GNASH_PERSONALITY", name);
+
+  // Per-shell identity variables.  These are additive (as zsh's emulate is):
+  // switching does not unset another shell's version variable.
+  std::string exec_path = get("SHELL");
+  std::string mach = get("MACHTYPE");
+  if (persona == Persona::Zsh) {
+    set("ZSH_VERSION", "5.9");
+    set("ZSH_NAME", "zsh");
+  } else if (persona == Persona::Ksh) {
+    set("KSH_VERSION", "Version AJM 93u+ 2012-08-01");
+  } else if (persona == Persona::Ash) {
+    // ash is minimal: it advertises no BASH_/ZSH_ identity variables.
+  } else if (persona == Persona::Csh) {
+    set("shell", exec_path);
+  } else {
+    set("BASH", exec_path);
+    set("BASH_VERSION", "5.3.0(1)-release");
+    std::vector<std::pair<std::optional<std::string>, std::string>> vi = {
+        {std::nullopt, "5"}, {std::nullopt, "3"},       {std::nullopt, "0"},
+        {std::nullopt, "1"}, {std::nullopt, "release"}, {std::nullopt, mach}};
+    if (vars.count("BASH_VERSINFO")) vars["BASH_VERSINFO"].readonly = false;
+    array_assign("BASH_VERSINFO", vi, false, false);
+    vars["BASH_VERSINFO"].readonly = true;
+    if (!is_set("BASH_LOADABLES_PATH"))
+      set("BASH_LOADABLES_PATH",
+          "/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:"
+          "/usr/pkg/lib/bash:/opt/pkg/lib/bash:.");
+  }
+}
+
 int Shell::run_string(const std::string &script) {
   if (is_csh()) return run_csh(*this, script);  // csh is a different language
   // Aliases are expanded only when interactive or `shopt -s expand_aliases'.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,14 @@ if(BASH_EXECUTABLE AND ZSH_EXECUTABLE)
             $<TARGET_FILE:gnash> ${ZSH_EXECUTABLE})
 endif()
 
+# Behavioral check for the runtime personality/emulate builtin.
+if(BASH_EXECUTABLE)
+  add_test(
+    NAME personality_test
+    COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/harness/personality_test.sh
+            $<TARGET_FILE:gnash>)
+endif()
+
 # ---------------------------------------------------------------------------
 # Conformance harness self-check.
 #

--- a/tests/harness/personality_test.sh
+++ b/tests/harness/personality_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Brian J. Fox
+# Licensed under GPLv2 with the GPLv2-AI Exception.
+
+# personality_test.sh GNASH
+#
+# Behavioral test for the runtime `personality' / `emulate' builtin: switching
+# the shell's personality mid-run, the -c and -L flags, and the emulate alias.
+
+set -u
+gnash=${1:?usage: personality_test.sh GNASH}
+fails=0
+
+# check DESCRIPTION EXPECTED  -- with the script on stdin, run under gnash
+check() {
+  local desc=$1 want=$2 got
+  got=$("$gnash" --personality="$3" -c "$4" 2>&1)
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: $desc" >&2
+    echo "  want: [$want]" >&2
+    echo "  got:  [$got]" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+# no argument prints the current personality
+check "report current (bash)" "bash" bash 'personality'
+check "report current (zsh)"  "zsh"  zsh  'personality'
+
+# switching changes expansion behavior live (word splitting differs)
+check "switch bash->zsh affects splitting" $'[a][b][c]\n[a b c]' bash \
+  'v="a b c"; printf "[%s]" $v; echo; personality zsh; printf "[%s]" $v; echo'
+
+# -c runs a command under the given personality, then restores
+check "-c runs under mode then restores" $'[x y]\nbash' bash \
+  'personality zsh -c '\''v="x y"; printf "[%s]" $v; echo'\''; personality'
+
+# -L makes the switch local to the enclosing function
+check "-L restores on function return" $'zsh\nbash' bash \
+  'f() { personality -L zsh; personality; }; f; personality'
+
+# without -L the switch persists after the function returns
+check "no -L leaks out of function" "zsh" bash \
+  'g() { personality zsh; }; g; personality'
+
+# emulate is the zsh-mode alias for personality
+check "emulate alias works in zsh" "sh" zsh 'emulate sh; personality'
+
+# emulate is not a builtin outside zsh mode (matches bash)
+check "emulate absent in bash mode" "127" bash \
+  'emulate zsh >/dev/null 2>&1; echo $?'
+
+# switching to csh runs subsequent input through the csh interpreter
+check "-c csh runs csh syntax" "b" bash \
+  'personality csh -c '\''set x = (a b c); echo $x[2]'\'''
+
+# an unknown personality name is rejected
+check "unknown name is an error" "1" bash \
+  'personality nonesuch >/dev/null 2>&1; echo $?'
+
+if [ $fails -eq 0 ]; then
+  echo "personality_test: all checks passed"
+  exit 0
+fi
+echo "personality_test: $fails failure(s)" >&2
+exit 1


### PR DESCRIPTION
## Summary

Adds a **`personality`** shell builtin that switches gnash's active personality **while the shell is running**, with syntax identical to zsh's **`emulate`**. In zsh mode, `emulate` is an alias for the same code.

```
personality [-lLR] [ {bash|zsh|sh|ksh|csh} [-c command] ]
emulate     [-lLR] [ {zsh|sh|ksh|csh}      [-c command] ]   (zsh mode only)
```

| Form | Behavior |
|------|----------|
| `personality` | print the current personality |
| `personality zsh` | switch persona live — e.g. `$var` stops word-splitting, `$ZSH_VERSION` appears |
| `personality zsh -c '…'` | run the command under zsh, then restore the previous personality |
| `personality -L zsh` | switch **local to the enclosing function**, restored on return (`emulate -L zsh` idiom) |
| `personality csh -c '…'` | runs csh syntax through the csh interpreter |
| `personality nonesuch` | error: unknown personality |

## Implementation

- The persona setup that was inline in `main.cpp`'s `configure_persona` is refactored into **`Shell::set_personality(name)`**, now shared by startup and the builtin (sets the `persona` enum, `$GNASH_PERSONALITY`, and per-shell identity vars).
- **`-L`** is implemented with a per-function-call stack `Shell::persona_restore`: each function call pushes an empty slot, a `-L` switch records the personality to restore into it, and the executor restores it on return.
- `emulate` is removed from the zsh no-op set and dispatched to the same handler; it stays absent outside zsh (so `emulate` in bash mode is "command not found", as in real bash).

## Testing

- New `tests/harness/personality_test.sh` (ctest `personality_test`): report/switch/`-c`/`-L`/leak/`emulate` alias/csh/unknown-name — all pass.
- Full suite (18 tests) + parser differential pass. Startup identity variables for bash/zsh/ksh/sh/csh verified unchanged after the `configure_persona` refactor.

Note: because csh is a separate interpreter, switching *into* csh works for subsequently-read input, but you cannot `personality bash` back out from *within* csh mode (the csh interpreter has no such builtin); the transient `personality csh -c '…'` form handles that cleanly.

Fixes #35
