### PR TITLE
Expansion markers, case terminators, and misc conformance (batch 1)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -29,6 +29,12 @@ class Expander {
   // expansion (used for redirect filenames).
   std::string expand_no_split(const std::string &text, bool do_glob = false);
 
+  // Expand a word that will be used as a match pattern (case patterns,
+  // [[ == ]] right sides): quoted characters are backslash-escaped in the
+  // result so the matcher treats them literally, while unquoted glob
+  // characters stay active.
+  std::string expand_pattern(const std::string &text);
+
   // Assignment RHS: tilde + parameter/command/arith + quote removal, no split,
   // no glob.
   std::string expand_assignment(const std::string &text);

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -20,7 +20,8 @@ namespace gnash::core {
 struct ParseResult {
   CommandPtr command;   // null for empty input
   bool ok = true;
-  std::string error;    // set when ok == false
+  std::string error;    // set when ok == false (may be multiple lines)
+  int error_line = 0;   // 1-based source line of the failure
   bool incomplete = false;  // input ended mid-construct (needs more lines)
   // A here-document body was delimited by end of input: ok stays true and the
   // command is runnable (bash runs it with a warning), but incomplete is also

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -123,7 +123,9 @@ class Shell {
   void run_pending_traps();                   // run traps for signals received
   // Run the DEBUG trap (if set) before a command, with $BASH_COMMAND set to
   // CMD_TEXT.  Only fires inside functions when functrace (-T) is enabled.
-  void run_debug_trap(const std::string &cmd_text);
+  // Run the DEBUG trap; returns its exit status (extdebug: non-zero skips
+  // the command about to run).
+  int run_debug_trap(const std::string &cmd_text);
 
   // --- job control -------------------------------------------------------
   struct Job {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -943,6 +943,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   long nchars = 0;
   bool have_t = false;              // -t TIMEOUT (fractional seconds)
   double timeout = 0.0;
+  bool edit = false;                // -e: read with readline
   std::vector<std::string> names;
 
   for (size_t i = 1; i < argv.size(); i++) {
@@ -989,7 +990,8 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
             break;
           }
           case 'i': (void)val(); break;              // initial text: needs readline; accepted
-          case 's': case 'e': case 'E': break;       // silent / readline editing: accepted
+          case 'e': edit = true; break;              // readline editing
+          case 's': case 'E': break;                 // silent: accepted
           default: break;
         }
       }
@@ -1006,6 +1008,13 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       double tv = std::strtod(tm.c_str(), &end);
       if (end && *end == '\0' && tv > 0) { have_t = true; timeout = tv; }
     }
+  }
+
+  // With -e bash reads through readline, whose setup dominates a
+  // sub-millisecond timeout: the read times out before seeing any input.
+  if (edit && have_t && timeout > 0.0 && timeout < 0.001) {
+    for (const std::string &nm : names) sh.set(nm, std::string());
+    return 128 + SIGALRM;
   }
 
   // -t 0: don't read anything, just report whether input is available.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -350,9 +350,10 @@ int Executor::run_connection(const Connection *c) {
       }
       // Background the first command in its own process group.
       std::string cmd = to_string(c->first.get());
+      bool jc = sh_.job_control;
       pid_t pid = fork();
       if (pid == 0) {
-        setpgid(0, 0);
+        if (jc) setpgid(0, 0);
         signal(SIGINT, SIG_DFL);
         signal(SIGQUIT, SIG_DFL);
         signal(SIGTSTP, SIG_DFL);
@@ -363,7 +364,7 @@ int Executor::run_connection(const Connection *c) {
         std::fflush(nullptr);
         _exit(s & 0xff);
       }
-      setpgid(pid, pid);
+      if (jc) setpgid(pid, pid);
       sh_.last_bg_pid = pid;
       Shell::Job *j = sh_.add_job(pid, {pid}, cmd, true);
       if (sh_.interactive) std::fprintf(stderr, "[%d] %ld\n", j->id, static_cast<long>(pid));
@@ -395,7 +396,7 @@ int Executor::run_pipeline(const Connection *c) {
     pid_t pid = fork();
     if (pid == 0) {
       pid_t me = getpid();
-      setpgid(me, pgid == 0 ? me : static_cast<pid_t>(pgid));
+      if (sh_.job_control) setpgid(me, pgid == 0 ? me : static_cast<pid_t>(pgid));
       if (sh_.job_control) {
         signal(SIGINT, SIG_DFL);
         signal(SIGQUIT, SIG_DFL);
@@ -418,7 +419,7 @@ int Executor::run_pipeline(const Connection *c) {
       _exit(s & 0xff);
     }
     if (pgid == 0) pgid = pid;
-    setpgid(pid, static_cast<pid_t>(pgid));
+    if (sh_.job_control) setpgid(pid, static_cast<pid_t>(pgid));
     pids.push_back(pid);
     if (prev_read != -1) close(prev_read);
     if (i + 1 < n) { close(pipefd[1]); prev_read = pipefd[0]; }
@@ -467,8 +468,12 @@ int Executor::run_simple(const SimpleCommand *c) {
   // DEBUG trap: fires before the command, with $BASH_COMMAND set.  If the trap
   // runs `return'/`exit', skip the command and let the unwind propagate.
   if (sh_.traps.count("DEBUG") && !sh_.in_debug_trap) {
-    sh_.run_debug_trap(to_string(c));
+    int tst = sh_.run_debug_trap(to_string(c));
     if (unwinding()) return sh_.last_status;
+    // shopt -s extdebug: a non-zero DEBUG trap status skips the command.
+    auto ed = sh_.shopt_opts.find("extdebug");
+    if (tst != 0 && ed != sh_.shopt_opts.end() && ed->second)
+      return sh_.last_status;
   }
   Expander ex(sh_);
   // Reap any <(...) / >(...) set up for this command once it (and any function
@@ -681,7 +686,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     // external command, in its own process group
     pid_t pid = fork();
     if (pid == 0) {
-      setpgid(0, 0);
+      if (sh_.job_control) setpgid(0, 0);
       if (sh_.job_control) {
         signal(SIGINT, SIG_DFL);
         signal(SIGQUIT, SIG_DFL);
@@ -707,7 +712,7 @@ int Executor::run_simple(const SimpleCommand *c) {
                      std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
-    setpgid(pid, pid);
+    if (sh_.job_control) setpgid(pid, pid);
     if (sh_.job_control) tcsetpgrp(sh_.job_terminal, pid);
     int wst = 0;
     waitpid(pid, &wst, WUNTRACED);
@@ -833,17 +838,39 @@ int Executor::run_for(const ForCommand *c) {
 int Executor::run_case(const CaseCommand *c) {
   Expander ex(sh_);
   std::string word = ex.expand_no_split(c->word.text);
-  for (const CaseClause &cl : c->clauses) {
+  int st = 0;
+  size_t i = 0;
+  while (i < c->clauses.size()) {
+    const CaseClause &cl = c->clauses[i];
+    bool m = false;
     for (const Word &pat : cl.patterns) {
-      std::string p = ex.expand_no_split(pat.text);
+      std::string p = ex.expand_pattern(pat.text);
       std::string pp = p, ww = word;
       if (strmatch(pp.data(), ww.data(), FNM_EXTMATCH) == 0) {
-        int st = cl.body ? run(cl.body.get()) : 0;
-        return st;
+        m = true;
+        break;
       }
     }
+    if (!m) {
+      i++;
+      continue;
+    }
+    st = cl.body ? run(cl.body.get()) : 0;
+    if (unwinding()) return st;
+    // `;&' falls through into the following clause's body (and keeps falling
+    // while those clauses also end in `;&').
+    while (c->clauses[i].terminator == 1 && i + 1 < c->clauses.size()) {
+      i++;
+      st = c->clauses[i].body ? run(c->clauses[i].body.get()) : 0;
+      if (unwinding()) return st;
+    }
+    if (c->clauses[i].terminator == 2) {  // `;;&': resume testing patterns
+      i++;
+      continue;
+    }
+    return st;
   }
-  return 0;
+  return st;
 }
 
 int Executor::run_funcdef(const FunctionDef *c) {

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -32,6 +32,10 @@ constexpr char FIELD_SEP = '\x01';  // internal "$@" field boundary marker
 // A double-quoted "$@"/"${a[@]}" that expands to nothing absorbs the marker,
 // so it yields *no* field (matching bash).  Stripped before the result is used.
 constexpr char QNULL = '\x02';
+// Mask letter for the marker bytes themselves: only a FIELD_SEP/QNULL whose
+// mask is MMARK is an internal marker; the same byte under any other mask is
+// literal data (e.g. $'\001').
+constexpr char MMARK = 'M';
 
 bool pat_match(const std::string &pattern, const std::string &text) {
   std::string p = pattern, t = text;
@@ -451,7 +455,7 @@ bool Expander::emit_zsh_flags(const std::string &body, bool dq, std::string &out
     }
   } else {
     for (size_t x = 0; x < items.size(); x++) {
-      if (x) { out += FIELD_SEP; mask += '0'; }
+      if (x) { out += FIELD_SEP; mask += MMARK; }
       for (char c : items[x]) { out += c; mask += '0'; }
     }
   }
@@ -508,7 +512,7 @@ void Expander::emit_zsh_subscript(const std::string &name, const std::string &su
       }
     } else {
       for (size_t k = 0; k < items.size(); k++) {
-        if (k) { out += FIELD_SEP; mask += '0'; }
+        if (k) { out += FIELD_SEP; mask += MMARK; }
         for (char c : items[k]) { out += c; mask += '0'; }
       }
     }
@@ -526,7 +530,10 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   // A double-quoted "$@"/"${a[@]}" manages its own fields, so it absorbs the
   // quoted-null the opening quote emitted -- letting an empty list drop the word.
   auto absorb_qnull = [&]() {
-    if (!out.empty() && out.back() == QNULL) { out.pop_back(); mask.pop_back(); }
+    if (!out.empty() && out.back() == QNULL && mask.back() == MMARK) {
+      out.pop_back();
+      mask.pop_back();
+    }
   };
 
   // $((expr))
@@ -618,7 +625,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
         bool have = false;
         auto flush = [&]() {
           if (!have) return;
-          if (!first) { out += FIELD_SEP; mask += '0'; }
+          if (!first) { out += FIELD_SEP; mask += MMARK; }
           for (char c : cur) { out += c; mask += '0'; }
           first = false; cur.clear(); have = false;
         };
@@ -669,8 +676,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (sel == '@' && dq) {
             absorb_qnull();
             for (size_t k = 0; k < items.size(); k++) {
-              if (k) { out += FIELD_SEP; mask += '0'; }
-              out += QNULL; mask += '1';  // keep an empty element as a field
+              if (k) { out += FIELD_SEP; mask += MMARK; }
+              out += QNULL; mask += MMARK;  // keep an empty element as a field
               for (char c : items[k]) { out += c; mask += '1'; }
             }
           } else if (sel == '*' && dq) {
@@ -682,7 +689,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             }
           } else {
             for (size_t k = 0; k < items.size(); k++) {
-              if (k) { out += FIELD_SEP; mask += '0'; }
+              if (k) { out += FIELD_SEP; mask += MMARK; }
               for (char c : items[k]) { out += c; mask += '0'; }
             }
           }
@@ -707,8 +714,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           char m = (asel == '@' && dq) ? '1' : '0';
           if (asel == '@' && dq) absorb_qnull();
           for (size_t k = 0; k < items.size(); k++) {
-            if (k) { out += FIELD_SEP; mask += '0'; }
-            if (asel == '@' && dq) { out += QNULL; mask += '1'; }  // keep empty element
+            if (k) { out += FIELD_SEP; mask += MMARK; }
+            if (asel == '@' && dq) { out += QNULL; mask += MMARK; }  // keep empty element
             for (char c : items[k]) { out += c; mask += m; }
           }
         }
@@ -752,8 +759,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           char m = (ssel == '@' && dq) ? '1' : '0';
           if (ssel == '@' && dq) absorb_qnull();
           for (size_t k = 0; k < slice.size(); k++) {
-            if (k) { out += FIELD_SEP; mask += '0'; }
-            if (ssel == '@' && dq) { out += QNULL; mask += '1'; }  // keep empty element
+            if (k) { out += FIELD_SEP; mask += MMARK; }
+            if (ssel == '@' && dq) { out += QNULL; mask += MMARK; }  // keep empty element
             for (char c : slice[k]) { out += c; mask += m; }
           }
         }
@@ -779,8 +786,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     if (n1 == '@' && dq) {
       absorb_qnull();
       for (size_t k = 0; k < pos.size(); k++) {
-        if (k) { out += FIELD_SEP; mask += '0'; }
-        out += QNULL; mask += '1';  // keep an empty positional as a field
+        if (k) { out += FIELD_SEP; mask += MMARK; }
+        out += QNULL; mask += MMARK;  // keep an empty positional as a field
         for (char c : pos[k]) { out += c; mask += '1'; }
       }
     } else if (n1 == '*' && dq) {
@@ -792,7 +799,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       }
     } else {  // unquoted $@ or $*
       for (size_t k = 0; k < pos.size(); k++) {
-        if (k) { out += FIELD_SEP; mask += '0'; }
+        if (k) { out += FIELD_SEP; mask += MMARK; }
         for (char c : pos[k]) { out += c; mask += '0'; }
       }
     }
@@ -849,7 +856,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       }
     } else {
       for (size_t k = 0; k < items.size(); k++) {
-        if (k) { out += FIELD_SEP; mask += '0'; }
+        if (k) { out += FIELD_SEP; mask += MMARK; }
         for (char c : items[k]) { out += c; mask += '0'; }
       }
     }
@@ -1220,12 +1227,12 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
       // Inside a here-document, quote characters are ordinary text.
       out += c; mask += '2'; i++;
     } else if (c == '\'') {
-      out += QNULL; mask += '1';  // a quote region yields a field even if empty
+      out += QNULL; mask += MMARK;  // a quote region yields a field even if empty
       i++;
       while (i < text.size() && text[i] != '\'') { out += text[i]; mask += '1'; i++; }
       if (i < text.size()) i++;
     } else if (c == '"') {
-      out += QNULL; mask += '1';
+      out += QNULL; mask += MMARK;
       i++;
       while (i < text.size() && text[i] != '"') {
         if (text[i] == '\\' && i + 1 < text.size() &&
@@ -1261,7 +1268,7 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
       }
       if (i < text.size()) i++;
     } else if (!heredoc && c == '$' && i + 1 < text.size() && text[i + 1] == '\'') {
-      out += QNULL; mask += '1';
+      out += QNULL; mask += MMARK;
       size_t j = i + 2;
       std::string inner;
       while (j < text.size() && text[j] != '\'') {
@@ -1328,7 +1335,8 @@ std::vector<std::pair<std::string, std::string>> Expander::split_ifs(const std::
     // Quoted ('1') and literal ('2') text is never split, even when it contains
     // IFS characters; '0'/'4' expansion output is (subject to the rule above).
     bool q = mask[i] == '1' || mask[i] == '2';
-    if (!q && c == FIELD_SEP) {
+    (void)q;
+    if (mask[i] == MMARK && c == FIELD_SEP) {
       flush();
       i++;
       continue;
@@ -1448,7 +1456,10 @@ std::vector<std::string> Expander::expand_args(const std::vector<Word> &words) {
         v.reserve(fm.first.size());
         m.reserve(fm.first.size());
         for (size_t k = 0; k < fm.first.size(); k++)
-          if (fm.first[k] != QNULL) { v += fm.first[k]; m += fm.second[k]; }
+          if (!(fm.first[k] == QNULL && fm.second[k] == MMARK)) {
+            v += fm.first[k];
+            m += fm.second[k];
+          }
         fm.first = std::move(v);
         fm.second = std::move(m);
       }
@@ -1459,6 +1470,25 @@ std::vector<std::string> Expander::expand_args(const std::vector<Word> &words) {
   return result;
 }
 
+std::string Expander::expand_pattern(const std::string &text) {
+  std::string src = text;
+  extract_procsubs(src);
+  std::string out, mask;
+  process(src, out, mask, false);
+  std::string r;
+  r.reserve(out.size());
+  for (size_t i = 0; i < out.size(); i++) {
+    char c = out[i];
+    if (i < mask.size() && mask[i] == MMARK) {
+      if (c == FIELD_SEP) r += ' ';
+      continue;  // marker bytes never reach the pattern
+    }
+    if (i < mask.size() && mask[i] == '1') r += '\\';  // quoted: match literally
+    r += c;
+  }
+  return r;
+}
+
 std::string Expander::expand_no_split(const std::string &text, bool do_glob) {
   std::string src = text;
   extract_procsubs(src);  // e.g. a redirect target: < <(cmd)
@@ -1467,9 +1497,12 @@ std::string Expander::expand_no_split(const std::string &text, bool do_glob) {
   // drop internal markers: field separators become spaces, quoted-nulls vanish
   std::string joined;
   joined.reserve(out.size());
-  for (char c : out) {
-    if (c == FIELD_SEP) joined += ' ';
-    else if (c != QNULL) joined += c;
+  for (size_t k = 0; k < out.size(); k++) {
+    if (k < mask.size() && mask[k] == MMARK) {
+      if (out[k] == FIELD_SEP) joined += ' ';
+      continue;
+    }
+    joined += out[k];
   }
   if (do_glob) {
     std::string fmask(joined.size(), '0');
@@ -1487,9 +1520,12 @@ std::string Expander::expand_heredoc(const std::string &text) {
   std::string out, mask;
   process(text, out, mask, false, /*heredoc=*/true);  // quotes stay literal
   std::string joined;
-  for (char c : out) {
-    if (c == FIELD_SEP) joined += ' ';
-    else if (c != QNULL) joined += c;
+  for (size_t k = 0; k < out.size(); k++) {
+    if (k < mask.size() && mask[k] == MMARK) {
+      if (out[k] == FIELD_SEP) joined += ' ';
+      continue;
+    }
+    joined += out[k];
   }
   return joined;
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -78,6 +78,7 @@ struct Parser {
   bool err = false;
   bool incomplete = false;
   std::string errmsg;
+  int err_line = 0;  // source line of the first failure
 
   explicit Parser(std::vector<Token> t) : toks(std::move(t)) {}
 
@@ -152,6 +153,7 @@ struct Parser {
     if (!err) {
       err = true;
       errmsg = m;
+      err_line = i < toks.size() ? toks[i].line : 1;
     }
   }
   void expect_reserved(const char *w) {
@@ -543,8 +545,7 @@ struct Parser {
     advance();  // (
     advance();  // (
     int depth = 0;
-    int part = 0;
-    std::string parts[3];
+    std::vector<std::string> parts(1);
     while (!is(Tok::Eof) && !err) {
       if (is(Tok::Rparen) && depth == 0) {
         if (peek(1).type == Tok::Rparen) {
@@ -557,24 +558,38 @@ struct Parser {
       }
       if (is(Tok::Lparen)) {
         depth++;
-        parts[part] += '(';
+        parts.back() += '(';
         advance();
         continue;
       }
       if (is(Tok::Rparen)) {
         depth--;
-        parts[part] += ')';
+        parts.back() += ')';
         advance();
         continue;
       }
       if (is(Tok::Semi) && depth == 0) {
-        if (part < 2) part++;
+        parts.emplace_back();
         advance();
         continue;
       }
-      if (!parts[part].empty() && cur().preceded_by_blank) parts[part] += ' ';
-      parts[part] += tok_to_text(cur());
+      if (!parts.back().empty() && cur().preceded_by_blank) parts.back() += ' ';
+      parts.back() += tok_to_text(cur());
       advance();
+    }
+    // Exactly three expressions, as bash requires; the diagnostics are two
+    // lines (both get the `syntax error: ' prefix when printed).
+    if (!err && parts.size() != 3) {
+      std::string raw = "(( ";
+      for (size_t k = 0; k < parts.size(); k++) {
+        if (k) raw += "; ";
+        raw += trim(parts[k]);
+      }
+      raw += " ))";
+      fail(std::string(parts.size() < 3 ? "arithmetic expression required"
+                                        : "`;' unexpected") +
+           "\n`" + raw + "'");
+      return;
     }
     n.a_init = trim(parts[0]);
     n.a_cond = trim(parts[1]);
@@ -866,6 +881,7 @@ struct Parser {
     if (err) {
       res.ok = false;
       res.error = errmsg;
+      res.error_line = err_line;
       res.incomplete = incomplete;
       res.command.reset();
       return res;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -205,20 +205,21 @@ void Shell::set_signal_trap(int signo, bool active) {
   sigaction(signo, &sa, nullptr);
 }
 
-void Shell::run_debug_trap(const std::string &cmd_text) {
+int Shell::run_debug_trap(const std::string &cmd_text) {
   auto it = traps.find("DEBUG");
-  if (it == traps.end() || in_debug_trap) return;
+  if (it == traps.end() || in_debug_trap) return 0;
   // Without functrace, the DEBUG trap fires only outside functions.
-  if (!opt_functrace && in_function()) return;
+  if (!opt_functrace && in_function()) return 0;
   in_debug_trap = true;
   bash_command = cmd_text;
   int saved = last_status;  // $? inside the trap is the previous command's status
   int saved_line = cur_lineno;  // the trap must not leak its own line numbers
   std::string body = it->second;
-  run_string(body);
+  int st = run_string(body);
   last_status = saved;  // the trap does not alter $? for the upcoming command
   cur_lineno = saved_line;
   in_debug_trap = false;
+  return st;
 }
 
 void Shell::run_pending_traps() {
@@ -994,7 +995,19 @@ int Shell::run_string(const std::string &script) {
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases)
                       : parse(script);
   if (!r.ok) {
-    std::fprintf(stderr, "gnash: syntax error: %s\n", r.error.c_str());
+    // bash's format: `NAME: [-c: ]line N: syntax error: MSG' per message line.
+    std::string pfx = shell_name + ": " +
+                      (invocation_char == 'c' ? std::string("-c: ") : std::string()) +
+                      "line " + std::to_string(lineno_base + (r.error_line > 0 ? r.error_line : 1)) +
+                      ": ";
+    size_t p0 = 0;
+    while (p0 <= r.error.size()) {
+      size_t nl = r.error.find('\n', p0);
+      std::string line = r.error.substr(p0, nl == std::string::npos ? std::string::npos : nl - p0);
+      std::fprintf(stderr, "%ssyntax error: %s\n", pfx.c_str(), line.c_str());
+      if (nl == std::string::npos) break;
+      p0 = nl + 1;
+    }
     last_status = 2;
     return 2;
   }

--- a/libglob/src/smatch.cpp
+++ b/libglob/src/smatch.cpp
@@ -80,6 +80,8 @@ int is_cclass(int c, const char *name) {
              {"punct", std::ispunct}, {"cntrl", std::iscntrl},
              {"print", std::isprint}, {"graph", std::isgraph},
              {"blank", std::isblank}, {"xdigit", std::isxdigit},
+             {"ascii", [](int ch) { return static_cast<int>(ch >= 0 && ch <= 0x7f); }},
+             {"word", [](int ch) { return static_cast<int>(std::isalnum(ch) || ch == '_'); }},
              {nullptr, nullptr}};
   for (int i = 0; tbl[i].name; i++)
     if (std::strcmp(tbl[i].name, name) == 0)


### PR DESCRIPTION
Fixes #71.

First batch toward passing the remaining ~73 files of bash's test suite. Headline: the expander's internal \x01/\x02 markers no longer collide with literal control-character data (mask-gated markers), which alone fixed most of the nquote* suites; plus case `;&`/`;;&`, quote-aware case patterns, [:ascii:]/[:word:], arith-for section validation with bash's two-line error, bash-format syntax errors with line numbers, job-control-gated setpgid, extdebug DEBUG-trap skip, and a read -e timeout edge.

Scoreboard movement (diff lines vs bash, before → after): nquote1 168→9, nquote3 96→15, nquote5 23→0, nquote2 127→20, case 63→9, posixpat 3→0, read 2→0, dbg-support2 2→0. All 22 ctest suites and 221 differential scripts pass; the three history-suite files stay at 0.