### PR TITLE
expand: set -u must not fire on the defaulting operators (fixes #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Six harnesses:
 
 - **Differential** (`tests/harness/run_diff.sh`, gated in ctest) — runs a growing corpus
   of scripts under both gnash and bash 5.3 and requires identical stdout + exit status.
-  Currently **172 scripts** covering expansion, arithmetic, control flow, arrays, functions,
+  Currently **176 scripts** covering expansion, arithmetic, control flow, arrays, functions,
   redirection, process substitution, the special variables, the full builtin set, and job
   control — all matching.
 - **csh differential** (`tests/harness/run_diff_csh.sh`, gated in ctest when `tcsh` is

--- a/STATUS.md
+++ b/STATUS.md
@@ -87,7 +87,7 @@ land.
     `jobs/fg/bg/disown/kill/suspend`, `pushd/popd/dirs`, `mapfile/readarray`, `alias/unalias`,
     `history/fc`, `hash`, `shopt`, `ulimit`, `enable`, `caller`, `bind`, `compgen/complete/
     compopt`, `help`, and `builtin`; `printf` supports `-v`/`%q`/`%b`, `type` all its flags.
-    Verified by a **differential execution harness** (`run_diff.sh`): **172 scripts** produce
+    Verified by a **differential execution harness** (`run_diff.sh`): **176 scripts** produce
     identical stdout and exit status to bash 5.3.
   - **Job control** — each pipeline / background command runs in its own process group; the
     shell hands the controlling terminal to a foreground job and reclaims it, reaps children,

--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -39,7 +39,9 @@ class Expander {
   std::string expand_heredoc(const std::string &text);
 
   // Value of a parameter (including specials); `set` reports whether it was set.
-  std::string param_value(const std::string &name, bool &set);
+  // `defaulting_op' is set by ${x-…}/${x:-…}/${x=…}/${x+…}/${x?…} callers, where
+  // an unset variable is handled by the operator and must NOT trip `set -u'.
+  std::string param_value(const std::string &name, bool &set, bool defaulting_op = false);
 
   // Replace any <(cmd) / >(cmd) in WORD with a /dev/fd/N path, forking the inner
   // command and recording it on the shell for later cleanup.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -119,7 +119,7 @@ static std::string tilde_assign(Shell &sh, const std::string &text) {
   return out;
 }
 
-std::string Expander::param_value(const std::string &name, bool &set) {
+std::string Expander::param_value(const std::string &name, bool &set, bool defaulting_op) {
   set = true;
   if (name == "?") return std::to_string(sh_.last_status);
   if (name == "$") return sh_.get("$");
@@ -146,10 +146,10 @@ std::string Expander::param_value(const std::string &name, bool &set) {
   if (sh_.get_if_set(name, v)) return v;
   if (sh_.dynamic_var(name, v)) return v;  // RANDOM/SECONDS/LINENO/BASHPID/EPOCH*
   set = false;
-  if (sh_.opt_nounset) {
+  if (sh_.opt_nounset && !defaulting_op) {
     std::fprintf(stderr, "%s%s: unbound variable\n", sh_.err_prefix().c_str(), name.c_str());
     sh_.exiting = true;
-    sh_.exit_status = 1;
+    sh_.exit_status = 127;  // bash exits a non-interactive shell with 127 here
   }
   return std::string();
 }
@@ -872,6 +872,19 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   if (length && !have_sub && sh.is_zsh() && sh.is_array(name))
     return std::to_string(sh.array_count(name));
 
+  // A defaulting/alternative/error operator (`-` `:-` `=` `:=` `+` `:+` `?` `:?`)
+  // handles an unset variable itself, so it must not trip `set -u' in
+  // param_value.  A bare `:' here begins a substring, not such an operator.
+  std::string rest = length ? std::string() : b.substr(p);
+  bool defaulting_op = false;
+  if (!rest.empty()) {
+    char c0 = rest[0];
+    if (c0 == '-' || c0 == '=' || c0 == '+' || c0 == '?') defaulting_op = true;
+    else if (c0 == ':' && rest.size() > 1 &&
+             (rest[1] == '-' || rest[1] == '=' || rest[1] == '+' || rest[1] == '?'))
+      defaulting_op = true;
+  }
+
   bool set = false;
   std::string val;
   if (have_sub) {
@@ -879,10 +892,9 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     val = sh.array_get(name, sh.zsh_subscript(name, ex.expand_no_split(sub)));
     set = sh.is_set(name);
   } else {
-    val = ex.param_value(name, set);
+    val = ex.param_value(name, set, defaulting_op);
   }
   if (length) return std::to_string(val.size());
-  std::string rest = b.substr(p);
   return apply_param_op(ex, sh, name, val, set, rest);
 }
 
@@ -924,7 +936,14 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       return val;
     }
     if (op == '?') {
-      if (empty) return std::string();  // (error message elided)
+      if (empty) {
+        std::string msg = expand_word(word);
+        if (msg.empty()) msg = colon ? "parameter null or not set" : "parameter not set";
+        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), name.c_str(), msg.c_str());
+        sh.exiting = true;
+        sh.exit_status = 127;  // bash: a fatal ${x?} / set -u error exits with 127
+        return std::string();
+      }
       return val;
     }
   }

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -211,6 +211,12 @@ scripts=(
   'a=(p "" q); for e in "${a[@]}"; do echo "[$e]"; done'
   # ulimit reports a single resource as a bare value
   'ulimit -n; ulimit -c'
+  # set -u: defaulting operators handle an unset variable (no nounset error)
+  'set -u; echo "${UNSET:-def}" "${UNSET-d2}" "${UNSET:+a}" "${OTHER:=x}"; echo "$OTHER"'
+  'set -u; v=hi; echo "${v:-nope}${v:+yes}"'
+  # set -u: a genuine unbound reference (and ${x?}) is fatal with status 127
+  'set -u; echo pre; echo "$UNSET"; echo post'
+  'echo pre; echo "${UNSET?boom}"; echo post'
 )
 
 fails=0


### PR DESCRIPTION
## Summary

Under `set -u`, gnash wrongly reported "unbound variable" for `\${x:-word}`, `\${x-word}`, `\${x:=word}`, `\${x=word}`, `\${x:+word}`, `\${x+word}`, and `\${x?msg}` — the operators that handle an unset variable — breaking the ubiquitous `\${VAR:-default}` idiom.

## Fix

`param_value` fired nounset before the operator ran. Pass a `defaulting_op` flag when the `\${...}` operator is one of `-` `:-` `=` `:=` `+` `:+` `?` `:?` and suppress the nounset error there; the operator supplies the value. Plain `\${x}`, `\${x#pat}`, `\${x:off}`, `\${x^^}` on an unset variable still fire nounset.

Also completes the `\${x?msg}` / `\${x:?msg}` operator (previously a stub returning empty): it prints the message (or the bash default) and exits. Fatal set -u / `\${x?}` errors now exit **127**, matching bash (was 1).

## Testing

15 set -u / `\${?}` cases (defaulting ops, genuine unbound, `?` messages, exit codes) match bash 5.3.15 exactly. 4 added to run_diff (172 -> 176). Full suite (19) passes.

Fixes #49