### PR TITLE
tests: make run_diff actually run its scripts, and find a real oracle (fixes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Six harnesses:
 
 - **Differential** (`tests/harness/run_diff.sh`, gated in ctest) — runs a growing corpus
   of scripts under both gnash and bash 5.3 and requires identical stdout + exit status.
-  Currently **167 scripts** covering expansion, arithmetic, control flow, arrays, functions,
+  Currently **172 scripts** covering expansion, arithmetic, control flow, arrays, functions,
   redirection, process substitution, the special variables, the full builtin set, and job
   control — all matching.
 - **csh differential** (`tests/harness/run_diff_csh.sh`, gated in ctest when `tcsh` is

--- a/STATUS.md
+++ b/STATUS.md
@@ -87,7 +87,7 @@ land.
     `jobs/fg/bg/disown/kill/suspend`, `pushd/popd/dirs`, `mapfile/readarray`, `alias/unalias`,
     `history/fc`, `hash`, `shopt`, `ulimit`, `enable`, `caller`, `bind`, `compgen/complete/
     compopt`, `help`, and `builtin`; `printf` supports `-v`/`%q`/`%b`, `type` all its flags.
-    Verified by a **differential execution harness** (`run_diff.sh`): **167 scripts** produce
+    Verified by a **differential execution harness** (`run_diff.sh`): **172 scripts** produce
     identical stdout and exit status to bash 5.3.
   - **Job control** — each pipeline / background command runs in its own process group; the
     shell hands the controlling terminal to a foreground job and reclaims it, reaps children,

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -12,6 +12,27 @@ set -u
 gnash=${1:?usage: run_diff.sh GNASH BASH}
 bash=${2:?usage: run_diff.sh GNASH BASH}
 
+# The oracle must be a REAL bash.  On a dev box a gnash symlink often shadows
+# `bash' on $PATH (so CMake's find_program hands us gnash, not bash); a
+# differential against gnash itself is meaningless.  If the given oracle reports
+# itself as gnash, look for a real bash: $GNASH_BASH, then a Homebrew Cellar
+# bash, then the usual locations.  If none is found, skip rather than fail.
+is_real_bash() { "$1" --version 2>/dev/null | head -1 | grep -qi 'GNU bash'; }
+if ! is_real_bash "$bash"; then
+  set +u  # GNASH_BASH may be unset
+  found=""
+  for cand in "$GNASH_BASH" /opt/homebrew/Cellar/bash/*/bin/bash \
+              /usr/local/bin/bash /opt/local/bin/bash /bin/bash; do
+    if [ -n "$cand" ] && [ -x "$cand" ] && is_real_bash "$cand"; then found=$cand; break; fi
+  done
+  set -u
+  if [ -z "$found" ]; then
+    echo "run_diff: no real bash oracle found (got '$bash'); skipping" >&2
+    exit 0
+  fi
+  bash=$found
+fi
+
 scripts=(
   'echo hello world'
   'echo -n no-newline'
@@ -182,12 +203,23 @@ scripts=(
   'set -o pipefail; (exit 3) | true | (exit 5); echo $?'
   'false | true; echo $?'
   'set -o pipefail; set +o pipefail; false | true; echo $?'
+  # exec resolves the command through the shell $PATH, and its flags
+  'd=/tmp/gnash_exec_rd; rm -rf "$d"; mkdir -p "$d"; printf "#!/bin/sh\necho exec-ok\n" > "$d/xp"; chmod +x "$d/xp"; PATH="$d:$PATH"; exec xp'
+  'exec -a ZEROTH /bin/sh -c "echo argv0=\$0"'
+  # quoted "$@" / "${a[@]}" keep empty elements
+  'set -- "" x ""; printf "<%s>" "$@"; echo'
+  'a=(p "" q); for e in "${a[@]}"; do echo "[$e]"; done'
+  # ulimit reports a single resource as a bare value
+  'ulimit -n; ulimit -c'
 )
 
 fails=0
 for s in "${scripts[@]}"; do
-  g_out=$(printf '%s' "$s" | "$gnash" </dev/null 2>/dev/null); g_rc=$?
-  b_out=$(printf '%s' "$s" | "$bash"  </dev/null 2>/dev/null); b_rc=$?
+  # Run the script via -c (stdin left as /dev/null so a stray `read' can't
+  # hang).  NOTE: the script must be passed as an argument, not piped to stdin;
+  # piping while redirecting stdin from /dev/null makes the shell read nothing.
+  g_out=$("$gnash" -c "$s" </dev/null 2>/dev/null); g_rc=$?
+  b_out=$("$bash"  -c "$s" </dev/null 2>/dev/null); b_rc=$?
   if [ "$g_out" != "$b_out" ] || [ "$g_rc" != "$b_rc" ]; then
     echo "MISMATCH: $s" >&2
     echo "  gnash (rc=$g_rc): $g_out" >&2


### PR DESCRIPTION
## Summary

The bash differential harness (ctest `run_diff`) was a **no-op**: it piped the script to stdin but then redirected stdin from `/dev/null`, so the shell read nothing — every script matched empty-vs-empty.

## Fix

- Run scripts via `-c "\$s"` (stdin left as /dev/null so a stray `read` can't hang).
- Guard the oracle: a gnash symlink often shadows `bash` on a dev box, so CMake hands the harness gnash as the "bash" oracle. Detect a non-bash oracle and fall back to `\$GNASH_BASH` / a Homebrew Cellar bash / usual locations; skip if none is real bash.

## Impact

Running the corpus for real surfaced two genuine divergences, since fixed (#43 quoted-`"\$@"` empty element, #45 ulimit output). The corpus grows by exec / quoted-`"\$@"` / ulimit regression cases (167 -> 172), all matching. Full suite (19) passes; ctest `run_diff` now runs and passes for real.

Fixes #47