### PR TITLE
POSIX grammar, tilde, IFS scoping, and error formats (batch 3)

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -54,6 +54,7 @@ struct Token {
   bool quoted = false;          // word contained quoting
   bool glued = false;           // Lparen immediately followed by `(' (for `((')
   bool lex_error = false;       // set on the Eof token if a span was unterminated
+  char lex_close = 0;           // the closer we were scanning for at EOF
   // Set on the Eof token when a here-document ran to end-of-input without its
   // delimiter: the body is still attached (bash runs it with a warning), but
   // line-oriented readers treat the input as incomplete.

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -196,6 +196,9 @@ class Shell {
 
   // --- diagnostics -------------------------------------------------------
   std::string shell_name = "gnash";  // program name shown in error messages
+  // Extra context component for parse errors ("eval", "command substitution"),
+  // as bash prints `NAME: eval: line N: ...'.
+  std::string error_context;
   // "NAME: line N: " prefix that bash prints before runtime errors.
   std::string err_prefix() const {
     return shell_name + ": line " + std::to_string(cur_lineno > 0 ? cur_lineno : 1) + ": ";

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -781,9 +781,17 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
 // Quote a scalar value for `set' output: bare if it is "simple", else single
 // quoted with embedded quotes escaped (matching bash).
 std::string set_quote(const std::string &v) {
+  // bash's sh_single_quote conventions: a lone single quote prints as \';
+  // `~' and `#' only force quoting at the start of the value.
+  if (v == "'") return "\\'";
   bool simple = true;  // an empty value prints bare (name=)
-  for (unsigned char c : v)
-    if (!(std::isalnum(c) || std::strchr("_-./:=+,%@", c))) { simple = false; break; }
+  for (size_t i = 0; i < v.size(); i++) {
+    unsigned char c = static_cast<unsigned char>(v[i]);
+    if (std::isalnum(c) || std::strchr("_-./:=+,%@^", c) != nullptr) continue;
+    if ((c == '~' || c == '#') && i != 0) continue;
+    simple = false;
+    break;
+  }
   if (simple) return v;
   std::string r = "'";
   for (char c : v) { if (c == '\'') r += "'\\''"; else r += c; }
@@ -2799,7 +2807,10 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     sh.continue_count = argv.size() > 1 ? std::atoi(argv[1].c_str()) : 1;
     st = 0;
   } else if (cmd == "eval") {
+    std::string saved_ctx = sh.error_context;
+    sh.error_context = "eval";  // parse errors report `NAME: eval: line N: ...'
     st = sh.run_string(join(argv, 1));
+    sh.error_context = saved_ctx;
   } else if (cmd == "source" || cmd == ".") {
     if (argv.size() > 1) {
       // Like bash: a filename without a slash is looked up on PATH first, then
@@ -2839,7 +2850,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   } else if (cmd == "local") {
     st = bi_declare(sh, argv, true, false);
   } else if (cmd == "declare" || cmd == "typeset") {
-    st = bi_declare(sh, argv, false, false);
+    // Inside a function, declare/typeset without -g makes the variable local.
+    st = bi_declare(sh, argv, sh.in_function(), false);
   } else if (cmd == "readonly") {
     st = bi_declare(sh, argv, false, true);
   } else if (cmd == "let") {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -654,11 +654,21 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.positional = saved_pos;
     sh_.arg0 = saved_arg0;
     if (sh_.returning) { sh_.returning = false; status = sh_.exit_status; }
+    // In posix mode, assignments preceding a function call persist.
+    if (sh_.opt_posix) restore.clear();
     undo_temp();
   } else if ((apply_temp(), run_builtin(sh_, argv, &status))) {
     // A preceding `VAR=val builtin' applies to the builtin (e.g. IFS=, read),
-    // then is restored.
+    // then is restored -- except that posix mode makes assignments before the
+    // POSIX special builtins permanent.
     builtin = true;
+    if (sh_.opt_posix) {
+      static const std::set<std::string> kSpecial = {
+          ":",      ".",     "break", "continue", "eval",  "exec",
+          "exit",   "export", "readonly", "return", "set", "shift",
+          "source", "times", "trap",  "unset"};
+      if (kSpecial.count(argv[0])) restore.clear();
+    }
     undo_temp();
   } else {
     undo_temp();  // not a builtin after all: the external path sets its own env
@@ -798,6 +808,18 @@ int Executor::run_loop(const LoopCommand *c) {
 
 int Executor::run_for(const ForCommand *c) {
   int st = 0;
+  if (!c->is_arith && !c->var.empty()) {
+    // The loop variable must be a valid identifier (validated at execution,
+    // as bash does: `NAME: line N: \`x-y': not a valid identifier').
+    bool okname = std::isalpha(static_cast<unsigned char>(c->var[0])) || c->var[0] == '_';
+    for (char ch : c->var)
+      if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) okname = false;
+    if (!okname) {
+      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
+                   c->var.c_str());
+      return (sh_.last_status = 1);
+    }
+  }
   if (c->is_arith) {
     bool ok = true;
     // The three arithmetic sections undergo parameter/command expansion before

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -623,6 +623,54 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     size_t end = scan_balanced(t, i + 1, '{', '}');
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
+
+      // ${name-word} / ${name+word} (and the `:' forms) with the operator
+      // firing: expand WORD by re-processing it here, so an embedded "$@"
+      // keeps its field structure (a flat string would lose empty fields).
+      {
+        size_t q = 0;
+        std::string nm;
+        if (q < body.size() &&
+            (body[q] == '@' || body[q] == '*' || body[q] == '#' || body[q] == '?' ||
+             body[q] == '$' || body[q] == '!' || body[q] == '-')) {
+          nm = body.substr(q, 1);
+          q++;
+        } else {
+          while (q < body.size() &&
+                 (std::isalnum(static_cast<unsigned char>(body[q])) || body[q] == '_'))
+            q++;
+          nm = body.substr(0, q);
+        }
+        if (!nm.empty() && q < body.size()) {
+          bool colon = body[q] == ':';
+          size_t opq = q + (colon ? 1 : 0);
+          if (opq < body.size() && (body[opq] == '-' || body[opq] == '+') &&
+              !(nm == "-" && q == 1)) {
+            char op = body[opq];
+            bool set = false;
+            std::string val = param_value(nm, set, true);
+            bool fire = (op == '-') ? (!set || (colon && val.empty()))
+                                    : (set && !(colon && val.empty()));
+            if (fire) {
+              process(body.substr(opq + 1), out, mask, false);
+              i = end + 1;
+              return;
+            }
+            if (op == '-' || op == '+') {
+              // Operator does not fire: the parameter's own value (for `-')
+              // or nothing (for `+'); fall through for arrays/subscripts.
+              if (nm != "@" && nm != "*" && body.find('[') == std::string::npos) {
+                if (op == '-') {
+                  char qm2 = dq ? '1' : '0';
+                  for (char c : val) { out += c; mask += qm2; }
+                }
+                i = end + 1;
+                return;
+              }
+            }
+          }
+        }
+      }
       // zsh `${(flags)name}' expansion flags (join/split/sort/unique/case/...).
       if (sh_.is_zsh() && !body.empty() && body[0] == '(' &&
           emit_zsh_flags(body, dq, out, mask)) {
@@ -1462,11 +1510,26 @@ void Expander::extract_procsubs(std::string &word) {
   }
 }
 
+static std::string tilde_assign(Shell &sh, const std::string &text);
+
 std::vector<std::string> Expander::expand_args(const std::vector<Word> &words) {
   std::vector<std::string> result;
   for (const Word &w : words) {
     for (const std::string &braced : brace_expand(w.text)) {
-      std::string tilded = expand_leading_tilde(sh_, braced);
+      // A word shaped like an assignment (name=value) gets assignment-style
+      // tilde expansion -- after the `=' and after each `:' -- unless posix
+      // mode is on.  (bash's W_ASSIGNMENT tilde rule.)
+      std::string pre = braced;
+      if (!sh_.opt_posix) {
+        size_t q = 0;
+        while (q < pre.size() &&
+               (std::isalnum(static_cast<unsigned char>(pre[q])) || pre[q] == '_'))
+          q++;
+        if (q > 0 && q < pre.size() && pre[q] == '=' &&
+            std::isalpha(static_cast<unsigned char>(pre[0])))
+          pre = pre.substr(0, q + 1) + tilde_assign(sh_, pre.substr(q + 1));
+      }
+      std::string tilded = expand_leading_tilde(sh_, pre);
       extract_procsubs(tilded);  // <(cmd) / >(cmd) -> /dev/fd/N
       std::string out, mask;
       process(tilded, out, mask, false);
@@ -1493,7 +1556,7 @@ std::vector<std::string> Expander::expand_args(const std::vector<Word> &words) {
 }
 
 std::string Expander::expand_pattern(const std::string &text) {
-  std::string src = text;
+  std::string src = expand_leading_tilde(sh_, text);  // `case ~ in ~)' matches
   extract_procsubs(src);
   std::string out, mask;
   process(src, out, mask, false);
@@ -1512,7 +1575,7 @@ std::string Expander::expand_pattern(const std::string &text) {
 }
 
 std::string Expander::expand_no_split(const std::string &text, bool do_glob) {
-  std::string src = text;
+  std::string src = expand_leading_tilde(sh_, text);  // case subjects, redirects
   extract_procsubs(src);  // e.g. a redirect target: < <(cmd)
   std::string out, mask;
   process(src, out, mask, false);

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -59,6 +59,7 @@ struct Lexer {
   std::vector<Pending> pending;
   int awaiting = -1;  // -1 none, 0 <<, 1 <<-
   bool unterminated = false;
+  char unterm_close = 0;  // the closer we were looking for at EOF
   bool heredoc_eof = false;        // here-doc body delimited by end of input
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
@@ -103,7 +104,8 @@ struct Lexer {
   void scan_single(std::string &w) {
     w += in[pos++];  // '
     while (pos < n && in[pos] != '\'') w += in[pos++];
-    if (pos < n) w += in[pos++]; else unterminated = true;
+    if (pos < n) w += in[pos++];
+    else { unterminated = true; if (!unterm_close) unterm_close = '\''; }
   }
   void scan_backtick(std::string &w) {
     w += in[pos++];  // `
@@ -115,7 +117,8 @@ struct Lexer {
         w += in[pos++];
       }
     }
-    if (pos < n) w += in[pos++]; else unterminated = true;
+    if (pos < n) w += in[pos++];
+    else { unterminated = true; if (!unterm_close) unterm_close = '`'; }
   }
   void scan_paren(std::string &w) {  // pos at '('
     int depth = 0;
@@ -144,7 +147,7 @@ struct Lexer {
         pos++;
       }
     } while (pos < n && depth > 0);
-    if (depth > 0) unterminated = true;
+    if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = ')'; }
   }
   void scan_brace(std::string &w) {  // pos at '{'
     int depth = 0;
@@ -173,7 +176,7 @@ struct Lexer {
         pos++;
       }
     } while (pos < n && depth > 0);
-    if (depth > 0) unterminated = true;
+    if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = '}'; }
   }
   void scan_double(std::string &w) {
     w += in[pos++];  // "
@@ -198,7 +201,8 @@ struct Lexer {
         pos++;
       }
     }
-    if (pos < n) w += in[pos++]; else unterminated = true;
+    if (pos < n) w += in[pos++];
+    else { unterminated = true; if (!unterm_close) unterm_close = '"'; }
   }
   void scan_dollar_single(std::string &w) {  // pos at '$', next '\''
     w += in[pos++];  // $
@@ -211,7 +215,8 @@ struct Lexer {
         w += in[pos++];
       }
     }
-    if (pos < n) w += in[pos++]; else unterminated = true;
+    if (pos < n) w += in[pos++];
+    else { unterminated = true; if (!unterm_close) unterm_close = '\''; }
   }
 
   bool is_metachar(char c) {
@@ -473,6 +478,7 @@ struct Lexer {
     Token eof;
     eof.type = Tok::Eof;
     eof.lex_error = unterminated;
+    eof.lex_close = unterm_close;
     eof.heredoc_eof = heredoc_eof;
     eof.heredoc_eof_delim = heredoc_eof_delim;
     eof.heredoc_eof_line = heredoc_eof_line;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -371,6 +371,7 @@ int main(int argc, char **argv) {
     std::string cmd = idx < args.size() ? args[idx++] : "";
     if (idx < args.size()) {
       sh.arg0 = args[idx];
+      sh.shell_name = args[idx];  // $0 also names the shell in error messages
       sh.positional.assign(args.begin() + idx + 1, args.end());
     }
     sh.init_job_control(false);

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -389,7 +389,8 @@ struct Parser {
 
     // Reserved terminators here mean a misplaced keyword.
     if (reserved_in({"then", "do", "done", "fi", "elif", "else", "esac", "}"})) {
-      fail(std::string("unexpected `") + cur().text + "'");
+      fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                        : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
       return nullptr;
     }
 
@@ -515,23 +516,35 @@ struct Parser {
       parse_arith_for_header(*n);
     } else {
       if (cur().type != Tok::Word) {
-        fail("expected variable name after `for'");
+        fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                          : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
         return n;
       }
       n->var = cur().text;
       advance();
-      if (reserved("in")) {
+      if (is(Tok::Semi)) {
         advance();
-        n->words_present = true;
-        while (cur().type == Tok::Word && !reserved_in({"do"})) {
-          n->words.push_back(Word{cur().text, cur().quoted ? W_QUOTED : 0});
+        newline_list();
+      } else {
+        newline_list();  // POSIX allows a linebreak before `in'
+        if (reserved("in")) {
           advance();
+          n->words_present = true;
+          while (cur().type == Tok::Word && !reserved_in({"do"})) {
+            n->words.push_back(Word{cur().text, cur().quoted ? W_QUOTED : 0});
+            advance();
+          }
         }
       }
     }
     if (is(Tok::Semi) || is(Tok::Newline)) {
       advance();
       newline_list();
+    }
+    if (reserved("{")) {  // bash allows a brace group as the body
+      n->body = parse_command({});
+      parse_redirect_list(n->redirects);
+      return n;
     }
     expect_reserved("do");
     n->body = parse_list({"done"});
@@ -604,7 +617,12 @@ struct Parser {
     std::string expr;
     bool okexpr = true;
     for (;;) {
-      if (is(Tok::Eof) || is(Tok::Semi) || is(Tok::Newline)) {
+      if (is(Tok::Eof)) {  // bash reports the unbalanced (( at EOF directly
+        incomplete = true;
+        fail("unexpected EOF while looking for matching `)'");
+        return nullptr;
+      }
+      if (is(Tok::Semi) || is(Tok::Newline)) {
         okexpr = false;  // not an arithmetic expression -> nested subshell
         break;
       }
@@ -796,7 +814,14 @@ struct Parser {
     }
     n->word = Word{cur().text, cur().quoted ? W_QUOTED : 0};
     advance();
-    expect_reserved("in");
+    newline_list();  // POSIX allows a linebreak before `in'
+    if (reserved("in")) {
+      advance();
+    } else {
+      fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                        : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
+      return n;
+    }
     newline_list();
     while (!err && !reserved("esac")) {
       CaseClause clause;
@@ -869,7 +894,10 @@ struct Parser {
     if (!toks.empty() && toks.back().lex_error) {
       res.ok = false;
       res.incomplete = true;  // unterminated quote/substitution
-      res.error = "unterminated quoted string or substitution";
+      char cl = toks.back().lex_close;
+      res.error = cl ? std::string("unexpected EOF while looking for matching `") + cl + "'"
+                     : std::string("unterminated quoted string or substitution");
+      res.error_line = toks.back().line;
       return res;
     }
     newline_list();
@@ -877,7 +905,8 @@ struct Parser {
     res.command = parse_list({});
     newline_list();
     if (!err && !is(Tok::Eof))
-      fail(std::string("unexpected token `") + tok_name(cur().type) + "'");
+      fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                        : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
     if (err) {
       res.ok = false;
       res.error = errmsg;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -39,6 +39,7 @@ Shell::Shell() {
     vars[name] = var;
   }
   if (!is_set("IFS")) set("IFS", " \t\n");
+  set("OPTIND", "1");  // bash initializes getopts state at startup
   set("PPID", std::to_string(static_cast<long>(getppid())));
   set("$", std::to_string(static_cast<long>(getpid())));
   seconds_base = static_cast<long long>(std::time(nullptr));  // $SECONDS origin
@@ -1007,18 +1008,41 @@ int Shell::run_string(const std::string &script) {
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases)
                       : parse(script);
   if (!r.ok) {
-    // bash's format: `NAME: [-c: ]line N: syntax error: MSG' per message line.
-    std::string pfx = shell_name + ": " +
-                      (invocation_char == 'c' ? std::string("-c: ") : std::string()) +
-                      "line " + std::to_string(lineno_base + (r.error_line > 0 ? r.error_line : 1)) +
+    // bash's format: `NAME: [CONTEXT: ][-c: ]line N: syntax error...' per
+    // message line; "near unexpected token" joins without a colon, and the
+    // offending source line is echoed after it.
+    std::string ctx;
+    if (!error_context.empty()) ctx = error_context + ": ";
+    else if (invocation_char == 'c') ctx = "-c: ";
+    std::string pfx = shell_name + ": " + ctx + "line " +
+                      std::to_string(lineno_base + (r.error_line > 0 ? r.error_line : 1)) +
                       ": ";
     size_t p0 = 0;
     while (p0 <= r.error.size()) {
       size_t nl = r.error.find('\n', p0);
       std::string line = r.error.substr(p0, nl == std::string::npos ? std::string::npos : nl - p0);
-      std::fprintf(stderr, "%ssyntax error: %s\n", pfx.c_str(), line.c_str());
+      if (line.compare(0, 14, "unexpected EOF") == 0) {
+        std::fprintf(stderr, "%s%s\n", pfx.c_str(), line.c_str());  // no `syntax error'
+      } else {
+        const char *sep = line.compare(0, 5, "near ") == 0 ? " " : ": ";
+        std::fprintf(stderr, "%ssyntax error%s%s\n", pfx.c_str(), sep, line.c_str());
+      }
       if (nl == std::string::npos) break;
       p0 = nl + 1;
+    }
+    if (r.error.compare(0, 5, "near ") == 0 && r.error_line > 0) {
+      // Echo the offending source line, as bash does.
+      size_t start = 0;
+      for (int k = 1; k < r.error_line && start != std::string::npos; k++) {
+        start = script.find('\n', start);
+        if (start != std::string::npos) start++;
+      }
+      if (start != std::string::npos) {
+        size_t fin = script.find('\n', start);
+        std::string src = script.substr(start, fin == std::string::npos ? std::string::npos
+                                                                        : fin - start);
+        std::fprintf(stderr, "%s`%s'\n", pfx.c_str(), src.c_str());
+      }
     }
     last_status = 2;
     return 2;


### PR DESCRIPTION
Fixes #75.

**21 of 83** bash test files now byte-identical (17 after batch 2, 10 at the start). Newly passing: posix2, parser-adjacent cases, tilde, ifs, iquote, nquote4. All 22 ctest suites and 221 differential scripts pass.