### PR TITLE
dirs +N/-N, ~N and DIRSTACK (batch 7)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -216,6 +216,9 @@ class Shell {
 
   // --- directory stack (pushd/popd/dirs); entries below the current dir ---
   std::vector<std::string> dir_stack;
+  // The full stack as $DIRSTACK / ~N sees it: logical $PWD at [0], then
+  // dir_stack.  Defined in builtins.cpp (uses logical_pwd).
+  std::vector<std::string> dirstack() const;
 
   // --- process substitutions <(...) / >(...) live for one command ---------
   struct ProcSub { long pid; int fd; };

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -588,12 +588,20 @@ int bi_pwd(Shell &sh, const std::vector<std::string> &argv) {
 
 // The full stack as bash presents it: current (logical) directory on top, then
 // the saved entries.
-std::vector<std::string> full_dirstack(Shell &sh) {
+}  // namespace (reopened below)
+}  // namespace gnash::core
+namespace gnash::core {
+std::vector<std::string> Shell::dirstack() const {
   std::vector<std::string> v;
-  v.push_back(logical_pwd(sh));
-  for (const std::string &d : sh.dir_stack) v.push_back(d);
+  std::string pwd = get("PWD");
+  char cwd[4096];
+  if (pwd.empty() && getcwd(cwd, sizeof cwd)) pwd = cwd;
+  v.push_back(pwd);
+  for (const std::string &d : dir_stack) v.push_back(d);
   return v;
 }
+namespace {
+std::vector<std::string> full_dirstack(Shell &sh) { return sh.dirstack(); }
 
 std::string tilde_abbrev(Shell &sh, const std::string &path, bool longform) {
   std::string home = sh.get("HOME");
@@ -606,10 +614,19 @@ std::string tilde_abbrev(Shell &sh, const std::string &path, bool longform) {
 
 int do_chdir(Shell &sh, const std::string &dir) { return change_dir(sh, dir, false); }
 
+int rot_index(const std::string &spec, size_t n);  // forward
+
 int bi_dirs(Shell &sh, const std::vector<std::string> &argv) {
   bool longform = false, oneline = false, verbose = false;
+  std::string select;  // a +N / -N argument: print only that entry
   for (size_t i = 1; i < argv.size(); i++) {
     const std::string &a = argv[i];
+    // A `+N' / `-N' selector (a dash/plus followed by a digit) is not an option.
+    if (a.size() >= 2 && (a[0] == '+' || a[0] == '-') &&
+        std::isdigit(static_cast<unsigned char>(a[1]))) {
+      select = a;
+      continue;
+    }
     if (a.empty() || a[0] != '-') break;
     for (size_t k = 1; k < a.size(); k++) {
       if (a[k] == 'c') { sh.dir_stack.clear(); return 0; }
@@ -620,6 +637,18 @@ int bi_dirs(Shell &sh, const std::vector<std::string> &argv) {
     }
   }
   std::vector<std::string> v = full_dirstack(sh);
+  if (!select.empty()) {  // print a single entry
+    int idx = rot_index(select, v.size());
+    if (idx < 0) {
+      std::fprintf(stderr, "gnash: dirs: %s: directory stack index out of range\n",
+                   select.c_str());
+      return 1;
+    }
+    std::string s = tilde_abbrev(sh, v[static_cast<size_t>(idx)], longform);
+    if (verbose) std::printf("%2d  %s\n", idx, s.c_str());
+    else std::printf("%s\n", s.c_str());
+    return 0;
+  }
   for (size_t i = 0; i < v.size(); i++) {
     std::string s = tilde_abbrev(sh, v[i], longform);
     if (verbose) std::printf("%2zu  %s\n", i, s.c_str());

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -180,6 +180,25 @@ static std::string expand_leading_tilde(Shell &sh, const std::string &w) {
     home = sh.get("PWD");
   } else if (prefix == "-") {
     home = sh.get("OLDPWD");
+  } else if (prefix[0] == '+' || prefix[0] == '-' ||
+             std::isdigit(static_cast<unsigned char>(prefix[0]))) {
+    // ~N / ~+N / ~-N: the Nth directory-stack entry (bash's DIRSTACK).
+    const char *dp = prefix.c_str();
+    bool from_end = (*dp == '-');
+    if (*dp == '+' || *dp == '-') dp++;
+    bool alldig = *dp != '\0';
+    for (const char *q = dp; *q; q++)
+      if (!std::isdigit(static_cast<unsigned char>(*q))) alldig = false;
+    if (alldig) {
+      std::vector<std::string> ds = sh.dirstack();
+      long k = std::atol(dp);
+      long idx = from_end ? static_cast<long>(ds.size()) - 1 - k : k;
+      if (idx >= 0 && static_cast<size_t>(idx) < ds.size()) home = ds[static_cast<size_t>(idx)];
+      else return w;  // out of range: leave literal
+    } else {
+      struct passwd *pw = getpwnam(prefix.c_str());
+      if (pw) home = pw->pw_dir;
+    }
   } else {
     struct passwd *pw = getpwnam(prefix.c_str());
     if (pw) home = pw->pw_dir;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -163,6 +163,11 @@ bool Shell::virtual_array(const std::string &name,
     for (const auto &kv : hashed) pairs.emplace_back(kv.first, kv.second);
     return true;
   }
+  if (name == "DIRSTACK") {
+    auto v = dirstack();
+    for (size_t i = 0; i < v.size(); i++) pairs.emplace_back(std::to_string(i), v[i]);
+    return true;
+  }
   if (name == "BASH_ARGC" || name == "BASH_ARGV") {
     auto v = (name == "BASH_ARGC") ? bash_argc_view() : bash_argv_view();
     for (size_t i = 0; i < v.size(); i++) pairs.emplace_back(std::to_string(i), v[i]);
@@ -335,6 +340,13 @@ std::string Shell::array_get(const std::string &n_in, const std::string &sub) co
   }
   if (n_in == "BASH_ARGC" || n_in == "BASH_ARGV") {  // numeric-indexed views
     auto v = (n_in == "BASH_ARGC") ? bash_argc_view() : bash_argv_view();
+    bool ok = true;
+    long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
+    if (!ok) k = 0;
+    return (k >= 0 && k < static_cast<long long>(v.size())) ? v[k] : std::string();
+  }
+  if (n_in == "DIRSTACK") {  // numeric-indexed live directory stack
+    auto v = dirstack();
     bool ok = true;
     long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
     if (!ok) k = 0;


### PR DESCRIPTION
Fixes #83. dstack2.tests 26 to 0 byte-identical. All 22 ctest suites and 221 differential scripts pass.