### PR TITLE
Quoting and expansion conformance (batch 2)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -46,29 +46,6 @@ std::string join(const std::vector<std::string> &v, size_t from) {
 
 // ---- echo / printf -------------------------------------------------------
 
-std::string decode_escapes(const std::string &s) {
-  std::string out;
-  for (size_t i = 0; i < s.size(); i++) {
-    if (s[i] == '\\' && i + 1 < s.size()) {
-      switch (s[++i]) {
-        case 'n': out += '\n'; break;
-        case 't': out += '\t'; break;
-        case 'r': out += '\r'; break;
-        case 'a': out += '\a'; break;
-        case 'b': out += '\b'; break;
-        case 'f': out += '\f'; break;
-        case 'v': out += '\v'; break;
-        case '\\': out += '\\'; break;
-        case '0': out += '\0'; break;
-        default: out += '\\'; out += s[i]; break;
-      }
-    } else {
-      out += s[i];
-    }
-  }
-  return out;
-}
-
 // printf %b: like echo -e but also interprets octal (\nnn, \0nnn) and hex
 // (\xHH) escapes, and \c which stops all further output.
 std::string decode_b(const std::string &s, bool &stop) {
@@ -141,12 +118,13 @@ int bi_echo(Shell &, const std::vector<std::string> &argv) {
     }
   }
   std::string out;
-  for (size_t j = i; j < argv.size(); j++) {
+  bool stop = false;
+  for (size_t j = i; j < argv.size() && !stop; j++) {
     if (j > i) out += ' ';
-    out += escapes ? decode_escapes(argv[j]) : argv[j];
+    out += escapes ? decode_b(argv[j], stop) : argv[j];
   }
   std::fwrite(out.data(), 1, out.size(), stdout);
-  if (newline) std::fputc('\n', stdout);
+  if (newline && !stop) std::fputc('\n', stdout);  // \c suppresses everything after
   return 0;
 }
 
@@ -374,7 +352,12 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
                    conv == 'o' || conv == 'u') {
           std::string sp = spec;
           sp.insert(sp.size() - 1, "l");  // promote to long
-          if (!append_formatted(out, sp, std::strtol(next().c_str(), nullptr, 0))) oversize = true;
+          std::string a = next();
+          // A leading ' or " makes the value the next character's code.
+          long v = (!a.empty() && (a[0] == '\'' || a[0] == '"'))
+                       ? (a.size() > 1 ? static_cast<unsigned char>(a[1]) : 0)
+                       : std::strtol(a.c_str(), nullptr, 0);
+          if (!append_formatted(out, sp, v)) oversize = true;
           consumed_any = true;
         } else if (conv == 'f' || conv == 'F' || conv == 'g' || conv == 'G' ||
                    conv == 'e' || conv == 'E') {

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -118,7 +118,8 @@ std::string ansi_c(const std::string &s) {
       }
       case 'x': {
         // Hex: \xHH (1-2 digits) or brace form \x{HH...}.  A bare \x with no
-        // hex digit is passed through unchanged.
+        // hex digit is passed through unchanged; a brace form with no digits
+        // terminates the whole string (bash's ansicstr bails out).
         bool brace = i + 1 < s.size() && s[i + 1] == '{';
         if (brace) i++;
         int v = 0, k = 0;
@@ -129,7 +130,8 @@ std::string ansi_c(const std::string &s) {
           k++;
         }
         if (brace && i + 1 < s.size() && s[i + 1] == '}') i++;
-        if (k == 0) { out += '\\'; out += 'x'; if (brace) out += '{'; }
+        if (brace && k == 0) return out;  // \x{ with no digits: drop the rest
+        if (k == 0) { out += '\\'; out += 'x'; }
         else out += static_cast<char>(v & 0xff);
         break;
       }
@@ -226,6 +228,19 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_histexpand) f += 'H';  // histexpand (set -H; interactive default)
     if (sh_.invocation_char) f += sh_.invocation_char;
     return f;
+  }
+  if (name == "*" || name == "@") {
+    // Unset exactly when there are no positional parameters (so ${*-x}
+    // defaults only for $# == 0); the value joins with the first IFS char.
+    set = !sh_.positional.empty();
+    std::string ifs = sh_.ifs();
+    char sep = ifs.empty() ? ' ' : ifs[0];
+    std::string r;
+    for (size_t k = 0; k < sh_.positional.size(); k++) {
+      if (k) r += sep;
+      r += sh_.positional[k];
+    }
+    return r;
   }
   if (!name.empty() && std::isdigit(static_cast<unsigned char>(name[0]))) {
     size_t idx = static_cast<size_t>(std::atoi(name.c_str()));
@@ -751,6 +766,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
         if (ssel == '*' && dq) {
           std::string is = sh_.ifs();
           std::string j = is.empty() ? std::string() : std::string(1, is[0]);
+          if (!slice.empty()) { out += QNULL; mask += MMARK; }  // "" stays a field
           for (size_t k = 0; k < slice.size(); k++) {
             if (k) for (char c : j) { out += c; mask += '1'; }
             for (char c : slice[k]) { out += c; mask += '1'; }
@@ -1153,7 +1169,11 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
 
   // ${name@op} -- parameter transformations.
   if (rest[0] == '@' && rest.size() >= 2) {
-    if (!set) return std::string();  // unset -> empty (even for @Q)
+    // @a/@A report the variable's attributes even when its scalar context
+    // (element 0) is unset -- an assoc array without ["0"] still has them.
+    if (!set && !(rest[1] == 'a' || rest[1] == 'A') )
+      return std::string();  // unset -> empty (even for @Q)
+    if (!set && sh.vars.find(name) == sh.vars.end()) return std::string();
     char t = rest[1];
     if (t == 'Q') return atq_quote(val);
     if (t == 'E') return ansic_expand(val);
@@ -1267,6 +1287,8 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
         }
       }
       if (i < text.size()) i++;
+    } else if (!heredoc && c == '$' && i + 1 < text.size() && text[i + 1] == '"') {
+      i++;  // $"...": locale-translated string; treated as a plain "..."
     } else if (!heredoc && c == '$' && i + 1 < text.size() && text[i + 1] == '\'') {
       out += QNULL; mask += MMARK;
       size_t j = i + 2;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -534,7 +534,19 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   std::string n = deref(n_in);
   auto it = vars.find(n);
   if (it == vars.end()) return false;
-  out = it->second.value;
+  const Variable &v = it->second;
+  // An array in scalar context is its element 0 (indexed) / "0" (assoc).
+  if (v.kind == VarKind::Indexed) {
+    if (!v.idx.count(0)) return false;
+    out = v.idx.at(0);
+    return true;
+  }
+  if (v.kind == VarKind::Assoc) {
+    if (!v.assoc.count("0")) return false;
+    out = v.assoc.at("0");
+    return true;
+  }
+  out = v.value;
   return true;
 }
 


### PR DESCRIPTION
Fixes #73.

echo -e full escape decoding, $'\x{...}' brace-hex exact semantics, $"..." translation strings, $*/$@ set-ness tied to $#, array element-0 scalar context (indexed and assoc), @a/@A on unset element 0, quoted empty ${*:N} slices, printf 'c char codes.

**17 of 83** bash test files now byte-identical to bash 5.3 in the same environment (10 at the start of this effort). All 22 ctest suites and 221 differential scripts pass.