### PR TITLE
executor: honor set -o pipefail (fixes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Six harnesses:
 
 - **Differential** (`tests/harness/run_diff.sh`, gated in ctest) — runs a growing corpus
   of scripts under both gnash and bash 5.3 and requires identical stdout + exit status.
-  Currently **161 scripts** covering expansion, arithmetic, control flow, arrays, functions,
+  Currently **167 scripts** covering expansion, arithmetic, control flow, arrays, functions,
   redirection, process substitution, the special variables, the full builtin set, and job
   control — all matching.
 - **csh differential** (`tests/harness/run_diff_csh.sh`, gated in ctest when `tcsh` is

--- a/STATUS.md
+++ b/STATUS.md
@@ -87,7 +87,7 @@ land.
     `jobs/fg/bg/disown/kill/suspend`, `pushd/popd/dirs`, `mapfile/readarray`, `alias/unalias`,
     `history/fc`, `hash`, `shopt`, `ulimit`, `enable`, `caller`, `bind`, `compgen/complete/
     compopt`, `help`, and `builtin`; `printf` supports `-v`/`%q`/`%b`, `type` all its flags.
-    Verified by a **differential execution harness** (`run_diff.sh`): **161 scripts** produce
+    Verified by a **differential execution harness** (`run_diff.sh`): **167 scripts** produce
     identical stdout and exit status to bash 5.3.
   - **Job control** — each pipeline / background command runs in its own process group; the
     shell hands the controlling terminal to a foreground job and reclaims it, reaps children,

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -231,6 +231,7 @@ class Shell {
   bool opt_nounset = false;   // -u
   bool opt_noglob = false;    // -f
   bool opt_verbose = false;   // -v
+  bool opt_pipefail = false;  // -o pipefail: pipeline status = last non-zero stage
   bool opt_functrace = false; // -T / -o functrace: DEBUG/RETURN traps inherited
   int errexit_suppress = 0;   // >0 while a command's status is being checked
   std::string bash_command;   // $BASH_COMMAND: the command currently executing

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -752,7 +752,7 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"noexec", false},      {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
       {"nounset", sh.opt_nounset}, {"onecmd", false},
-      {"physical", false},    {"pipefail", false},
+      {"physical", false},    {"pipefail", sh.opt_pipefail},
       {"posix", false},       {"privileged", false},
       {"verbose", sh.opt_verbose}, {"vi", rl_editing_mode == 0},
       {"xtrace", sh.opt_xtrace}};
@@ -801,6 +801,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
               else if (o == "noglob") sh.opt_noglob = on;
               else if (o == "verbose") sh.opt_verbose = on;
               else if (o == "functrace" || o == "errtrace") sh.opt_functrace = on;
+              else if (o == "pipefail") sh.opt_pipefail = on;
               // `set -o vi'/`set -o emacs' switch the readline editing mode
               // (they are mutually exclusive); `+o' flips to the other.
               else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -410,15 +410,20 @@ int Executor::run_pipeline(const Connection *c) {
   if (prev_read != -1) close(prev_read);
 
   if (sh_.job_control) tcsetpgrp(sh_.job_terminal, static_cast<pid_t>(pgid));
-  int st = 0;
+  int last_st = 0, pipefail_st = 0;
   bool any_stopped = false;
   for (size_t i = 0; i < pids.size(); i++) {
     int wst = 0;
     waitpid(pids[i], &wst, WUNTRACED);
-    if (WIFSTOPPED(wst)) any_stopped = true;
-    else if (i == pids.size() - 1)
-      st = WIFEXITED(wst) ? WEXITSTATUS(wst) : (128 + WTERMSIG(wst));
+    if (WIFSTOPPED(wst)) { any_stopped = true; continue; }
+    int s = WIFEXITED(wst) ? WEXITSTATUS(wst) : (128 + WTERMSIG(wst));
+    if (i == pids.size() - 1) last_st = s;
+    if (s != 0) pipefail_st = s;  // track the last (rightmost) non-zero stage
   }
+  // Normally the pipeline's status is the last stage's; under `set -o pipefail'
+  // it is the last stage to exit non-zero (0 if all succeeded), so an upstream
+  // failure is not masked by a later success.
+  int st = sh_.opt_pipefail ? pipefail_st : last_st;
   if (sh_.job_control) tcsetpgrp(sh_.job_terminal, static_cast<pid_t>(sh_.shell_pgid));
 
   if (any_stopped) {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -175,6 +175,13 @@ scripts=(
   'echo "$BASHOPTS" | tr : "\n" | sort'
   'shopt -s extglob nullglob; echo "$BASHOPTS" | tr : "\n" | grep -E "extglob|nullglob"'
   'echo "${BASH_VERSINFO[3]} ${BASH_VERSINFO[4]}"'
+  # pipefail: pipeline status is the last non-zero stage (0 if all succeed)
+  'set -o pipefail; false | true; echo $?'
+  'set -o pipefail; true | false; echo $?'
+  'set -o pipefail; true | true; echo $?'
+  'set -o pipefail; (exit 3) | true | (exit 5); echo $?'
+  'false | true; echo $?'
+  'set -o pipefail; set +o pipefail; false | true; echo $?'
 )
 
 fails=0


### PR DESCRIPTION
## Summary

`set -o pipefail` was accepted but ignored — a pipeline's status was always the rightmost stage's, so `false | true` returned 0 (bash: 1).

## Fix

- Add `opt_pipefail`; wire `set -o pipefail` / `set +o pipefail` and the `set -o` display.
- In `run_pipeline`, when pipefail is on, return the status of the last (rightmost) stage that exited non-zero, else 0 — matching bash.

## Testing

Verified vs bash 5.3.15: `false|true`=1, `true|false`=1, `true|true`=0, `(exit 3)|true|(exit 5)`=5, `set +o pipefail` restores default, `set -o` shows the state. `run_diff.sh` gains 6 pipefail cases (161 -> 167). Full suite (19) + parser differential pass.

Fixes #39