### PR TITLE
expand: keep an empty element in "$@" / "${a[@]}" (fixes #43)

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -583,6 +583,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             absorb_qnull();
             for (size_t k = 0; k < items.size(); k++) {
               if (k) { out += FIELD_SEP; mask += '0'; }
+              out += QNULL; mask += '1';  // keep an empty element as a field
               for (char c : items[k]) { out += c; mask += '1'; }
             }
           } else if (sel == '*' && dq) {
@@ -620,6 +621,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (asel == '@' && dq) absorb_qnull();
           for (size_t k = 0; k < items.size(); k++) {
             if (k) { out += FIELD_SEP; mask += '0'; }
+            if (asel == '@' && dq) { out += QNULL; mask += '1'; }  // keep empty element
             for (char c : items[k]) { out += c; mask += m; }
           }
         }
@@ -664,6 +666,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (ssel == '@' && dq) absorb_qnull();
           for (size_t k = 0; k < slice.size(); k++) {
             if (k) { out += FIELD_SEP; mask += '0'; }
+            if (ssel == '@' && dq) { out += QNULL; mask += '1'; }  // keep empty element
             for (char c : slice[k]) { out += c; mask += m; }
           }
         }
@@ -690,6 +693,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       absorb_qnull();
       for (size_t k = 0; k < pos.size(); k++) {
         if (k) { out += FIELD_SEP; mask += '0'; }
+        out += QNULL; mask += '1';  // keep an empty positional as a field
         for (char c : pos[k]) { out += c; mask += '1'; }
       }
     } else if (n1 == '*' && dq) {


### PR DESCRIPTION
## Summary

`set -- "" x ""; for a in "\$@"; do echo "[\$a]"; done` ran two iterations instead of three — a trailing/non-first empty element in quoted `"\$@"`/`"\${a[@]}"` was dropped.

## Fix

Elements are emitted separated by an internal FIELD_SEP; an empty element contributed no characters, so an empty field at a boundary was lost in `split_ifs`. Emit a quoted-null marker at the start of each element in the quoted `@` expansions (`\$@`, `\${a[@]}`, `\${a[@]OP}`, `\${a[@]:off:len}`) so every element is a distinct field. Unquoted `\$@` still drops empties; an entirely empty `"\$@"` still removes the word.

## Testing

11 empty-element cases (loops, printf, operators, slices, empty arrays) all match bash 5.3.15. Full suite (19) + parser differential pass.

Fixes #43