### PR TITLE
Match bash on its history.tests: the history and fc builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,7 @@ Six harnesses:
   and self-test summaries, so a behaviourally-correct gnash still diverges on those lines.
   The differential and error-format harnesses (individual constructs cross-checked against
   real bash) are the more representative signal. The tests gnash reproduces exactly are
-  pinned as a ctest regression gate (`conformance_gate.sh`).
+  pinned as a ctest regression gate (`conformance_gate.sh`). The readline-domain test
+  files — `read.tests`, `histexp.tests`, and `history.tests` — produce output
+  byte-identical to bash 5.3's when both shells run them in the same environment
+  (modulo the program name and a run-varying pid in one job-control warning).

--- a/compat/readline/history.h
+++ b/compat/readline/history.h
@@ -102,6 +102,7 @@ extern int history_lines_read_from_file;
 extern int history_lines_written_to_file;
 extern char history_comment_char;
 extern int history_write_timestamps;
+extern int history_multiline_entries;
 extern int max_input_history;
 
 /* History expansion tunables (defined in histexpand.cpp). */

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -245,6 +245,9 @@ class Shell {
   bool opt_histexpand = false;  // -H / -o histexpand: `!' history expansion
   bool history_loaded = false;  // $HISTFILE has been read into the history list
   int hist_new_entries = 0;     // entries added this session (for `history -a')
+  // History index of the currently-executing command's own entry (so `fc'
+  // excludes and later replaces it), or -1 when it was not recorded.
+  int hist_cur_cmd_index = -1;
   int lineno_base = 0;          // added to AST line numbers ($LINENO, errors) when
                                 // a script runs command-by-command
 
@@ -258,8 +261,9 @@ class Shell {
   // it was saved.
   bool add_history_line(const std::string &line);
   // Append a continuation LINE of a multi-line command to the newest history
-  // entry (shopt cmdhist), joined with bash's delimiting rules.
-  void append_history_line(const std::string &line);
+  // entry (shopt cmdhist), joined with bash's delimiting rules (or a newline
+  // inside a here-document).
+  void append_history_line(const std::string &line, bool heredoc = false);
   int errexit_suppress = 0;   // >0 while a command's status is being checked
   std::string bash_command;   // $BASH_COMMAND: the command currently executing
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -837,6 +837,27 @@ void set_print_var(const std::string &name, const Variable &v) {
   }
 }
 
+// Apply one `set -o NAME' / `set +o NAME'; false if NAME is unknown.
+bool set_o_option(Shell &sh, const std::string &o, bool on) {
+  if (o == "errexit") sh.opt_errexit = on;
+  else if (o == "xtrace") sh.opt_xtrace = on;
+  else if (o == "nounset") sh.opt_nounset = on;
+  else if (o == "noglob") sh.opt_noglob = on;
+  else if (o == "verbose") sh.opt_verbose = on;
+  else if (o == "noexec") { if (!sh.interactive) sh.opt_noexec = on; }
+  else if (o == "functrace" || o == "errtrace") sh.opt_functrace = on;
+  else if (o == "pipefail") sh.opt_pipefail = on;
+  else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
+  else if (o == "histexpand") sh.opt_histexpand = on;
+  else if (o == "posix") sh.opt_posix = on;
+  // `set -o vi'/`set -o emacs' switch the readline editing mode (they are
+  // mutually exclusive); `+o' flips to the other.
+  else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }
+  else if (o == "emacs") { if (on) rl_emacs_editing_mode(0, 0); else rl_vi_editing_mode(0, 0); }
+  else return false;
+  return true;
+}
+
 // The `set -o'/`set +o' option table with each option's current state.
 std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
   bool i = sh.interactive;
@@ -895,22 +916,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
                 else std::printf("set %co %s\n", o.second ? '-' : '+', o.first.c_str());
               }
             } else {
-              std::string o = argv[++i];
-              if (o == "errexit") sh.opt_errexit = on;
-              else if (o == "xtrace") sh.opt_xtrace = on;
-              else if (o == "nounset") sh.opt_nounset = on;
-              else if (o == "noglob") sh.opt_noglob = on;
-              else if (o == "verbose") sh.opt_verbose = on;
-              else if (o == "noexec") { if (!sh.interactive) sh.opt_noexec = on; }
-              else if (o == "functrace" || o == "errtrace") sh.opt_functrace = on;
-              else if (o == "pipefail") sh.opt_pipefail = on;
-              else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
-              else if (o == "histexpand") sh.opt_histexpand = on;
-              else if (o == "posix") sh.opt_posix = on;
-              // `set -o vi'/`set -o emacs' switch the readline editing mode
-              // (they are mutually exclusive); `+o' flips to the other.
-              else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }
-              else if (o == "emacs") { if (on) rl_emacs_editing_mode(0, 0); else rl_vi_editing_mode(0, 0); }
+              set_o_option(sh, argv[++i], on);
             }
             k = a.size();  // -o consumes the rest of the word
             break;
@@ -1728,6 +1734,7 @@ namespace {  // reopen the anonymous namespace
 int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
   shopt_seed(sh);
   bool set_s = false, unset_u = false, quiet_q = false, print_p = false;
+  bool o_names = false;  // -o: names are `set -o' option names
   size_t i = 1;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
@@ -1739,10 +1746,39 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
         case 'u': unset_u = true; break;
         case 'q': quiet_q = true; break;
         case 'p': print_p = true; break;
-        case 'o': break;  // -o maps to set -o options; accepted
+        case 'o': o_names = true; break;
         default: break;
       }
     }
+  }
+
+  if (o_names) {
+    if (i >= argv.size()) {  // list set -o options
+      for (const auto &o : set_option_states(sh)) {
+        if (set_s && !o.second) continue;
+        if (unset_u && o.second) continue;
+        if (!quiet_q) std::printf("set %co %s\n", o.second ? '-' : '+', o.first.c_str());
+      }
+      return 0;
+    }
+    int st = 0;
+    for (; i < argv.size(); i++) {
+      const std::string &n = argv[i];
+      bool found = false, cur = false;
+      for (const auto &o : set_option_states(sh))
+        if (o.first == n) { found = true; cur = o.second; }
+      if (!found) {
+        if (!quiet_q)
+          std::fprintf(stderr, "%sshopt: %s: invalid shell option name\n",
+                       sh.err_prefix().c_str(), n.c_str());
+        st = 1;
+        continue;
+      }
+      if (set_s || unset_u) set_o_option(sh, n, set_s);
+      else if (quiet_q) { if (!cur) st = 1; }
+      else std::printf("set %co %s\n", cur ? '-' : '+', n.c_str());
+    }
+    return st;
   }
   auto show = [&](const std::string &n, bool on) {
     if (quiet_q) return;
@@ -2033,114 +2069,362 @@ static std::string hist_file(Shell &sh) {
 }
 
 int bi_history(Shell &sh, const std::vector<std::string> &argv) {
+  static const char *kUsage =
+      "history: usage: history [-c] [-d offset] [n] or history -anrw [filename] "
+      "or history -ps arg [arg...]";
+
+  // Parse a history display number (possibly negative = from the end) into a
+  // 0-based list index; false if out of range.
+  auto resolve = [&](long v, int &idx) {
+    long n = v < 0 ? history_length + v : v - history_base;
+    if (n < 0 || n >= history_length) return false;
+    idx = static_cast<int>(n);
+    return true;
+  };
+
+  bool clear = false, del = false, app = false, wr = false, rd = false, nw = false;
+  bool stash = false, expand = false;
+  std::string del_arg, fname;
   int limit = -1;
   size_t i = 1;
+  std::vector<std::string> rest;
+
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
-    if (a == "-c") { clear_history(); return 0; }
-    if (a == "-d") {
-      if (i + 1 < argv.size()) remove_history(std::atoi(argv[i + 1].c_str()) - history_base);
-      return 0;
-    }
-    if (a == "-s") {
-      std::string s = join(argv, i + 1);
-      if (!s.empty()) { add_history(s.c_str()); sh.hist_new_entries++; }
-      return 0;
-    }
-    if (a == "-p") {
-      int st = 0;
-      sh.sync_histchars();
-      for (size_t k = i + 1; k < argv.size(); k++) {
-        char *e = nullptr;
-        int hr = history_expand(const_cast<char *>(argv[k].c_str()), &e);
-        if (hr < 0) {
-          std::fprintf(stderr, "%shistory: %s: history expansion failed\n",
-                       sh.err_prefix().c_str(), argv[k].c_str());
-          st = 1;
-        } else if (e) {
-          std::printf("%s\n", e);
+    if (a == "--") { i++; break; }
+    if (a.size() >= 2 && a[0] == '-' &&
+        !std::isdigit(static_cast<unsigned char>(a[1]))) {
+      for (size_t k = 1; k < a.size(); k++) {
+        switch (a[k]) {
+          case 'c': clear = true; break;
+          case 'd':
+            del = true;
+            if (k + 1 < a.size()) { del_arg = a.substr(k + 1); k = a.size(); }
+            else if (i + 1 < argv.size()) del_arg = argv[++i];
+            break;
+          case 'a': app = true; break;
+          case 'w': wr = true; break;
+          case 'r': rd = true; break;
+          case 'n': nw = true; break;
+          case 's': stash = true; break;
+          case 'p': expand = true; break;
+          default:
+            std::fprintf(stderr, "%shistory: -%c: invalid option\n",
+                         sh.err_prefix().c_str(), a[k]);
+            std::fprintf(stderr, "%s\n", kUsage);
+            return 2;
         }
-        std::free(e);
       }
-      return st;
+    } else {
+      break;
     }
-    if (a == "-w") { write_history((i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str()); return 0; }
-    if (a == "-a") {
-      append_history(sh.hist_new_entries, (i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str());
-      sh.hist_new_entries = 0;
+  }
+  for (; i < argv.size(); i++) rest.push_back(argv[i]);
+
+  if (app + wr + rd + nw > 1) {
+    std::fprintf(stderr, "%shistory: cannot use more than one of -anrw\n",
+                 sh.err_prefix().c_str());
+    return 2;
+  }
+
+  if (clear) {
+    clear_history();
+    sh.hist_new_entries = 0;
+    if (!del && !app && !wr && !rd && !nw && !stash && !expand && rest.empty()) return 0;
+  }
+  if (del) {
+    // OFFSET or START-END ranges, in history display numbers; negative counts
+    // from the end.  bash's error messages distinguish an unparsable token
+    // ("invalid number") from a parsable but out-of-range one.
+    const std::string &d = del_arg;
+    char *e1 = nullptr;
+    long v1 = std::strtol(d.c_str(), &e1, 10);
+    int lo, hi;
+    if (e1 != d.c_str() && *e1 == '\0') {           // single offset
+      if (!resolve(v1, lo)) {
+        std::fprintf(stderr, "%shistory: %s: history position out of range\n",
+                     sh.err_prefix().c_str(), d.c_str());
+        return 2;
+      }
+      HIST_ENTRY *old = remove_history(lo);
+      if (old) free_history_entry(old);
       return 0;
     }
-    if (a == "-r" || a == "-n") { read_history((i + 1 < argv.size() ? argv[i + 1] : hist_file(sh)).c_str()); return 0; }
-    if (!a.empty() && (std::isdigit(static_cast<unsigned char>(a[0])))) { limit = std::atoi(a.c_str()); continue; }
-    break;
+    if (e1 != d.c_str() && *e1 == '-') {             // START-END range
+      const char *p2 = e1 + 1;
+      char *e2 = nullptr;
+      long v2 = std::strtol(p2, &e2, 10);
+      if (e2 != p2 && *e2 == '\0') {
+        if (!resolve(v1, lo)) {
+          std::fprintf(stderr, "%shistory: %ld: history position out of range\n",
+                       sh.err_prefix().c_str(), v1);
+          return 2;
+        }
+        if (!resolve(v2, hi)) {
+          std::fprintf(stderr, "%shistory: %ld: history position out of range\n",
+                       sh.err_prefix().c_str(), v2);
+          return 2;
+        }
+        if (hi < lo) { int t = lo; lo = hi; hi = t; }
+        for (int k = hi; k >= lo; k--) {
+          HIST_ENTRY *old = remove_history(k);
+          if (old) free_history_entry(old);
+        }
+        return 0;
+      }
+      // Range-shaped but the end does not parse: report the whole token.
+      std::fprintf(stderr, "%shistory: %s: history position out of range\n",
+                   sh.err_prefix().c_str(), d.c_str());
+      return 2;
+    }
+    std::fprintf(stderr, "%shistory: %s: invalid number\n", sh.err_prefix().c_str(),
+                 d.c_str());
+    return 2;
   }
+  if (stash) {
+    std::string line = join(rest, 0);
+    if (!line.empty()) { add_history(line.c_str()); sh.hist_new_entries++; }
+    return 0;
+  }
+  if (expand) {
+    int st = 0;
+    sh.sync_histchars();
+    for (const std::string &a : rest) {
+      char *e = nullptr;
+      int hr = history_expand(const_cast<char *>(a.c_str()), &e);
+      if (hr < 0) {
+        std::fprintf(stderr, "%shistory: %s: history expansion failed\n",
+                     sh.err_prefix().c_str(), a.c_str());
+        st = 1;
+      } else if (e) {
+        std::printf("%s\n", e);
+      }
+      std::free(e);
+    }
+    return st;
+  }
+  history_write_timestamps = sh.is_set("HISTTIMEFORMAT") ? 1 : 0;
+  history_multiline_entries = history_write_timestamps;
+  if (wr) { write_history((rest.empty() ? hist_file(sh) : rest[0]).c_str()); return 0; }
+  if (app) {
+    append_history(sh.hist_new_entries, (rest.empty() ? hist_file(sh) : rest[0]).c_str());
+    sh.hist_new_entries = 0;
+    return 0;
+  }
+  if (rd || nw) { read_history((rest.empty() ? hist_file(sh) : rest[0]).c_str()); return 0; }
+
+  if (!rest.empty()) {
+    char *e = nullptr;
+    long v = std::strtol(rest[0].c_str(), &e, 10);
+    if (e == rest[0].c_str() || *e != '\0' || v < 0) {
+      std::fprintf(stderr, "%shistory: %s: numeric argument required\n",
+                   sh.err_prefix().c_str(), rest[0].c_str());
+      return 2;
+    }
+    limit = static_cast<int>(v);
+  }
+
   HIST_ENTRY **list = history_list();
   if (!list) return 0;
   int n = 0;
   while (list[n]) n++;
-  int start = (limit > 0 && limit < n) ? n - limit : 0;
+  int start = (limit >= 0 && limit < n) ? n - limit : 0;
   for (int k = start; k < n; k++)
     std::printf("%5d  %s\n", history_base + k, list[k]->line);
   return 0;
 }
 
 int bi_fc(Shell &sh, const std::vector<std::string> &argv) {
+  static const char *kUsage =
+      "fc: usage: fc [-e ename] [-lnr] [first] [last] or fc -s [pat=rep] [command]";
+  enum { kInvalid = -2, kNotFound = -3 };
+
   bool list = false, nonum = false, reverse = false, subst = false;
+  std::string ename;
+  bool have_e = false;
   size_t i = 1;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     if (a.size() < 2 || a[0] != '-') break;
     if (a == "--") { i++; break; }
+    // A leading -N (digits) is a command spec, not options.
+    if (std::isdigit(static_cast<unsigned char>(a[1]))) break;
+    bool consumed_next = false;
     for (size_t k = 1; k < a.size(); k++) {
-      if (a[k] == 'l') list = true;
-      else if (a[k] == 'n') nonum = true;
-      else if (a[k] == 'r') reverse = true;
-      else if (a[k] == 's') subst = true;
-      else if (a[k] == 'e') { if (i + 1 < argv.size()) i++; }  // editor: ignored
+      switch (a[k]) {
+        case 'l': list = true; break;
+        case 'n': nonum = true; break;
+        case 'r': reverse = true; break;
+        case 's': subst = true; break;
+        case 'e':
+          have_e = true;
+          if (k + 1 < a.size()) { ename = a.substr(k + 1); k = a.size(); }
+          else if (i + 1 < argv.size()) { ename = argv[i + 1]; consumed_next = true; }
+          break;
+        default:
+          std::fprintf(stderr, "%sfc: -%c: invalid option\n", sh.err_prefix().c_str(),
+                       a[k]);
+          std::fprintf(stderr, "%s\n", kUsage);
+          return 2;
+      }
     }
+    if (consumed_next) i++;
   }
+  // `fc -e -' is the re-execute-without-editing form: same as `fc -s'.
+  if (have_e && ename == "-") subst = true;
+
   HIST_ENTRY **hl = history_list();
   int n = 0;
   if (hl) while (hl[n]) n++;
   if (n == 0) return 0;
 
-  if (subst) {  // fc -s [old=new] [command]: re-run a previous command
-    std::string oldpat, newpat, match;
+  // The fc invocation's own entry (when it was recorded) is skipped: fc works
+  // on the commands before it (bash's hist_last_line_added).
+  bool self_recorded = sh.hist_cur_cmd_index >= 0 && sh.hist_cur_cmd_index == n - 1;
+  int last_hist = n - 1 - (self_recorded ? 1 : 0);
+  int real_last = n - 1;
+  if (last_hist < 0) last_hist = 0;
+
+  auto no_command = [&]() {
+    std::fprintf(stderr, "%sfc: no command found\n", sh.err_prefix().c_str());
+    return 1;
+  };
+  auto out_of_range = [&]() {
+    std::fprintf(stderr, "%sfc: history specification out of range\n",
+                 sh.err_prefix().c_str());
+    return 1;
+  };
+
+  // bash's fc_gethnum: resolve SPEC to a 0-based index.  Numeric specs clamp
+  // to the valid range (hn_first selects which end); `-0' is special.
+  auto gethnum = [&](const std::string &spec, bool hn_first) -> int {
+    const char *s = spec.c_str();
+    int sign = 1;
+    if (*s == '-') { sign = -1; s++; }
+    if (std::isdigit(static_cast<unsigned char>(*s))) {
+      const char *q = s;
+      while (std::isdigit(static_cast<unsigned char>(*q))) q++;
+      long v = std::atol(s) * sign;
+      (void)q;
+      if (v < 0) {
+        v += last_hist + 1;
+        return v < 0 ? 0 : static_cast<int>(v);
+      }
+      if (v == 0) return sign == -1 ? (list ? real_last : kInvalid) : last_hist;
+      v -= history_base;
+      if (v < 0) return hn_first ? 0 : last_hist;
+      if (v > last_hist) return hn_first ? 0 : last_hist;
+      return static_cast<int>(v);
+    }
+    for (int k = last_hist; k >= 0; k--)
+      if (std::strncmp(hl[k]->line, spec.c_str(), spec.size()) == 0) return k;
+    return kNotFound;
+  };
+
+  // Replace fc's own entry with the command it ran (bash's fc_replhist), or
+  // record the command when fc itself wasn't recorded.
+  auto replace_self = [&](const std::string &cmd) {
+    if (self_recorded) {
+      HIST_ENTRY *old = replace_history_entry(n - 1, cmd.c_str(), nullptr);
+      if (old) free_history_entry(old);
+    } else {
+      add_history(cmd.c_str());
+      sh.hist_new_entries++;
+    }
+  };
+
+  if (subst) {  // fc -s [pat=rep ...] [command]: re-run with substitutions
+    std::vector<std::pair<std::string, std::string>> subs;
+    std::string spec;
     for (; i < argv.size(); i++) {
       auto eq = argv[i].find('=');
-      if (eq != std::string::npos && oldpat.empty()) { oldpat = argv[i].substr(0, eq); newpat = argv[i].substr(eq + 1); }
-      else match = argv[i];
+      if (eq != std::string::npos && spec.empty())
+        subs.emplace_back(argv[i].substr(0, eq), argv[i].substr(eq + 1));
+      else
+        spec = argv[i];
     }
-    int idx = n - 1;  // most recent
-    if (!match.empty())
-      for (int k = n - 1; k >= 0; k--)
-        if (std::strncmp(hl[k]->line, match.c_str(), match.size()) == 0) { idx = k; break; }
+    int idx = spec.empty() ? last_hist : gethnum(spec, false);
+    if (idx < 0) return no_command();
     std::string cmd = hl[idx]->line;
-    if (!oldpat.empty()) {
-      auto p = cmd.find(oldpat);
-      if (p != std::string::npos) cmd.replace(p, oldpat.size(), newpat);
+    for (const auto &pr : subs) {          // each pat=rep applies globally
+      if (pr.first.empty()) continue;
+      size_t pos = 0;
+      while ((pos = cmd.find(pr.first, pos)) != std::string::npos) {
+        cmd.replace(pos, pr.first.size(), pr.second);
+        pos += pr.second.size();
+      }
     }
-    std::printf("%s\n", cmd.c_str());
-    add_history(cmd.c_str());
+    std::fprintf(stderr, "%s\n", cmd.c_str());
+    replace_self(cmd);
     return sh.run_string(cmd);
   }
 
-  // fc -l [first] [last]: list a range (default last 16).
-  int first = n - 16, last = n - 1;
-  std::vector<std::string> nums;
-  for (; i < argv.size(); i++) nums.push_back(argv[i]);
-  if (nums.size() >= 1) first = std::atoi(nums[0].c_str()) - history_base;
-  if (nums.size() >= 2) last = std::atoi(nums[1].c_str()) - history_base;
-  if (first < 0) first = 0;
-  if (last >= n) last = n - 1;
-  if (!list) list = true;  // default action without an editor is to list here
-  auto emit = [&](int k) {
-    if (nonum) std::printf("%s\n", hl[k]->line);
-    else std::printf("%d\t %s\n", history_base + k, hl[k]->line);
-  };
-  if (reverse) for (int k = last; k >= first; k--) emit(k);
-  else for (int k = first; k <= last; k++) emit(k);
-  return 0;
+  std::vector<std::string> specs;
+  for (; i < argv.size(); i++) specs.push_back(argv[i]);
+
+  int histbeg, histend;
+  if (!specs.empty()) {
+    histbeg = gethnum(specs[0], true);
+    if (specs.size() > 1)
+      histend = gethnum(specs[1], false);
+    else if (histbeg == real_last)
+      histend = list ? real_last : histbeg;
+    else
+      histend = list ? last_hist : histbeg;
+  } else if (list) {
+    histend = last_hist;
+    histbeg = histend - 16 + 1;
+    if (histbeg < 0) histbeg = 0;
+  } else {
+    histbeg = histend = last_hist;
+  }
+  if (histbeg == kInvalid || histend == kInvalid) return out_of_range();
+  if (histbeg == kNotFound || histend == kNotFound) return no_command();
+  if (histbeg > histend) { int t = histbeg; histbeg = histend; histend = t; reverse = !list || reverse; }
+
+  if (list) {
+    auto emit = [&](int k) {
+      if (nonum) std::printf("\t %s\n", hl[k]->line);
+      else std::printf("%d\t %s\n", history_base + k, hl[k]->line);
+    };
+    if (reverse) for (int k = histend; k >= histbeg; k--) emit(k);
+    else for (int k = histbeg; k <= histend; k++) emit(k);
+    return 0;
+  }
+
+  // fc [-e ename] [first] [last]: edit and re-execute.
+  std::string text;
+  if (reverse) for (int k = histend; k >= histbeg; k--) { text += hl[k]->line; text += '\n'; }
+  else for (int k = histbeg; k <= histend; k++) { text += hl[k]->line; text += '\n'; }
+
+  char tmpl[] = "/tmp/gnash_fc_XXXXXX";
+  int fd = mkstemp(tmpl);
+  if (fd < 0) return 1;
+  (void)!write(fd, text.data(), text.size());
+  close(fd);
+
+  if (!have_e) {
+    ename = sh.get("FCEDIT");
+    if (ename.empty()) ename = sh.get("EDITOR");
+    if (ename.empty()) ename = "vi";
+  }
+  // `fc -e -' re-executes without editing.
+  if (ename != "-") {
+    int est = sh.run_string(ename + " " + tmpl);
+    if (est != 0) { unlink(tmpl); return est; }
+  }
+
+  std::ifstream f(tmpl);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  unlink(tmpl);
+  std::string cmd = ss.str();
+  while (!cmd.empty() && cmd.back() == '\n') cmd.pop_back();
+  if (cmd.empty()) return 0;
+  std::printf("%s\n", cmd.c_str());
+  std::fflush(stdout);
+  replace_self(cmd);
+  return sh.run_string(cmd);
 }
 
 // ---- compgen / complete / compopt ----------------------------------------

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -289,7 +289,7 @@ int Executor::run(const Command *c) {
   // reached mid-script executes (turning noexec on), after which every later
   // command is skipped, and a subsequent `set +n' never runs to turn it back
   // off.  Ignored by interactive shells, exactly as bash does.
-  if (sh_.opt_noexec && !sh_.interactive) return sh_.last_status;
+  if (sh_.opt_noexec) return sh_.last_status;
 
   sh_.run_pending_traps();  // deliver any signals received between commands
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -15,6 +15,7 @@
 #include <cerrno>
 #include <csignal>
 #include <cstdio>
+#include <cstring>
 #include <cstdlib>
 #include <sys/wait.h>
 #include <termios.h>
@@ -44,6 +45,15 @@ void Shell::init_job_control(bool interactive_shell) {
     tcsetpgrp(job_terminal, shell_pgid);
     job_control = true;
   } else {
+    static bool warned = false;
+    if (interactive_shell && !warned) {
+      warned = true;
+      // Forced interactive (-i) without a terminal, as bash reports it (once).
+      std::fprintf(stderr, "%s: cannot set terminal process group (%d): %s\n",
+                   shell_name.c_str(), static_cast<int>(getpgrp()),
+                   std::strerror(ENOTTY));
+      std::fprintf(stderr, "%s: no job control in this shell\n", shell_name.c_str());
+    }
     job_control = false;
     shell_pgid = getpgrp();
   }

--- a/core/src/repl.cpp
+++ b/core/src/repl.cpp
@@ -263,8 +263,11 @@ int run_interactive(Shell &sh) {
 
   // The history file is $HISTFILE (set per-personality in main, e.g. the bash
   // persona defaults to ~/.bash_history), falling back to the built-in default.
+  // $HISTFILE set-but-empty means no history file at all; only an unset
+  // HISTFILE falls back to the default path.
   std::string histfile = sh.get("HISTFILE");
-  if (histfile.empty()) histfile = history_path();
+  if (!sh.is_set("HISTFILE")) histfile = history_path();
+  history_multiline_entries = sh.is_set("HISTTIMEFORMAT") ? 1 : 0;
   if (!histfile.empty()) read_history(histfile.c_str());
   using_history();
   // Interactive shells default to `-o history' and `-H'; the file was loaded
@@ -320,7 +323,7 @@ int run_interactive(Shell &sh) {
       continue;
     }
     if (!line) {  // Ctrl-D on an empty line
-      std::printf("exit\n");
+      std::fprintf(stderr, "exit\n");
       break;
     }
     std::string input(line);
@@ -374,10 +377,11 @@ int run_interactive(Shell &sh) {
     if (interrupted) continue;  // reprompt with PS1, discarding the partial command
 
     if (sh.opt_history && input.find_first_not_of(" \t\n") != std::string::npos)
-      sh.add_history_line(input);
+      sh.hist_cur_cmd_index = sh.add_history_line(input) ? history_length - 1 : -1;
     g_sigint_received = 0;  // start the command uninterrupted
     strmatch_set_interrupt(0);
     sh.run_string(input);
+    sh.hist_cur_cmd_index = -1;
     if (g_sigint_received) {  // C-c aborted the command mid-run: reprompt cleanly
       g_sigint_received = 0;
       strmatch_set_interrupt(0);
@@ -392,12 +396,19 @@ int run_interactive(Shell &sh) {
 
   // Save to the current $HISTFILE (a startup file may have changed it) and
   // truncate it to $HISTFILESIZE lines, as bash does on exit.
+  // bash saves only when $HISTFILE is set and non-empty at exit; an unset
+  // HISTFILE falls back to the startup default.
   std::string savefile = sh.get("HISTFILE");
-  if (savefile.empty()) savefile = histfile;
+  if (!sh.is_set("HISTFILE")) savefile = histfile;
   if (!savefile.empty()) {
+    // bash writes `#<epoch>' timestamp lines when HISTTIMEFORMAT is set.
+    history_write_timestamps = sh.is_set("HISTTIMEFORMAT") ? 1 : 0;
     write_history(savefile.c_str());
-    int hfs = std::atoi(sh.get("HISTFILESIZE").c_str());
-    if (hfs > 0) history_truncate_file(savefile.c_str(), hfs);
+    const std::string hfs_s = sh.get("HISTFILESIZE");
+    char *hfe = nullptr;
+    long hfs = std::strtol(hfs_s.c_str(), &hfe, 10);
+    if (!hfs_s.empty() && hfe && *hfe == '\0' && hfs >= 0)
+      history_truncate_file(savefile.c_str(), static_cast<int>(hfs));
   }
   int rc = sh.exiting ? sh.exit_status : sh.last_status;
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -559,10 +559,13 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     return false;
   }
   var.value = v;
-  // Assigning HISTSIZE re-stifles the loaded history list, as bash does.
+  // Assigning HISTSIZE re-stifles the loaded history list, as bash does; a
+  // non-numeric or empty value leaves the list unbounded.
   if (n == "HISTSIZE" && history_loaded) {
-    int hs = std::atoi(v.c_str());
-    if (hs >= 0) stifle_history(hs);
+    char *e = nullptr;
+    long hv = std::strtol(v.c_str(), &e, 10);
+    if (!v.empty() && e && *e == '\0' && hv >= 0) stifle_history(static_cast<int>(hv));
+    else unstifle_history();
   }
   return true;
 }
@@ -578,6 +581,7 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
 void Shell::export_name(const std::string &n) { vars[n].exported = true; }
 
 void Shell::unset(const std::string &n_in) {
+  if (n_in == "HISTSIZE" && history_loaded) unstifle_history();
   // `unset name' on a nameref removes the target; only `unset -n' (not modeled
   // here) removes the nameref itself.  Following the ref matches common usage.
   std::string n = deref(n_in);
@@ -730,11 +734,14 @@ void Shell::enable_history() {
   if (history_loaded) return;
   history_loaded = true;
   using_history();
+  history_multiline_entries = is_set("HISTTIMEFORMAT") ? 1 : 0;
   std::string hf = get("HISTFILE");
   if (!hf.empty()) read_history(hf.c_str());
   if (is_set("HISTSIZE")) {
-    int hs = std::atoi(get("HISTSIZE").c_str());
-    if (hs >= 0) stifle_history(hs);
+    const std::string hs = get("HISTSIZE");
+    char *e = nullptr;
+    long v = std::strtol(hs.c_str(), &e, 10);
+    if (!hs.empty() && e && *e == '\0' && v >= 0) stifle_history(static_cast<int>(v));
   }
   using_history();
 }
@@ -790,11 +797,19 @@ bool Shell::add_history_line(const std::string &line) {
   return true;
 }
 
-void Shell::append_history_line(const std::string &line) {
+void Shell::append_history_line(const std::string &line, bool heredoc) {
   if (history_length == 0) return;
   HIST_ENTRY *e = history_get(history_base + history_length - 1);
   if (e == nullptr || e->line == nullptr) return;
   std::string cur = e->line;
+
+  if (heredoc) {  // keep the document's line structure
+    std::string joined = cur + "\n" + line;
+    using_history();
+    HIST_ENTRY *old = replace_history_entry(history_length - 1, joined.c_str(), e->data);
+    if (old) free_history_entry(old);
+    return;
+  }
 
   // Join with bash's history_delimiting_chars, approximately: no semicolon
   // after an operator or after a keyword that a command follows directly.
@@ -825,9 +840,12 @@ void Shell::append_history_line(const std::string &line) {
   if (old) free_history_entry(old);
 }
 
-// True if TEXT ends inside a quoted string, command/process substitution, or
-// backquotes -- contexts where bash does not history-expand continuation lines.
-static bool in_open_context(const std::string &t) {
+// Where TEXT ends: inside a quoted string, inside a command/process
+// substitution or backquotes, or in neither.  Used to decide whether bash
+// would history-expand a continuation line and how it joins the command's
+// history entry.
+enum class OpenCtx { None, Quote, Subst };
+static OpenCtx open_context(const std::string &t) {
   bool squote = false, dquote = false;
   int depth = 0;
   for (size_t i = 0; i < t.size(); i++) {
@@ -843,7 +861,8 @@ static bool in_open_context(const std::string &t) {
     }
     if (c == ')' && depth > 0) depth--;
   }
-  return squote || dquote || depth > 0;
+  if (squote || dquote) return OpenCtx::Quote;
+  return depth > 0 ? OpenCtx::Subst : OpenCtx::None;
 }
 
 int Shell::run_script_lines(const std::string &text) {
@@ -855,11 +874,13 @@ int Shell::run_script_lines(const std::string &text) {
   std::string pending;
   bool cont_bslash = false;  // previous line ended in a line continuation
   bool first_line_saved = false;  // this command's first line is in the history
+  bool in_heredoc = false;   // the pending command has an open here-document
   int st = last_status;
 
   auto flush = [&]() {
     cont_bslash = false;
     first_line_saved = false;
+    in_heredoc = false;
     if (pending.find_first_not_of(" \t\n") == std::string::npos) {
       pending.clear();
       return;
@@ -867,6 +888,7 @@ int Shell::run_script_lines(const std::string &text) {
     lineno_base = pending_line - 1;
     st = run_string(pending);
     lineno_base = 0;
+    hist_cur_cmd_index = -1;
     pending.clear();
   };
 
@@ -883,7 +905,8 @@ int Shell::run_script_lines(const std::string &text) {
     // pre_process_line): `!' expansion with the expanded line echoed to
     // stderr, then recorded in the history -- all before execution.
     if (opt_history && line.find_first_not_of(" \t") != std::string::npos) {
-      if (opt_histexpand && (fresh || !in_open_context(pending))) {
+      OpenCtx ctx = fresh ? OpenCtx::None : open_context(pending);
+      if (opt_histexpand && ctx == OpenCtx::None) {
         sync_histchars();
         cur_lineno = lineno;  // the expansion error prefix names this line
         // Expanding a later line of a multi-line command: history references
@@ -916,12 +939,17 @@ int Shell::run_script_lines(const std::string &text) {
       }
       if (fresh) {
         first_line_saved = add_history_line(line);
+        hist_cur_cmd_index = first_line_saved ? history_length - 1 : -1;
       } else if (first_line_saved &&
-                 !(line.find_first_not_of(" \t") != std::string::npos &&
-                   line[line.find_first_not_of(" \t")] == '#')) {
+                 (in_heredoc || ctx == OpenCtx::Quote ||
+                  !(line.find_first_not_of(" \t") != std::string::npos &&
+                    line[line.find_first_not_of(" \t")] == '#'))) {
         // shopt cmdhist: later lines of the command extend its history entry
-        // (pure comment lines are not appended).
-        append_history_line(line);
+        // (pure comment lines are not appended).  Here-document lines and
+        // lines continuing a quoted string keep their line structure:
+        // newline joins, with a here-document body's trailing newline
+        // preserved when the delimiter closes it.
+        append_history_line(line, in_heredoc || ctx == OpenCtx::Quote);
       }
     }
 
@@ -939,7 +967,16 @@ int Shell::run_script_lines(const std::string &text) {
     }
     cont_bslash = false;
 
-    if (pos < text.size() && parse(pending).incomplete) continue;
+    if (pos < text.size()) {
+      ParseResult chk = parse(pending);
+      bool was_heredoc = in_heredoc;
+      in_heredoc = chk.heredoc_eof;
+      if (was_heredoc && !in_heredoc && first_line_saved)
+        append_history_line("", true);  // the closing delimiter's newline
+      if (chk.incomplete) continue;
+    } else {
+      in_heredoc = false;
+    }
     flush();
   }
   if (!exiting) flush();  // whatever remains (an incomplete tail still errors)

--- a/include/gnash/history.hpp
+++ b/include/gnash/history.hpp
@@ -107,6 +107,9 @@ class History {
   // -- tunables (mirror the exported history_* globals) -------------------
   char comment_char = '#';
   bool write_timestamps = false;
+  // Group non-timestamp lines into multi-line entries when reading a file
+  // that carries timestamps (bash: $HISTTIMEFORMAT is set).
+  bool multiline_entries = false;
   int lines_read_from_file = 0;
   int lines_written_to_file = 0;
 

--- a/libhistory/src/histfile.cpp
+++ b/libhistory/src/histfile.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "gnash/history.hpp"
+#include "gnash/sh/xmalloc.hpp"
 
 namespace gnash::history {
 
@@ -83,21 +84,49 @@ int History::read_file_range(const char *filename, int from, int to) {
   int last = (to < from) ? nlines : to;
   if (last > nlines) last = nlines;
 
+  // When the file carries `#<epoch>' timestamp lines and multiline entries
+  // are enabled (bash: $HISTTIMEFORMAT is set), the timestamps delimit the
+  // entries: the lines between two timestamps are one entry joined with
+  // newlines, with each group's leading blank lines dropped.
+  bool has_timestamps = false;
+  for (int i = from; i < last; i++)
+    if (is_timestamp_line(lines[static_cast<std::size_t>(i)], comment_char)) {
+      has_timestamps = true;
+      break;
+    }
+  const bool group = multiline_entries && has_timestamps;
+
   std::string pending_ts;
   bool have_ts = false;
+  bool in_entry = false;  // grouping: the current entry has begun
   int count = 0;
   for (int i = from; i < last; i++) {
     const std::string &ln = lines[static_cast<std::size_t>(i)];
     if (is_timestamp_line(ln, comment_char)) {
       pending_ts = ln;
       have_ts = true;
+      in_entry = false;
       continue;
     }
+    if (group && in_entry) {  // continuation of the current entry
+      Entry *e = entries_.empty() ? nullptr : entries_.back();
+      if (e) {
+        std::string joined = e->line ? e->line : "";
+        joined += '\n';
+        joined += ln;
+        gnash::sh::xfree(e->line);
+        e->line = gnash::sh::savestring(joined.c_str());
+        continue;
+      }
+    }
+    if (group && !in_entry && ln.find_first_not_of(" \t") == std::string::npos)
+      continue;  // leading blank lines of a group are dropped
     add(ln);
     if (have_ts) {
       add_time(pending_ts);
       have_ts = false;
     }
+    in_entry = true;
     count++;
   }
 
@@ -167,7 +196,10 @@ int History::truncate_file(const char *filename, int nlines) {
   if (nlines >= total) return 0;  // nothing to trim
 
   int keep_from_entry = total - nlines;
-  int start_line = entry_idx[static_cast<std::size_t>(keep_from_entry)];
+  // nlines == 0 keeps nothing: truncate the file to empty.
+  int start_line = keep_from_entry >= total
+                       ? static_cast<int>(lines.size())
+                       : entry_idx[static_cast<std::size_t>(keep_from_entry)];
   // Keep an immediately-preceding timestamp line with its entry.
   if (start_line > 0 &&
       is_timestamp_line(lines[static_cast<std::size_t>(start_line - 1)], comment_char))

--- a/libhistory/src/shim.cpp
+++ b/libhistory/src/shim.cpp
@@ -30,6 +30,7 @@ int history_lines_read_from_file = 0;
 int history_lines_written_to_file = 0;
 char history_comment_char = '#';
 int history_write_timestamps = 0;
+int history_multiline_entries = 0;
 int max_input_history = 0;
 }
 
@@ -40,6 +41,7 @@ History &H() {
   History &h = default_history();
   h.comment_char = history_comment_char;
   h.write_timestamps = history_write_timestamps != 0;
+  h.multiline_entries = history_multiline_entries != 0;
   return h;
 }
 

--- a/libreadline/src/isearch.cpp
+++ b/libreadline/src/isearch.cpp
@@ -9,6 +9,7 @@
 // accepts, C-g aborts (restoring the original line), C-r/C-s repeat, DEL trims.
 
 #include <cstdio>
+#include <unistd.h>
 #include <cstring>
 #include <string>
 
@@ -42,7 +43,7 @@ int isearch(int dir) {
   std::string orig(rl_line_buffer, static_cast<size_t>(rl_end));
   std::string ss;
   int matchpos = -1;  // history index currently displayed, -1 = none yet
-  bool tty = rl_outstream != nullptr;
+  bool tty = rl_outstream != nullptr && isatty(fileno(rl_outstream));
 
   for (;;) {
     if (tty) show(dir, ss);
@@ -55,6 +56,7 @@ int isearch(int dir) {
       return 0;
     }
     if (c == '\r' || c == '\n') {  // accept
+      if (matchpos >= 0) history_set_pos(matchpos);
       rl_done = 1;
       return 0;
     }
@@ -74,7 +76,12 @@ int isearch(int dir) {
       ss.push_back(static_cast<char>(c));
       start = (matchpos < 0) ? ((dir < 0) ? history_length - 1 : 0) : matchpos;
     } else {
-      // Any other key terminates the search, leaving the found line.
+      // Any other key terminates the search, leaving the found line; the key
+      // itself is executed as a normal command (as GNU readline does).  The
+      // history position moves to the match so commands like C-o and C-p
+      // continue from it.
+      if (matchpos >= 0) history_set_pos(matchpos);
+      gnash::readline::stuff_input(std::string(1, static_cast<char>(c)));
       return 0;
     }
 
@@ -117,7 +124,7 @@ std::string nsearch_string;
 
 // Read the search string; false if the user aborted.
 bool nsearch_read(int pchar) {
-  FILE *o = rl_outstream;
+  FILE *o = (rl_outstream && isatty(fileno(rl_outstream))) ? rl_outstream : nullptr;
   std::string s;
   for (;;) {
     if (o) {

--- a/libreadline/src/misc.cpp
+++ b/libreadline/src/misc.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <cstdio>
 #include <cstring>
+#include <unistd.h>
 #include <string>
 #include <vector>
 
@@ -200,7 +201,7 @@ extern "C" int rl_re_read_init_file(int /*count*/, int /*key*/) {
 
 extern "C" int rl_execute_named_command(int count, int /*key*/) {
   FILE *o = rl_outstream ? rl_outstream : stdout;
-  bool tty = rl_outstream != nullptr;
+  bool tty = isatty(fileno(o));
   std::string name;
 
   for (;;) {

--- a/libreadline/src/readline.cpp
+++ b/libreadline/src/readline.cpp
@@ -443,7 +443,9 @@ extern "C" char *readline(const char *prompt) {
   if (saved_history_offset >= 0) {
     int back = where_history() - (saved_history_offset - history_base);
     saved_history_offset = -1;
-    if (back > 0) rl_get_previous_history(back, 0);
+    // A non-positive count moves forward -- the position can already be
+    // before the target (e.g. after an incremental search).
+    if (back != 0) rl_get_previous_history(back, 0);
   }
 
   rl_last_func = nullptr;  // a new line: nothing was dispatched before it
@@ -470,6 +472,11 @@ extern "C" char *readline(const char *prompt) {
     if (sigaction(SIGINT, &sa, &old_int) == 0) int_installed = true;
     prep_terminal(fd);
     rl_redisplay();
+  } else {
+    // Interactive on a non-terminal (bash -i on a pipe): the prompt goes to
+    // stderr, and the accepted line is echoed after it.
+    std::fputs(rl_prompt, stderr);
+    std::fflush(stderr);
   }
 
   while (!rl_done) {
@@ -499,6 +506,9 @@ extern "C" char *readline(const char *prompt) {
     std::fputc('\n', rl_outstream);
     std::fflush(rl_outstream);
     if (int_installed) sigaction(SIGINT, &old_int, nullptr);
+  } else if (!(rl_eof_found && rl_end == 0) && !rl_pending_sigint) {
+    std::fprintf(stderr, "%s\n", rl_line_buffer);
+    std::fflush(stderr);
   }
 
   if (rl_pending_sigint) return gnash::sh::savestring("");  // discarded line


### PR DESCRIPTION
Fixes #69.

With this PR, gnash's output for bash 5.3's `tests/history.tests` is **byte-identical to bash's** in the same environment (the only residual differences are the program name and the run-varying pid inside bash's job-control warning — which differ between two bash runs as well). Together with the previous two PRs, all three readline-domain files in bash's suite — `read.tests`, `histexp.tests`, `history.tests` — now match byte-for-byte. All 22 ctest suites and 221 differential scripts pass, and interactive behavior was smoke-tested under a pty.

**history builtin**: option validation with bash's usage/error texts, `-d` ranges and negative offsets with bash's out-of-range/invalid-number error split, `-a` appending only new entries.

**fc builtin** (rewritten around `fc.def`): excludes and replaces its own history entry (`fc -s` used to re-run itself in an infinite loop), global multi-`pat=rep` substitution, `fc -e ename` edit-and-rerun, `fc -e -`, `fc_gethnum` spec resolution (clamping, `-0`, prefix searches), `fc -l` defaulting and formats.

**Shell wiring**: `shopt -o`; HISTSIZE/HISTFILESIZE/HISTFILE edge semantics (incl. an out-of-bounds read in `truncate_file` and exit-saves clobbering files when `HISTFILE=` was empty); command-line `-n` honored interactively; bash's interactive-on-a-pipe behavior (stderr prompts/echo/exit + job-control warnings); `HISTTIMEFORMAT` timestamp lines on write and multi-line entry grouping on read.

**readline**: incremental search moves the history position to the match and re-dispatches its terminator key, making `C-r` + `C-o` (operate-and-get-next) chains replay successive history lines as bash does.