### PR TITLE
bash-format function printing and declare -f/-F (batch 4)

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -76,7 +76,11 @@ struct Command {
 
 using CommandPtr = std::unique_ptr<Command>;
 
-std::string to_string(const Command *c);  // full canonical rendering
+std::string to_string(const Command *c);
+
+// bash's multi-line function rendering (print_cmd.c named_function_string),
+// used by `type', `declare -f', and `set' -- byte-identical to bash.
+std::string named_function_string(const std::string &name, const Command *body);  // full canonical rendering
 
 struct SimpleCommand : Command {
   std::vector<Word> words;  // assignment prefix + argv, in order

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -8,6 +8,7 @@
 // semantically faithful.
 
 #include "gnash/core/ast.hpp"
+#include "gnash/core/parser.hpp"
 
 namespace gnash::core {
 
@@ -156,9 +157,9 @@ void CondCommand::print(std::string &out) const {
 
 void ArithCommand::print(std::string &out) const {
   invert_prefix(this, out);
-  out += "((";
+  out += "(( ";
   out += expression;
-  out += "))";
+  out += " ))";
   print_redirects(redirects, out);
 }
 
@@ -195,6 +196,340 @@ void FunctionDef::print(std::string &out) const {
   out += " () ";
   if (body) body->print(out);
   print_redirects(redirects, out);
+}
+
+
+// ---- bash-format multi-line printing (print_cmd.c's named_function_string) --
+//
+// `type', `declare -f', and `set' display function bodies in bash's canonical
+// indented form; these must match bash byte-for-byte (including trailing
+// blanks after `NAME () ', `{ ', and `case W in ').
+
+namespace {
+
+std::string canonical_word(const std::string &w);
+
+struct MPrinter {
+  std::string out;
+  std::vector<const Redirect *> pending_heredocs;
+  bool last_was_heredoc = false;
+  bool last_was_amp = false;
+
+  void ind(int n) { out.append(static_cast<size_t>(n), ' '); }
+  void nl(int n) { out += '\n'; ind(n); }
+
+  void print_redir(const Redirect &r) {
+    out += ' ';
+    if (r.source_fd >= 0) out += std::to_string(r.source_fd);
+    switch (r.op) {
+      case RedirOp::HereDoc: out += "<<"; out += r.target.text; return;
+      case RedirOp::HereDocStrip: out += "<<-"; out += r.target.text; return;
+      case RedirOp::DupInput: out += "<&"; out += r.target.text; return;
+      case RedirOp::DupOutput: out += ">&"; out += r.target.text; return;
+      default: break;
+    }
+    out += op_string(r.op);
+    out += ' ';
+    out += r.target.text;
+  }
+
+  void print_redirs(const std::vector<Redirect> &rs) {
+    for (const Redirect &r : rs) {
+      print_redir(r);
+      if (r.op == RedirOp::HereDoc || r.op == RedirOp::HereDocStrip)
+        pending_heredocs.push_back(&r);
+    }
+  }
+
+  // Emit queued here-document bodies right after the command's line.
+  bool flush_heredocs() {
+    if (pending_heredocs.empty()) return false;
+    for (const Redirect *r : pending_heredocs) {
+      out += '\n';
+      out += r->heredoc_body;  // body lines keep their own newlines
+      out += r->target.text;
+    }
+    pending_heredocs.clear();
+    return true;
+  }
+
+  // One statement (a sequence element) at INDENT; records how it ended so the
+  // caller knows whether to append `;'.
+  void stmt(const Command *c, int I) {
+    last_was_amp = false;
+    inline_cmd(c, I);
+    last_was_heredoc = flush_heredocs();
+  }
+
+  // Statement sequences: each Semi-connected element on its own line.  The
+  // parser builds these left-associated, so recurse into both sides.
+  void list(const Command *c, int I) {
+    const auto *cn = dynamic_cast<const Connection *>(c);
+    if (cn && (cn->conn == Connector::Semi || cn->conn == Connector::Newline)) {
+      list(cn->first.get(), I);
+      if (cn->second) {
+        if (last_was_heredoc) { out += '\n'; nl(I); }
+        else if (last_was_amp) { nl(I); }
+        else { out += ';'; nl(I); }
+        list(cn->second.get(), I);
+      }
+      return;
+    }
+    if (cn && cn->conn == Connector::Amp) {
+      list(cn->first.get(), I);
+      if (!last_was_amp) out += " &";
+      last_was_amp = true;
+      last_was_heredoc = false;
+      if (cn->second) {
+        out += ' ';  // `a & b' stays on one line
+        last_was_amp = false;
+        list(cn->second.get(), I);
+      }
+      return;
+    }
+    stmt(c, I);
+  }
+
+  // Terminate a clause body (then/else/do): append `;' unless the last
+  // statement ended with `&' or a here-document.
+  void clause_semi() {
+    if (!last_was_amp && !last_was_heredoc) out += ';';
+  }
+
+  // Render one command; compounds span lines from INDENT.
+  void inline_cmd(const Command *c, int I) {
+    if (c == nullptr) return;
+    if (c->flags & CMD_INVERT_RETURN) out += "! ";
+    if (c->flags & CMD_TIME) out += (c->flags & CMD_TIME_POSIX) ? "time -p " : "time ";
+
+    if (const auto *sc = dynamic_cast<const SimpleCommand *>(c)) {
+      for (size_t i = 0; i < sc->words.size(); i++) {
+        if (i) out += ' ';
+        out += canonical_word(sc->words[i].text);
+      }
+      print_redirs(sc->redirects);
+      return;
+    }
+    if (const auto *cn = dynamic_cast<const Connection *>(c)) {
+      switch (cn->conn) {
+        case Connector::And:
+          inline_cmd(cn->first.get(), I);
+          out += " && ";
+          inline_cmd(cn->second.get(), I);
+          return;
+        case Connector::Or:
+          inline_cmd(cn->first.get(), I);
+          out += " || ";
+          inline_cmd(cn->second.get(), I);
+          return;
+        case Connector::Pipe:
+          inline_cmd(cn->first.get(), I);
+          out += " | ";
+          inline_cmd(cn->second.get(), I);
+          return;
+        case Connector::Amp:
+          inline_cmd(cn->first.get(), I);
+          out += " &";
+          last_was_amp = true;
+          if (cn->second) {
+            out += ' ';
+            inline_cmd(cn->second.get(), I);
+            last_was_amp = false;
+          }
+          return;
+        case Connector::Semi:
+        case Connector::Newline:
+          inline_cmd(cn->first.get(), I);
+          out += "; ";
+          inline_cmd(cn->second.get(), I);
+          return;
+      }
+      return;
+    }
+    if (const auto *g = dynamic_cast<const Group *>(c)) {
+      out += "{ ";
+      nl(I + 4);
+      list(g->body.get(), I + 4);
+      nl(I);
+      out += '}';
+      print_redirs(g->redirects);
+      return;
+    }
+    if (const auto *ss = dynamic_cast<const Subshell *>(c)) {
+      out += "( ";
+      inline_cmd(ss->body.get(), I);
+      out += " )";
+      print_redirs(ss->redirects);
+      return;
+    }
+    if (const auto *ic = dynamic_cast<const IfCommand *>(c)) {
+      out += "if ";
+      inline_line_here(ic->cond.get());
+      out += "; then";
+      nl(I + 4);
+      list(ic->then_part.get(), I + 4);
+      clause_semi();
+      nl(I);
+      if (ic->else_part) {
+        out += "else";
+        nl(I + 4);
+        list(ic->else_part.get(), I + 4);
+        clause_semi();
+        nl(I);
+      }
+      out += "fi";
+      print_redirs(ic->redirects);
+      return;
+    }
+    if (const auto *lc = dynamic_cast<const LoopCommand *>(c)) {
+      out += lc->until ? "until " : "while ";
+      inline_line_here(lc->cond.get());
+      out += "; do";
+      nl(I + 4);
+      list(lc->body.get(), I + 4);
+      clause_semi();
+      nl(I);
+      out += "done";
+      print_redirs(lc->redirects);
+      return;
+    }
+    if (const auto *fc = dynamic_cast<const ForCommand *>(c)) {
+      if (fc->is_arith) {
+        out += "for ((";
+        out += fc->a_init;
+        out += "; ";
+        out += fc->a_cond;
+        out += "; ";
+        out += fc->a_update;
+        out += "))";
+      } else {
+        out += fc->is_select ? "select " : "for ";
+        out += fc->var;
+        out += " in ";
+        if (fc->words_present) {
+          for (size_t i = 0; i < fc->words.size(); i++) {
+            if (i) out += ' ';
+            out += canonical_word(fc->words[i].text);
+          }
+        } else {
+          out += "\"$@\"";  // bash canonicalizes a bare `for i'
+        }
+        out += ';';
+      }
+      nl(I);
+      out += "do";
+      nl(I + 4);
+      list(fc->body.get(), I + 4);
+      clause_semi();
+      nl(I);
+      out += "done";
+      print_redirs(fc->redirects);
+      return;
+    }
+    if (const auto *cc = dynamic_cast<const CaseCommand *>(c)) {
+      out += "case ";
+      out += cc->word.text;
+      out += " in ";
+      for (const CaseClause &cl : cc->clauses) {
+        nl(I + 4);
+        for (size_t i = 0; i < cl.patterns.size(); i++) {
+          if (i) out += " | ";
+          out += cl.patterns[i].text;
+        }
+        out += ')';
+        out += '\n';
+        if (cl.body) {
+          ind(I + 8);
+          list(cl.body.get(), I + 8);
+        }
+        out += '\n';
+        ind(I + 4);
+        out += cl.terminator == 1 ? ";&" : cl.terminator == 2 ? ";;&" : ";;";
+      }
+      nl(I);
+      out += "esac";
+      print_redirs(cc->redirects);
+      return;
+    }
+    if (const auto *fd = dynamic_cast<const FunctionDef *>(c)) {
+      out += fd->name;
+      out += " () ";
+      out += '\n';
+      ind(I);
+      inline_cmd(fd->body.get(), I);
+      return;
+    }
+    // [[ ]] / (( )) / coproc / anything else: the single-line rendering.
+    std::string one;
+    c->print(one);
+    out += one;
+  }
+
+  // A condition (if/while) or subshell body on one line.
+  void inline_line_here(const Command *c) {
+    MPrinter sub;
+    sub.inline_line(c);
+    out += sub.out;
+  }
+  void inline_line(const Command *c) {
+    std::string one;
+    if (c) c->print(one);
+    out += one;
+  }
+};
+
+// Re-render `$(...)' command substitutions in W through the parser, as bash
+// prints the parsed form ("$( echo hi )" becomes "$(echo hi)").  On any parse
+// trouble the original text is kept.
+std::string canonical_word(const std::string &w) {
+  size_t at = w.find("$(");
+  if (at == std::string::npos) return w;
+  std::string out;
+  size_t i = 0;
+  while (i < w.size()) {
+    if (w[i] == '\'') {  // skip single-quoted spans
+      size_t j = w.find('\'', i + 1);
+      out += w.substr(i, j == std::string::npos ? std::string::npos : j - i + 1);
+      if (j == std::string::npos) return w;
+      i = j + 1;
+      continue;
+    }
+    if (w[i] == '$' && i + 1 < w.size() && w[i + 1] == '(' &&
+        !(i + 2 < w.size() && w[i + 2] == '(')) {
+      int depth = 0;
+      size_t j = i + 1;
+      for (; j < w.size(); j++) {
+        if (w[j] == '(') depth++;
+        else if (w[j] == ')' && --depth == 0) break;
+      }
+      if (j >= w.size()) return w;
+      std::string inner = w.substr(i + 2, j - (i + 2));
+      ParseResult pr = parse(inner);
+      if (pr.ok && pr.command) {
+        out += "$(";
+        std::string one;
+        pr.command->print(one);
+        out += one;
+        out += ')';
+      } else {
+        out += w.substr(i, j - i + 1);
+      }
+      i = j + 1;
+      continue;
+    }
+    out += w[i++];
+  }
+  return out;
+}
+
+}  // namespace
+
+std::string named_function_string(const std::string &name, const Command *body) {
+  MPrinter p;
+  p.out = name + " () ";
+  p.out += '\n';
+  p.inline_cmd(body, 0);
+  return p.out;
 }
 
 }  // namespace gnash::core

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1190,12 +1190,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   bool mk_array = false, mk_assoc = false, integer = false, readonly = force_ro;
   bool exported = false, global = false, local = force_local, nameref = false;
   bool lcase = false, ucase = false;  // -l lowercase / -u uppercase attribute
+  bool funcs = false, funcnames = false;  // -f (definitions) / -F (names)
   size_t i = 1;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     if (a.size() >= 2 && a[0] == '-') {
       for (size_t k = 1; k < a.size(); k++) {
         switch (a[k]) {
+          case 'f': funcs = true; break;
+          case 'F': funcnames = true; break;
           case 'a': mk_array = true; break;
           case 'A': mk_assoc = true; break;
           case 'i': integer = true; break;
@@ -1213,6 +1216,27 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       break;
     }
   }
+  // -f / -F: display function definitions or names.  With -x, restrict to
+  // exported functions (gnash doesn't export functions, so none qualify).
+  if (funcs || funcnames) {
+    int st = 0;
+    if (exported) return i >= argv.size() ? 0 : 1;
+    if (i >= argv.size()) {  // all functions
+      for (const auto &kv : sh.functions) {
+        if (funcnames) std::printf("declare -f %s\n", kv.first.c_str());
+        else std::printf("%s\n", named_function_string(kv.first, kv.second).c_str());
+      }
+      return 0;
+    }
+    for (; i < argv.size(); i++) {
+      auto it = sh.functions.find(argv[i]);
+      if (it == sh.functions.end()) { st = 1; continue; }
+      if (funcnames) std::printf("%s\n", argv[i].c_str());
+      else std::printf("%s\n", named_function_string(argv[i], it->second).c_str());
+    }
+    return st;
+  }
+
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     size_t nend = a.find_first_of("[=");
@@ -1357,8 +1381,8 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
         switch (L.kind) {
           case 'k': std::printf("%s is a shell keyword\n", n.c_str()); break;
           case 'f':
-            std::printf("%s is a function\n%s () %s\n", n.c_str(), n.c_str(),
-                        to_string(sh.functions[n]).c_str());
+            std::printf("%s is a function\n%s\n", n.c_str(),
+                        named_function_string(n, sh.functions[n]).c_str());
             break;
           case 'b': std::printf("%s is a shell builtin\n", n.c_str()); break;
           case 'F': std::printf("%s is %s\n", n.c_str(), L.text.c_str()); break;

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -101,8 +101,8 @@ int main() {
   ok("[[ $x =~ ^ab.*$ ]]", "[[ $x =~ ^ab.*$ ]]");
 
   // arithmetic (( )) and arithmetic for
-  ok("(( x + 1 ))", "((x + 1))");
-  ok("(( i = 0 ))", "((i = 0))");
+  ok("(( x + 1 ))", "(( x + 1 ))");
+  ok("(( i = 0 ))", "(( i = 0 ))");
   // arithmetic sections are rendered faithfully to the source spacing, so a
   // glued operator like `<' (which the lexer splits) is re-glued, not spaced.
   ok("for ((i=0; i<10; i++)); do echo $i; done", "for ((i=0; i<10; i++)); do echo $i; done");


### PR DESCRIPTION
Fixes #77. Multi-line function printer matching bash's print_cmd.c byte-for-byte, plus declare -f/-F. cprint 72→10, type 127→60, herestr 17→1, heredoc 161→123. All 22 ctest suites and 221 differential scripts pass.