### PR TITLE
completion: complete command names in command position (fixes #51)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -128,6 +128,7 @@ land.
     expansion, the core parses/executes. Prompt expansion (a `\u@\h:\w\$ ` default), multi-line
     continuation, arrow-key recall, `!!`/`^old^new^`, a persistent history file
     (`$HISTFILE`/`~/.gnash_history`), interactive job control, `EXIT`/signal traps, and
-    completion — filenames (a trailing `/` for directories), `$`-variable names (incl. the
-    dynamic specials), and per-persona syntax highlighting. Verified by driving gnash through a
-    pseudo-terminal.
+    completion — command names in command position (keywords, aliases, functions, builtins,
+    and `$PATH` executables), filenames elsewhere (a trailing `/` for directories),
+    `$`-variable names (incl. the dynamic specials), and per-persona syntax highlighting.
+    Verified by driving gnash through a pseudo-terminal.

--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -20,6 +20,11 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status);
 // interactive syntax highlighting.
 bool command_is_valid(Shell &sh, const std::string &name);
 
+// Every command name beginning with PREFIX -- shell keywords, aliases,
+// functions, builtins, and executables on $PATH -- sorted and de-duplicated.
+// Used for command-position tab completion.
+std::vector<std::string> command_completions(Shell &sh, const std::string &prefix);
+
 // Populate sh.shopt_opts with the default shopt option states (idempotent).
 // Called at startup so $BASHOPTS reflects the defaults before any `shopt' runs.
 void shopt_seed(Shell &sh);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2141,6 +2141,45 @@ bool command_is_valid(Shell &sh, const std::string &name) {
   return !find_in_path(sh, name).empty();
 }
 
+std::vector<std::string> command_completions(Shell &sh, const std::string &prefix) {
+  std::set<std::string> out;
+  auto consider = [&](const std::string &n) {
+    if (n.size() >= prefix.size() && n.compare(0, prefix.size(), prefix) == 0) out.insert(n);
+  };
+  // Shell keywords, aliases, functions, and builtins (skipping any `enable -n'd).
+  static const char *kw[] = {"if",   "then",     "else",   "elif", "fi",     "for",
+                             "while", "until",   "do",     "done", "case",   "esac",
+                             "in",   "function", "select", "time", "coproc", nullptr};
+  for (int i = 0; kw[i]; i++) consider(kw[i]);
+  for (const auto &kv : sh.aliases) consider(kv.first);
+  for (const auto &kv : sh.functions) consider(kv.first);
+  for (const auto &b : builtin_names_sorted())
+    if (!sh.disabled_builtins.count(b)) consider(b);
+  // Executable regular files on $PATH, matched by basename.
+  std::string path = sh.get("PATH");
+  size_t i = 0;
+  while (i <= path.size()) {
+    size_t j = path.find(':', i);
+    std::string dir = path.substr(i, j == std::string::npos ? std::string::npos : j - i);
+    if (dir.empty()) dir = ".";
+    if (DIR *d = opendir(dir.c_str())) {
+      while (struct dirent *e = readdir(d)) {
+        const char *nm = e->d_name;
+        if (std::strncmp(nm, prefix.c_str(), prefix.size()) != 0) continue;
+        std::string full = dir + "/" + nm;
+        struct stat st;
+        if (access(full.c_str(), X_OK) == 0 && stat(full.c_str(), &st) == 0 &&
+            S_ISREG(st.st_mode))
+          out.insert(nm);
+      }
+      closedir(d);
+    }
+    if (j == std::string::npos) break;
+    i = j + 1;
+  }
+  return std::vector<std::string>(out.begin(), out.end());
+}
+
 // personality [ -lLR ] [ NAME [ -c command ] ]   (alias: emulate)
 //
 // Switch the shell's personality at runtime, with syntax identical to zsh's

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -138,9 +138,46 @@ extern "C" void gnash_zsh_highlight(const char *line, int len, int *colors) {
   }
 }
 
-// readline's attempted-completion hook: when the word being completed is
-// introduced by `$' (or `${'), complete over defined shell variables instead
-// of filenames.
+// True when the word starting at `start' is in command position: the first word
+// of a simple command.  That is the start of the line, or just after a command
+// separator (`;' `|' `&' `(' `{' backtick newline), skipping any leading
+// `VAR=val' assignment prefixes (which keep the next word in command position).
+static bool at_command_position(int start) {
+  int p = start - 1;
+  for (;;) {
+    while (p >= 0 && (rl_line_buffer[p] == ' ' || rl_line_buffer[p] == '\t')) p--;
+    if (p < 0) return true;
+    char c = rl_line_buffer[p];
+    if (c == ';' || c == '|' || c == '&' || c == '(' || c == '{' || c == '`' || c == '\n')
+      return true;
+    int e = p;  // end of the preceding token
+    while (p >= 0 && rl_line_buffer[p] != ' ' && rl_line_buffer[p] != '\t' &&
+           std::strchr(";|&(){}`\n", rl_line_buffer[p]) == nullptr)
+      p--;
+    std::string tok(rl_line_buffer + p + 1, static_cast<size_t>(e - p));
+    if (!is_assignment_word(tok)) return false;  // a real command word precedes us
+    // else: an assignment prefix -- keep scanning, we are still in command position
+  }
+}
+
+// readline generator: successive command names matching `text' (built once when
+// state == 0), for command-position completion.
+extern "C" char *gnash_command_completion(const char *text, int state) {
+  static std::vector<std::string> matches;
+  static size_t idx;
+  if (state == 0) {
+    matches = g_notify_shell ? command_completions(*g_notify_shell, text)
+                             : std::vector<std::string>();
+    idx = 0;
+  }
+  if (idx < matches.size()) return strdup(matches[idx++].c_str());
+  return nullptr;
+}
+
+// readline's attempted-completion hook.  A word introduced by `$'/`${' completes
+// over shell variables; a word in command position (with no `/') completes over
+// all command names (keywords/aliases/functions/builtins/$PATH); otherwise fall
+// back to readline's default filename completion.
 extern "C" char **gnash_attempted_completion(const char *text, int start, int end) {
   (void)end;
   bool dollar = start > 0 && rl_line_buffer[start - 1] == '$';
@@ -148,6 +185,12 @@ extern "C" char **gnash_attempted_completion(const char *text, int start, int en
   if (dollar || braced) {
     rl_attempted_completion_over = 1;  // don't fall back to filename completion
     return rl_completion_matches(text, gnash_var_completion);
+  }
+  // Command position: complete command names, unless the word is a path (has a
+  // `/'), in which case a filename completion of the executable is wanted.
+  if (std::strchr(text, '/') == nullptr && at_command_position(start)) {
+    rl_attempted_completion_over = 1;
+    return rl_completion_matches(text, gnash_command_completion);
   }
   return nullptr;  // let readline fall back to its default (filename) completion
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,10 @@ add_executable(arith_test arith_test.cpp)
 target_link_libraries(arith_test PRIVATE gnash::core gnash_warnings)
 add_test(NAME arith_test COMMAND arith_test)
 
+add_executable(command_complete_test command_complete_test.cpp)
+target_link_libraries(command_complete_test PRIVATE gnash::core gnash_warnings)
+add_test(NAME command_complete_test COMMAND command_complete_test)
+
 # Differential execution check vs bash over the implemented feature set.
 if(BASH_EXECUTABLE)
   add_test(

--- a/tests/command_complete_test.cpp
+++ b/tests/command_complete_test.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// command_complete_test.cpp -- command-position completion sources
+// (keywords, builtins, aliases, and $PATH executables).
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "gnash/core/builtins.hpp"
+#include "gnash/core/shell.hpp"
+
+namespace core = gnash::core;
+
+static int failures = 0;
+
+static bool has(const std::vector<std::string> &v, const std::string &s) {
+  return std::find(v.begin(), v.end(), s) != v.end();
+}
+
+// Assert command_completions(prefix) does/does not offer `name'.
+static void want(core::Shell &sh, const char *prefix, const char *name, bool expect) {
+  std::vector<std::string> v = core::command_completions(sh, prefix);
+  if (has(v, name) != expect) {
+    std::fprintf(stderr, "FAIL command_completions(\"%s\") %s \"%s\"\n", prefix,
+                 expect ? "should contain" : "should not contain", name);
+    failures++;
+  }
+}
+
+int main() {
+  core::Shell sh;
+
+  // A temp directory with one executable, used as the entire $PATH.
+  char dir[] = "/tmp/gnash_cc_XXXXXX";
+  if (!mkdtemp(dir)) {
+    std::fprintf(stderr, "mkdtemp failed\n");
+    return 1;
+  }
+  std::string exe = std::string(dir) + "/zqcmd";
+  if (FILE *f = std::fopen(exe.c_str(), "w")) { std::fputs("#!/bin/sh\n", f); std::fclose(f); }
+  chmod(exe.c_str(), 0755);
+  std::string noexe = std::string(dir) + "/zqplain";  // present but not executable
+  if (FILE *f = std::fopen(noexe.c_str(), "w")) { std::fputs("x\n", f); std::fclose(f); }
+  sh.set("PATH", dir);
+  sh.aliases["zqalias"] = "ls";
+
+  want(sh, "ech", "echo", true);       // builtin
+  want(sh, "expo", "export", true);    // builtin
+  want(sh, "whil", "while", true);     // keyword
+  want(sh, "cas", "case", true);       // keyword
+  want(sh, "zqal", "zqalias", true);   // alias
+  want(sh, "zqc", "zqcmd", true);      // $PATH executable
+  want(sh, "zq", "zqalias", true);     // shared prefix -> both alias and PATH exe
+  want(sh, "zq", "zqcmd", true);
+  want(sh, "zqp", "zqplain", false);   // non-executable file is not a command
+  want(sh, "zznomatchzz", "echo", false);  // prefix filters everything out
+
+  // A disabled builtin drops out of the candidates.
+  sh.disabled_builtins.insert("echo");
+  want(sh, "ech", "echo", false);
+
+  unlink(exe.c_str());
+  unlink(noexe.c_str());
+  rmdir(dir);
+
+  if (failures == 0) {
+    std::printf("all command-completion tests passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "%d command-completion test(s) failed\n", failures);
+  return 1;
+}


### PR DESCRIPTION
## Summary

At the command position (first word of a command), TAB now completes over **all** command kinds — shell keywords, aliases, functions, builtins, and `\$PATH` executables — instead of falling through to filename completion.

## Implementation

- `command_completions(sh, prefix)` (builtins.cpp) gathers and de-dups candidates from every source (skips `enable -n`'d builtins; only executable regular files from `\$PATH`).
- The interactive completer (repl.cpp) detects command position — start of line, after `;`/`|`/`&`/`(`/`{`/backtick/newline, or after `VAR=val` assignment prefixes — and completes commands there. A word containing `/` (e.g. `./x`, `/usr/bin/l`) still does filename completion. Argument position and `\$var` completion are unchanged.

## Testing

- New `command_complete_test`: keywords/builtins/aliases/`\$PATH` executables complete; disabled builtins and non-executables are excluded.
- pty-verified end to end: `ech`→`echo`, `typese`→`typeset`, a `\$PATH` exe, alias+function listing, assignment prefix keeps command position, argument position/paths still complete filenames, `\$HOME` still completes. Full suite 20/20.

Fixes #51