### PR TITLE
repl: re-apply readline hooks when personality changes at runtime (fixes #55)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -7,6 +7,7 @@
 #define GNASH_CORE_SHELL_HPP
 
 #include <csignal>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -176,6 +177,10 @@ class Shell {
   // ...).  Used both at startup and by the `personality'/`emulate' builtin to
   // switch personality while the shell is running.
   void set_personality(const std::string &name);
+  // Invoked at the end of set_personality (once set), so an interactive REPL can
+  // re-apply persona-dependent readline hooks (highlighting, TAB completion
+  // style, ...) when the personality changes at runtime.  Null until registered.
+  std::function<void()> on_personality_change;
   // Per-function-call saved personality for `personality -L' / `emulate -L':
   // each function call pushes an empty slot; a -L switch records the personality
   // to restore into the current slot; the slot is restored on function return.

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -225,6 +225,27 @@ extern "C" int gnash_display_shell_version(int /*count*/, int /*key*/) {
   rl_redisplay();  // repaint the prompt and current input below the version line
   return 0;
 }
+
+// (Re)apply the persona-dependent readline configuration.  The zsh persona gets
+// live command-line highlighting, TAB menu-completion (Shift-TAB backward), and
+// dotfile hiding; the other personas use readline's defaults -- no highlighting,
+// TAB inserts the common prefix then lists.  Called at startup and again
+// whenever the personality changes at runtime, so `personality zsh' / `emulate'
+// take effect immediately.  Completion keys live in the emacs keymap (as the
+// rest of the setup does); the read loop selects the mode's keymap per line.
+void apply_persona_readline(Shell &sh) {
+  bool zsh = sh.is_zsh();
+  rl_highlight_function = zsh ? gnash_zsh_highlight : nullptr;
+  rl_match_hidden_files = zsh ? 0 : 1;
+  rl_set_keymap(rl_get_keymap_by_name("emacs"));
+  if (zsh) {
+    rl_bind_key('\t', rl_menu_complete);
+    rl_bind_keyseq("\\e[Z", rl_backward_menu_complete);
+  } else {
+    rl_bind_key('\t', rl_complete);
+    rl_bind_keyseq("\\e[Z", rl_complete);
+  }
+}
 }  // namespace
 
 int run_interactive(Shell &sh) {
@@ -246,8 +267,6 @@ int run_interactive(Shell &sh) {
   rl_event_hook = gnash_job_notify_hook;
   // Complete variable names after `$'.
   rl_attempted_completion_function = gnash_attempted_completion;
-  // zsh persona: highlight the command line as it is typed.
-  if (sh.is_zsh()) rl_highlight_function = gnash_zsh_highlight;
 
   // Bind C-x C-v to display-shell-version, as bash does by default.  Build the
   // keymaps first (idempotent) and target the emacs keymap so the sequence
@@ -256,15 +275,11 @@ int run_interactive(Shell &sh) {
   rl_set_keymap(rl_get_keymap_by_name("emacs"));
   rl_bind_keyseq("\\C-x\\C-v", gnash_display_shell_version);
 
-  // zsh persona: TAB cycles through completions (menu completion), Shift-TAB
-  // cycles backward -- the characteristic zsh feel, versus bash's insert-common-
-  // prefix-then-list.  Also hide dotfiles unless the word begins with `.', as
-  // zsh does (bash-family personas keep readline's default of matching them).
-  if (sh.is_zsh()) {
-    rl_bind_key('\t', rl_menu_complete);
-    rl_bind_keyseq("\\e[Z", rl_backward_menu_complete);
-    rl_match_hidden_files = 0;
-  }
+  // Persona-dependent readline hooks (highlighting, TAB completion style, dotfile
+  // hiding).  Applied now, and re-applied whenever the personality is switched at
+  // runtime via `personality'/`emulate'.
+  apply_persona_readline(sh);
+  sh.on_personality_change = [&sh]() { apply_persona_readline(sh); };
 
   while (!sh.exiting) {
     // Catch SIGINT during command execution so C-c aborts the running command

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -628,6 +628,10 @@ void Shell::set_personality(const std::string &name) {
           "/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:"
           "/usr/pkg/lib/bash:/opt/pkg/lib/bash:.");
   }
+
+  // Let an interactive REPL re-apply persona-dependent readline hooks when the
+  // personality is switched at runtime (`personality'/`emulate').
+  if (on_personality_change) on_personality_change();
 }
 
 int Shell::run_string(const std::string &script) {


### PR DESCRIPTION
## Summary

The persona-dependent readline hooks (zsh live highlighting, TAB menu-completion + below-line menu, dotfile hiding; vs default insert-common-prefix completion) were configured once at startup. A runtime `personality`/`emulate` switch changed the persona but left the hooks alone — so `personality zsh` gained no highlighting/menu, and switching away kept them.

## Fix

Factor the setup into `apply_persona_readline()` and re-run it on every change: `Shell::set_personality` calls an `on_personality_change` hook that the interactive REPL registers to reconfigure readline. Startup uses the same function, so both directions (to/from zsh) are handled.

## Testing

pty-verified: `--personality=bash` then `personality zsh` -> menu-below + highlighting now active; `--personality=zsh` then `personality bash` -> highlighting off, TAB does bash LCP (`debi`->`debinhex`), no menu-below. Full suite 20/20; personality_test passes.

Fixes #55