### PR TITLE
Match bash on its histexp.tests: script history and expansion wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Six harnesses:
 
 - **Differential** (`tests/harness/run_diff.sh`, gated in ctest) — runs a growing corpus
   of scripts under both gnash and bash 5.3 and requires identical stdout + exit status.
-  Currently **213 scripts** covering expansion, arithmetic, control flow, arrays, functions,
+  Currently **221 scripts** covering expansion, arithmetic, control flow, arrays, functions,
   redirection, process substitution, the special variables, the full builtin set, and job
   control — all matching.
 - **csh differential** (`tests/harness/run_diff_csh.sh`, gated in ctest when `tcsh` is

--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -54,6 +54,12 @@ struct Token {
   bool quoted = false;          // word contained quoting
   bool glued = false;           // Lparen immediately followed by `(' (for `((')
   bool lex_error = false;       // set on the Eof token if a span was unterminated
+  // Set on the Eof token when a here-document ran to end-of-input without its
+  // delimiter: the body is still attached (bash runs it with a warning), but
+  // line-oriented readers treat the input as incomplete.
+  bool heredoc_eof = false;
+  std::string heredoc_eof_delim;
+  int heredoc_eof_line = 0;
   // For a here-document delimiter word, the collected body and whether the
   // delimiter was quoted (which disables expansion of the body).
   std::string heredoc_body;

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -22,6 +22,12 @@ struct ParseResult {
   bool ok = true;
   std::string error;    // set when ok == false
   bool incomplete = false;  // input ended mid-construct (needs more lines)
+  // A here-document body was delimited by end of input: ok stays true and the
+  // command is runnable (bash runs it with a warning), but incomplete is also
+  // set so line-at-a-time readers keep accumulating input.
+  bool heredoc_eof = false;
+  std::string heredoc_eof_delim;
+  int heredoc_eof_line = 0;
 };
 
 // Parse a complete program.

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -241,6 +241,25 @@ class Shell {
   bool opt_noexec = false;    // -n: read/parse commands but don't execute them
   bool opt_pipefail = false;  // -o pipefail: pipeline status = last non-zero stage
   bool opt_functrace = false; // -T / -o functrace: DEBUG/RETURN traps inherited
+  bool opt_history = false;     // -o history: record command lines in the history
+  bool opt_histexpand = false;  // -H / -o histexpand: `!' history expansion
+  bool history_loaded = false;  // $HISTFILE has been read into the history list
+  int hist_new_entries = 0;     // entries added this session (for `history -a')
+  int lineno_base = 0;          // added to AST line numbers ($LINENO, errors) when
+                                // a script runs command-by-command
+
+  bool opt_posix = false;       // -o posix
+  // Turn on `-o history': the first enable loads $HISTFILE and applies the
+  // $HISTSIZE stifle, as bash does.
+  void enable_history();
+  // Point the history library's expansion characters at $histchars.
+  void sync_histchars();
+  // Add LINE to the history honoring $HISTCONTROL and $HISTIGNORE; true if
+  // it was saved.
+  bool add_history_line(const std::string &line);
+  // Append a continuation LINE of a multi-line command to the newest history
+  // entry (shopt cmdhist), joined with bash's delimiting rules.
+  void append_history_line(const std::string &line);
   int errexit_suppress = 0;   // >0 while a command's status is being checked
   std::string bash_command;   // $BASH_COMMAND: the command currently executing
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
@@ -271,6 +290,9 @@ class Shell {
 
   // Parse and execute a script; returns the final exit status.
   int run_string(const std::string &script);
+  // Run a script buffer command-by-command (as bash reads scripts), so history
+  // recording/expansion and mid-script alias definitions behave like bash.
+  int run_script_lines(const std::string &text);
   // Command substitution: run SCRIPT, return its stdout (trailing newlines
   // stripped); *status gets the exit status.
   std::string run_and_capture(const std::string &script, int *status);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -844,15 +844,15 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"allexport", false},   {"braceexpand", true},
       {"emacs", rl_editing_mode == 1}, {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
-      {"hashall", true},      {"histexpand", i},
-      {"history", i},         {"ignoreeof", false},
+      {"hashall", true},      {"histexpand", sh.opt_histexpand},
+      {"history", sh.opt_history}, {"ignoreeof", false},
       {"interactive-comments", true}, {"keyword", false},
       {"monitor", i},         {"noclobber", false},
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
       {"nounset", sh.opt_nounset}, {"onecmd", false},
       {"physical", false},    {"pipefail", sh.opt_pipefail},
-      {"posix", false},       {"privileged", false},
+      {"posix", sh.opt_posix}, {"privileged", false},
       {"verbose", sh.opt_verbose}, {"vi", rl_editing_mode == 0},
       {"xtrace", sh.opt_xtrace}};
 }
@@ -886,6 +886,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'v': sh.opt_verbose = on; break;
           case 'n': if (!sh.interactive) sh.opt_noexec = on; break;  // ignored when interactive
           case 'T': sh.opt_functrace = on; break;  // DEBUG/RETURN trap inheritance
+          case 'H': sh.opt_histexpand = on; break;  // `!' history expansion
           case 'o': {
             if (i + 1 >= argv.size()) {
               // `set -o' lists states; `set +o' reproduces as commands.
@@ -903,6 +904,9 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
               else if (o == "noexec") { if (!sh.interactive) sh.opt_noexec = on; }
               else if (o == "functrace" || o == "errtrace") sh.opt_functrace = on;
               else if (o == "pipefail") sh.opt_pipefail = on;
+              else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
+              else if (o == "histexpand") sh.opt_histexpand = on;
+              else if (o == "posix") sh.opt_posix = on;
               // `set -o vi'/`set -o emacs' switch the readline editing mode
               // (they are mutually exclusive); `+o' flips to the other.
               else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }
@@ -2040,19 +2044,32 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
     }
     if (a == "-s") {
       std::string s = join(argv, i + 1);
-      if (!s.empty()) add_history(s.c_str());
+      if (!s.empty()) { add_history(s.c_str()); sh.hist_new_entries++; }
       return 0;
     }
     if (a == "-p") {
+      int st = 0;
+      sh.sync_histchars();
       for (size_t k = i + 1; k < argv.size(); k++) {
         char *e = nullptr;
-        history_expand(const_cast<char *>(argv[k].c_str()), &e);
-        if (e) { std::printf("%s\n", e); std::free(e); }
+        int hr = history_expand(const_cast<char *>(argv[k].c_str()), &e);
+        if (hr < 0) {
+          std::fprintf(stderr, "%shistory: %s: history expansion failed\n",
+                       sh.err_prefix().c_str(), argv[k].c_str());
+          st = 1;
+        } else if (e) {
+          std::printf("%s\n", e);
+        }
+        std::free(e);
       }
-      return 0;
+      return st;
     }
     if (a == "-w") { write_history((i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str()); return 0; }
-    if (a == "-a") { append_history(0, (i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str()); return 0; }
+    if (a == "-a") {
+      append_history(sh.hist_new_entries, (i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str());
+      sh.hist_new_entries = 0;
+      return 0;
+    }
     if (a == "-r" || a == "-n") { read_history((i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str()); return 0; }
     if (!a.empty() && (std::isdigit(static_cast<unsigned char>(a[0])))) { limit = std::atoi(a.c_str()); continue; }
     break;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -458,7 +458,7 @@ int Executor::run_pipeline(const Connection *c) {
 }
 
 int Executor::run_simple(const SimpleCommand *c) {
-  if (c->line > 0) sh_.cur_lineno = c->line;  // $LINENO
+  if (c->line > 0) sh_.cur_lineno = sh_.lineno_base + c->line;  // $LINENO
   // Consume the exec-in-place permission for *this* command up front, so it
   // applies only to a direct external here -- never to commands that a builtin
   // (eval/source) or function invoked by this command goes on to run.
@@ -560,7 +560,9 @@ int Executor::run_simple(const SimpleCommand *c) {
     apply_redirects(sh_, c->redirects, saved);
     for (const auto &a : assigns) sh_.set(a.first, a.second);
     restore_fds(saved);
-    return (sh_.last_status = sh_.cmdsub_ran ? sh_.last_cmdsub_status : 0);
+    int st = sh_.cmdsub_ran ? sh_.last_cmdsub_status : 0;
+    if (c->flags & CMD_INVERT_RETURN) st = st ? 0 : 1;  // a bare `!'
+    return (sh_.last_status = st);
   }
 
   // A bare job spec in command position (`%1', `%', `%%', `%-', `%name') is a

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -219,7 +219,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_verbose) f += 'v';
     if (sh_.opt_xtrace) f += 'x';
     f += 'B';                       // braceexpand: on by default
-    if (sh_.interactive) f += 'H';  // histexpand: on for interactive shells
+    if (sh_.opt_histexpand) f += 'H';  // histexpand (set -H; interactive default)
     if (sh_.invocation_char) f += sh_.invocation_char;
     return f;
   }
@@ -919,6 +919,31 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   bool length = false;
   std::string b = body;
   if (b.size() > 1 && b[0] == '#') { length = true; b = b.substr(1); }
+
+  // ${!name} indirection and ${!prefix*}/${!prefix@} name listing.  A `['
+  // after the name is the ${!arr[@]} keys form, handled by the array path.
+  if (b.size() > 1 && b[0] == '!' &&
+      (std::isalpha(static_cast<unsigned char>(b[1])) || b[1] == '_')) {
+    size_t q = 1;
+    while (q < b.size() && (std::isalnum(static_cast<unsigned char>(b[q])) || b[q] == '_')) q++;
+    std::string iname = b.substr(1, q - 1);
+    if (q == b.size() || b[q] != '[') {
+      if (q + 1 == b.size() && (b[q] == '*' || b[q] == '@')) {
+        std::string names;
+        for (const auto &kv : sh.vars) {
+          if (kv.first.compare(0, iname.size(), iname) != 0) continue;
+          if (!names.empty()) names += ' ';
+          names += kv.first;
+        }
+        return names;
+      }
+      // The value of INAME is the parameter to expand; any operator that
+      // follows applies to the indirected parameter.
+      std::string target = sh.get(iname);
+      if (length) return std::to_string(expand_brace_body(ex, sh, target + b.substr(q)).size());
+      return expand_brace_body(ex, sh, target + b.substr(q));
+    }
+  }
 
   size_t p = 0;
   std::string name;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -59,6 +59,9 @@ struct Lexer {
   std::vector<Pending> pending;
   int awaiting = -1;  // -1 none, 0 <<, 1 <<-
   bool unterminated = false;
+  bool heredoc_eof = false;        // here-doc body delimited by end of input
+  std::string heredoc_eof_delim;
+  int heredoc_eof_line = 0;
   std::size_t line_scanned = 0;  // bytes already counted for line numbering
   int cur_line = 1;              // 1-based line at line_scanned
 
@@ -399,7 +402,13 @@ struct Lexer {
         body += '\n';
         if (!had_nl) break;  // EOF before delimiter
       }
-      if (!found) unterminated = true;  // delimiter never seen: need more input
+      if (!found && !heredoc_eof) {
+        // Delimiter never seen: end-of-input delimits the body (bash warns).
+        // Line readers treat this as incomplete and keep accumulating input.
+        heredoc_eof = true;
+        heredoc_eof_delim = pd.delim;
+        heredoc_eof_line = out[pd.index].line;
+      }
       out[pd.index].heredoc_body = body;
       out[pd.index].has_heredoc = true;
       out[pd.index].heredoc_quoted = pd.quoted;
@@ -457,9 +466,16 @@ struct Lexer {
         awaiting = -1;
       }
     }
+    // A here-doc redirection with no newline after it (input ended on the
+    // command line): collect now so the empty body and the end-of-input
+    // condition are recorded.
+    if (!pending.empty()) collect_heredocs();
     Token eof;
     eof.type = Tok::Eof;
     eof.lex_error = unterminated;
+    eof.heredoc_eof = heredoc_eof;
+    eof.heredoc_eof_delim = heredoc_eof_delim;
+    eof.heredoc_eof_line = heredoc_eof_line;
     out.push_back(eof);
   }
 };

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -392,7 +392,7 @@ int main(int argc, char **argv) {
     read_startup_files(sh, startup_prefix, login, false, sopts);
     // Base frame for BASH_SOURCE[0]/$0 = the script path, as bash reports it.
     sh.push_src_frame("main", args[idx], 0, false);
-    sh.run_string(ss.str());
+    sh.run_script_lines(ss.str());
   } else {
     // Read commands from standard input.
     sh.invocation_char = 's';  // $- includes `s' when reading from stdin
@@ -437,7 +437,7 @@ int main(int argc, char **argv) {
     read_startup_files(sh, startup_prefix, login, false, sopts);
     std::ostringstream ss;
     ss << std::cin.rdbuf();
-    sh.run_string(ss.str());
+    sh.run_script_lines(ss.str());
   }
 
   int rc = sh.exiting ? sh.exit_status : sh.last_status;

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -853,7 +853,7 @@ struct Parser {
     ParseResult res;
     if (!toks.empty() && toks.back().lex_error) {
       res.ok = false;
-      res.incomplete = true;  // unterminated quote/substitution/here-doc
+      res.incomplete = true;  // unterminated quote/substitution
       res.error = "unterminated quoted string or substitution";
       return res;
     }
@@ -868,6 +868,15 @@ struct Parser {
       res.error = errmsg;
       res.incomplete = incomplete;
       res.command.reset();
+      return res;
+    }
+    // A here-document delimited by end of input: runnable, but incomplete for
+    // callers that can supply more lines.
+    if (!toks.empty() && toks.back().heredoc_eof) {
+      res.incomplete = true;
+      res.heredoc_eof = true;
+      res.heredoc_eof_delim = toks.back().heredoc_eof_delim;
+      res.heredoc_eof_line = toks.back().heredoc_eof_line;
     }
     return res;
   }

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -267,6 +267,11 @@ int run_interactive(Shell &sh) {
   if (histfile.empty()) histfile = history_path();
   if (!histfile.empty()) read_history(histfile.c_str());
   using_history();
+  // Interactive shells default to `-o history' and `-H'; the file was loaded
+  // above, so a later `set -o history' must not reload it.
+  sh.opt_history = true;
+  sh.opt_histexpand = true;
+  sh.history_loaded = true;
   // Keep at most $HISTSIZE entries in memory (bash default 500).
   int histsize = std::atoi(sh.get("HISTSIZE").c_str());
   if (histsize > 0) stifle_history(histsize);
@@ -322,19 +327,23 @@ int run_interactive(Shell &sh) {
     std::free(line);
 
     // History (`!!', `!n', `^old^new^', ...) expansion.
-    char *expanded = nullptr;
-    int hr = history_expand(const_cast<char *>(input.c_str()), &expanded);
-    if (expanded) {
-      if (hr < 0) {
-        std::fprintf(stderr, "%s\n", expanded);
+    if (sh.opt_histexpand) {
+      sh.sync_histchars();
+      char *expanded = nullptr;
+      int hr = history_expand(const_cast<char *>(input.c_str()), &expanded);
+      if (expanded) {
+        if (hr < 0) {
+          std::fprintf(stderr, "%s\n", expanded);
+          std::free(expanded);
+          continue;
+        }
+        if (hr != 0) std::fprintf(stderr, "%s\n", expanded);  // echo the expansion
+        input = expanded;
         std::free(expanded);
-        continue;
-      }
-      input = expanded;
-      std::free(expanded);
-      if (hr == 2) {  // `:p' modifier -- print, don't execute
-        std::printf("%s\n", input.c_str());
-        continue;
+        if (hr == 2) {  // `:p' modifier -- print, don't execute (but record)
+          if (sh.opt_history) sh.add_history_line(input);
+          continue;
+        }
       }
     }
 
@@ -364,7 +373,8 @@ int run_interactive(Shell &sh) {
     }
     if (interrupted) continue;  // reprompt with PS1, discarding the partial command
 
-    if (input.find_first_not_of(" \t\n") != std::string::npos) add_history(input.c_str());
+    if (sh.opt_history && input.find_first_not_of(" \t\n") != std::string::npos)
+      sh.add_history_line(input);
     g_sigint_received = 0;  // start the command uninterrupted
     strmatch_set_interrupt(0);
     sh.run_string(input);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -17,6 +17,7 @@
 #include <sys/wait.h>
 
 #include "readline/history.h"
+#include "strmatch.h"
 
 #include "gnash/core/csh.hpp"
 #include "gnash/core/executor.hpp"
@@ -558,6 +559,11 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     return false;
   }
   var.value = v;
+  // Assigning HISTSIZE re-stifles the loaded history list, as bash does.
+  if (n == "HISTSIZE" && history_loaded) {
+    int hs = std::atoi(v.c_str());
+    if (hs >= 0) stifle_history(hs);
+  }
   return true;
 }
 
@@ -635,6 +641,311 @@ void Shell::set_personality(const std::string &name) {
   if (on_personality_change) on_personality_change();
 }
 
+// ---- history wiring (bash's bashhist.c equivalents) ------------------------
+
+namespace {
+
+Shell *g_hist_shell = nullptr;  // for the inhibit callback below
+
+// Port of bash's bash_history_inhibit_expansion(): the `!' at STRING[I] is
+// not a history expansion -- glob negation, ${!var}, $!, extglob !(...), or
+// shell-quoted (scanning with quote rules, including fresh quoting contexts
+// inside $(...) and backquotes; posix mode treats double quotes as quoting
+// the expansion character).
+int gnash_history_inhibit_expansion(char *string, int i) {
+  if (i > 0 && string[i - 1] == '[' && std::strchr(string + i + 1, ']')) return 1;
+  if (i > 1 && string[i - 1] == '{' && string[i - 2] == '$' &&
+      std::strchr(string + i + 1, '}'))
+    return 1;
+  if (i > 0 && string[i - 1] == '$') return 1;
+  if (string[i + 1] == '(' && std::strchr(string + i + 2, ')')) return 1;
+
+  bool posix = g_hist_shell && g_hist_shell->opt_posix;
+  int dquote = history_quoting_state == '"';
+  std::vector<int> saved_dq;  // dquote state saved at each $( / ` level
+  bool in_backq = false;
+  size_t p = 0;
+  const size_t target = static_cast<size_t>(i);
+  while (string[p] && p < target) {
+    char c = string[p];
+    if (c == '\\') {
+      p += string[p + 1] ? 2 : 1;
+      continue;
+    }
+    if (c == '\'' && !dquote) {  // skip the single-quoted section
+      p++;
+      while (string[p] && string[p] != '\'') p++;
+      if (string[p]) p++;
+      continue;
+    }
+    if (c == '"') {
+      if (posix) {  // posix: double quotes quote the expansion char entirely
+        p++;
+        while (string[p] && string[p] != '"') {
+          if (string[p] == '\\' && string[p + 1]) p++;
+          p++;
+        }
+        if (string[p]) p++;
+      } else {
+        dquote = 1 - dquote;
+        p++;
+      }
+      continue;
+    }
+    if (c == '$' && string[p + 1] == '(') {  // fresh quoting context
+      saved_dq.push_back(dquote);
+      dquote = 0;
+      p += 2;
+      continue;
+    }
+    if (c == ')' && !saved_dq.empty()) {
+      dquote = saved_dq.back();
+      saved_dq.pop_back();
+      p++;
+      continue;
+    }
+    if (c == '`') {
+      if (in_backq && !saved_dq.empty()) {
+        dquote = saved_dq.back();
+        saved_dq.pop_back();
+      } else {
+        saved_dq.push_back(dquote);
+        dquote = 0;
+      }
+      in_backq = !in_backq;
+      p++;
+      continue;
+    }
+    p++;
+  }
+  if (p != target) return 1;                    // quoted away: not an expansion
+  if (dquote && string[i + 1] == '"') return 1; // `!"' inside double quotes
+  return 0;
+}
+
+}  // namespace
+
+void Shell::enable_history() {
+  opt_history = true;
+  if (history_loaded) return;
+  history_loaded = true;
+  using_history();
+  std::string hf = get("HISTFILE");
+  if (!hf.empty()) read_history(hf.c_str());
+  if (is_set("HISTSIZE")) {
+    int hs = std::atoi(get("HISTSIZE").c_str());
+    if (hs >= 0) stifle_history(hs);
+  }
+  using_history();
+}
+
+void Shell::sync_histchars() {
+  history_quotes_inhibit_expansion = 1;
+  using_history();  // `!!' and relative events resolve from the end of the list
+  // bash's no-expand set and inhibition callback (globs, ${!var}, quoting).
+  history_no_expand_chars = const_cast<char *>(" \t\n\r=;&|()<>");
+  history_inhibit_expansion_function = gnash_history_inhibit_expansion;
+  g_hist_shell = this;
+  std::string hc = get("histchars");
+  history_expansion_char = hc.size() > 0 ? hc[0] : '!';
+  history_subst_char = hc.size() > 1 ? hc[1] : '^';
+  history_comment_char = hc.size() > 2 ? hc[2] : '#';
+}
+
+bool Shell::add_history_line(const std::string &line) {
+  // $HISTCONTROL: ignorespace / ignoredups / ignoreboth (erasedups not modeled).
+  std::string hc = get("HISTCONTROL");
+  bool ign_space = hc.find("ignorespace") != std::string::npos ||
+                   hc.find("ignoreboth") != std::string::npos;
+  bool ign_dups = hc.find("ignoredups") != std::string::npos ||
+                  hc.find("ignoreboth") != std::string::npos;
+  if (ign_space && !line.empty() && (line[0] == ' ' || line[0] == '\t')) return false;
+
+  const char *prev = nullptr;
+  if (history_length > 0) {
+    HIST_ENTRY *e = history_get(history_base + history_length - 1);
+    if (e) prev = e->line;
+  }
+  if (ign_dups && prev && line == prev) return false;
+
+  // $HISTIGNORE: colon-separated patterns; `&' matches the previous entry.
+  std::string hi = get("HISTIGNORE");
+  size_t p = 0;
+  while (p <= hi.size() && !hi.empty()) {
+    size_t q = hi.find(':', p);
+    std::string pat = hi.substr(p, q == std::string::npos ? std::string::npos : q - p);
+    if (pat == "&") {
+      if (prev && line == prev) return false;
+    } else if (!pat.empty() &&
+               strmatch(const_cast<char *>(pat.c_str()), const_cast<char *>(line.c_str()),
+                        FNM_EXTMATCH) == 0) {
+      return false;
+    }
+    if (q == std::string::npos) break;
+    p = q + 1;
+  }
+
+  add_history(line.c_str());
+  hist_new_entries++;
+  return true;
+}
+
+void Shell::append_history_line(const std::string &line) {
+  if (history_length == 0) return;
+  HIST_ENTRY *e = history_get(history_base + history_length - 1);
+  if (e == nullptr || e->line == nullptr) return;
+  std::string cur = e->line;
+
+  // Join with bash's history_delimiting_chars, approximately: no semicolon
+  // after an operator or after a keyword that a command follows directly.
+  std::string delim = "; ";
+  std::string t = cur;
+  while (!t.empty() && (t.back() == ' ' || t.back() == '\t')) t.pop_back();
+  if (!t.empty() && t.back() == '\\' && (t.size() < 2 || t[t.size() - 2] != '\\')) {
+    // The previous line ended in an escaped newline: splice directly.
+    t.pop_back();
+    cur = t;
+    delim = "";
+  } else if (!t.empty() && std::strchr(";&|({", t.back())) {
+    delim = " ";
+  } else {
+    size_t ws = t.find_last_of(" \t;");
+    std::string w = ws == std::string::npos ? t : t.substr(ws + 1);
+    if (w == "do" || w == "then" || w == "else" || w == "elif" || w == "in" ||
+        w == "while" || w == "until" || w == "if" || w == "for" || w == "case" ||
+        w == "select" || w == "function")
+      delim = " ";
+  }
+  if (line.find_first_not_of(" \t") == std::string::npos) return;  // blank line
+
+  std::string joined = cur + delim + line;
+  using_history();
+  HIST_ENTRY *old = replace_history_entry(history_length - 1, joined.c_str(),
+                                          e->data);
+  if (old) free_history_entry(old);
+}
+
+// True if TEXT ends inside a quoted string, command/process substitution, or
+// backquotes -- contexts where bash does not history-expand continuation lines.
+static bool in_open_context(const std::string &t) {
+  bool squote = false, dquote = false;
+  int depth = 0;
+  for (size_t i = 0; i < t.size(); i++) {
+    char c = t[i];
+    if (c == '\\' && !squote) { if (i + 1 < t.size()) i++; continue; }
+    if (squote) { if (c == '\'') squote = false; continue; }
+    if (c == '\'' && !dquote) { squote = true; continue; }
+    if (c == '"') { dquote = !dquote; continue; }
+    if (c == '`') { depth = depth ? depth - 1 : depth + 1; continue; }
+    if (c == '(' && i > 0 && (t[i - 1] == '$' || t[i - 1] == '<' || t[i - 1] == '>')) {
+      depth++;
+      continue;
+    }
+    if (c == ')' && depth > 0) depth--;
+  }
+  return squote || dquote || depth > 0;
+}
+
+int Shell::run_script_lines(const std::string &text) {
+  if (is_csh()) return run_string(text);  // csh runs whole-buffer
+
+  size_t pos = 0;
+  int lineno = 0;        // 1-based physical line being read
+  int pending_line = 1;  // first line of the accumulating command
+  std::string pending;
+  bool cont_bslash = false;  // previous line ended in a line continuation
+  bool first_line_saved = false;  // this command's first line is in the history
+  int st = last_status;
+
+  auto flush = [&]() {
+    cont_bslash = false;
+    first_line_saved = false;
+    if (pending.find_first_not_of(" \t\n") == std::string::npos) {
+      pending.clear();
+      return;
+    }
+    lineno_base = pending_line - 1;
+    st = run_string(pending);
+    lineno_base = 0;
+    pending.clear();
+  };
+
+  while (pos < text.size() && !exiting) {
+    size_t nl = text.find('\n', pos);
+    std::string line = (nl == std::string::npos) ? text.substr(pos) : text.substr(pos, nl - pos);
+    pos = (nl == std::string::npos) ? text.size() : nl + 1;
+    lineno++;
+
+    bool fresh = pending.empty();
+    if (fresh) pending_line = lineno;
+
+    // With `-o history' each line is preprocessed as it is read (bash's
+    // pre_process_line): `!' expansion with the expanded line echoed to
+    // stderr, then recorded in the history -- all before execution.
+    if (opt_history && line.find_first_not_of(" \t") != std::string::npos) {
+      if (opt_histexpand && (fresh || !in_open_context(pending))) {
+        sync_histchars();
+        cur_lineno = lineno;  // the expansion error prefix names this line
+        // Expanding a later line of a multi-line command: history references
+        // must resolve to the previous complete command, not the partial one,
+        // so lift the partial entry out for the duration of the expansion.
+        HIST_ENTRY *hidden = nullptr;
+        if (!fresh && first_line_saved && history_length > 0) {
+          hidden = remove_history(history_length - 1);
+          using_history();
+        }
+        char *hv = nullptr;
+        int hr = history_expand(const_cast<char *>(line.c_str()), &hv);
+        if (hidden) {
+          add_history(hidden->line);
+          free_history_entry(hidden);
+          using_history();
+        }
+        if (hr < 0) {
+          std::fprintf(stderr, "%s%s\n", err_prefix().c_str(), hv ? hv : "history expansion failed");
+          std::free(hv);
+          st = last_status = 1;
+          continue;  // the failed line is neither run nor recorded
+        }
+        if (hr != 0 && hv) std::fprintf(stderr, "%s\n", hv);  // echo the expansion
+        if (hv) { line = hv; std::free(hv); }
+        if (hr == 2) {  // `:p' modifier: print and record, don't execute
+          if (fresh) add_history_line(line);
+          continue;
+        }
+      }
+      if (fresh) {
+        first_line_saved = add_history_line(line);
+      } else if (first_line_saved &&
+                 !(line.find_first_not_of(" \t") != std::string::npos &&
+                   line[line.find_first_not_of(" \t")] == '#')) {
+        // shopt cmdhist: later lines of the command extend its history entry
+        // (pure comment lines are not appended).
+        append_history_line(line);
+      }
+    }
+
+    if (cont_bslash) pending += line;
+    else if (pending.empty()) pending = line;
+    else pending += "\n" + line;
+
+    // A trailing (unescaped) backslash continues onto the next line.
+    size_t nbs = 0;
+    while (nbs < pending.size() && pending[pending.size() - 1 - nbs] == '\\') nbs++;
+    if (nbs % 2 == 1) {
+      pending.pop_back();
+      cont_bslash = true;
+      continue;
+    }
+    cont_bslash = false;
+
+    if (pos < text.size() && parse(pending).incomplete) continue;
+    flush();
+  }
+  if (!exiting) flush();  // whatever remains (an incomplete tail still errors)
+  return st;
+}
+
 int Shell::run_string(const std::string &script) {
   if (is_csh()) return run_csh(*this, script);  // csh is a different language
   // Aliases are expanded only when interactive or `shopt -s expand_aliases'.
@@ -650,6 +961,11 @@ int Shell::run_string(const std::string &script) {
     last_status = 2;
     return 2;
   }
+  if (r.heredoc_eof)  // run anyway, with bash's warning
+    std::fprintf(stderr,
+                 "%swarning: here-document at line %d delimited by end-of-file (wanted `%s')\n",
+                 err_prefix().c_str(), lineno_base + r.heredoc_eof_line,
+                 r.heredoc_eof_delim.c_str());
   if (!r.command) { subshell_leaf = false; return last_status; }
   const Command *c = r.command.get();
   retained.push_back(std::move(r.command));

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -289,6 +289,18 @@ source /tmp/gnrx3.$$; rm -f /tmp/gnrx3.$$'
   'LC_ALL=C printf "<%q>\n" "$(printf "tab\thigh\200")"'
   # printf %b arguments still handle \0NNN
   'printf "%b\n" "A\0101Z" | cat -v'
+  # ${!name} indirection, with operators, and ${!prefix*} name listing
+  'x=y; y=hello; echo "${!x}"'
+  'x=unset_zz; echo "${!x:-fallback}"'
+  'ab1=v1; ab2=v2; echo ${!ab*}'
+  'set -- one two; n=2; echo "${!n}"'
+  # a bare `!' negates the null command; `! cmd' inverts
+  '! ; echo $?'
+  '! true; echo $?'
+  '! false; echo $?'
+  # a here-document delimited by end-of-file still runs (with a warning)
+  'cat <<XEOF 2>/dev/null
+line1'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #67.

gnash's output for bash 5.3's `tests/histexp.tests` is now **byte-identical to bash's** in the same environment (was ~330 diff lines); `read.tests` stays at 0; all 22 ctest suites and 221 differential scripts (8 new) pass.

**The big change**: scripts now execute command-by-command (`Shell::run_script_lines`) like bash, instead of one whole-buffer parse. Each line is preprocessed as read (bash's `pre_process_line`): history-expanded — echoing expansions to stderr, `:p` printing without executing, line-numbered errors — then recorded. `$LINENO`/error line numbers stay correct via a `lineno_base` offset. Mid-script alias definitions now affect later commands too, as in bash.

**History wiring** (bashhist.c equivalents): real `set -o history` / `set -H` flags (interactive defaults on, first enable loads $HISTFILE + $HISTSIZE stifle), $HISTCONTROL / $HISTIGNORE / $histchars, `history -p/-a/-s` fixes, $- includes H.

**Inhibition rules**: bash's `history_no_expand_chars` set, a port of `bash_history_inhibit_expansion` ([!...] globs, ${!var}, $!, extglob, shell-quoting contexts incl. fresh quoting inside $(...), posix-mode double-quote inhibition via a real `set -o posix` flag), relative events anchored to the list end.

**cmdhist**: multi-line commands become one history entry joined with bash's delimiter rules; continuation-line expansions resolve to the previous complete command (the partial entry is lifted out during expansion); lines inside command/process substitutions and quotes are not expanded.

**Fixed along the way**: `${!name}` indirection + `${!prefix*}` listing were unimplemented (returned `$!`); bare `!` didn't invert the null command; here-documents delimited by end-of-input now match bash (runnable body + warning, incomplete signal for line readers).