### PR TITLE
Restricted shell mode and hash-based execution (batch 11)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -270,6 +270,7 @@ class Shell {
                                 // a script runs command-by-command
 
   bool opt_posix = false;       // -o posix
+  bool opt_restricted = false;  // -r / -o restricted / rbash: restricted shell
   // Turn on `-o history': the first enable loads $HISTFILE and applies the
   // $HISTSIZE stifle, as bash does.
   void enable_history();

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -553,6 +553,10 @@ int change_dir(Shell &sh, const std::string &dir, bool physical) {
 }
 
 int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
+  if (sh.opt_restricted) {
+    std::fprintf(stderr, "%scd: restricted\n", sh.err_prefix().c_str());
+    return 1;
+  }
   bool physical = false;
   size_t i = 1;
   for (; i < argv.size(); i++) {
@@ -923,6 +927,10 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
   else if (o == "histexpand") sh.opt_histexpand = on;
   else if (o == "posix") sh.opt_posix = on;
+  else if (o == "restricted") {
+    if (on) sh.opt_restricted = true;
+    else return false;  // cannot clear restricted; caller reports the error
+  }
   // `set -o vi'/`set -o emacs' switch the readline editing mode (they are
   // mutually exclusive); `+o' flips to the other.
   else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }
@@ -981,6 +989,15 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'n': if (!sh.interactive) sh.opt_noexec = on; break;  // ignored when interactive
           case 'T': sh.opt_functrace = on; break;  // DEBUG/RETURN trap inheritance
           case 'H': sh.opt_histexpand = on; break;  // `!' history expansion
+          case 'r':  // restricted: can be turned on, never off
+            if (on) sh.opt_restricted = true;
+            else {
+              std::fprintf(stderr, "%sset: +r: invalid option\n", sh.err_prefix().c_str());
+              std::fprintf(stderr, "set: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] "
+                                   "[--] [-] [arg ...]\n");
+              return 2;
+            }
+            break;
           case 'o': {
             if (i + 1 >= argv.size()) {
               // `set -o' lists states; `set +o' reproduces as commands.
@@ -989,7 +1006,12 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
                 else std::printf("set %co %s\n", o.second ? '-' : '+', o.first.c_str());
               }
             } else {
-              set_o_option(sh, argv[++i], on);
+              std::string oname = argv[++i];
+              if (!set_o_option(sh, oname, on) && oname == "restricted" && !on) {
+                std::fprintf(stderr, "%sset: restricted: invalid option name\n",
+                             sh.err_prefix().c_str());
+                return 2;
+              }
             }
             k = a.size();  // -o consumes the rest of the word
             break;
@@ -1904,7 +1926,21 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
     }
     if (consumed) continue;
   }
-  if (!ppath.empty() && i < argv.size()) { sh.hashed[argv[i]] = ppath; return 0; }
+  if (!ppath.empty() && i < argv.size()) {
+    // Under a restricted shell, a hashed pathname may not contain `/', and a
+    // relative one cannot be resolved, so neither can be hashed.
+    if (sh.opt_restricted) {
+      if (ppath.find('/') != std::string::npos)
+        std::fprintf(stderr, "%shash: %s: restricted\n", sh.err_prefix().c_str(),
+                     ppath.c_str());
+      else
+        std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(),
+                     ppath.c_str());
+      return 1;
+    }
+    sh.hashed[argv[i]] = ppath;
+    return 0;
+  }
   if (i >= argv.size()) {
     if (sh.hashed.empty()) {
       if (!list_l) std::printf("hash: hash table empty\n");
@@ -3046,6 +3082,12 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     st = sh.run_string(join(argv, 1));
     sh.error_context = saved_ctx;
   } else if (cmd == "source" || cmd == ".") {
+    if (argv.size() > 1 && sh.opt_restricted &&
+        argv[1].find('/') != std::string::npos) {
+      std::fprintf(stderr, "%s%s: %s: restricted\n", sh.err_prefix().c_str(),
+                   cmd.c_str(), argv[1].c_str());
+      return 1;
+    }
     if (argv.size() > 1) {
       // Like bash: a filename without a slash is looked up on PATH first, then
       // (as a fallback) in the current directory.
@@ -3200,7 +3242,12 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       for (size_t k = 1; k < o.size(); k++) {
         if (o[k] == 'v') desc_v = true;
         else if (o[k] == 'V') desc_V = true;
-        else if (o[k] == 'p') { /* default PATH: accepted, no-op */ }
+        else if (o[k] == 'p') {  // default PATH; disallowed under restricted
+          if (sh.opt_restricted) {
+            std::fprintf(stderr, "%scommand: -p: restricted\n", sh.err_prefix().c_str());
+            return 2;
+          }
+        }
         else { bad = true; badopt = std::string("-") + o[k]; break; }
       }
       if (bad) break;
@@ -3236,6 +3283,10 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       else st = 0;
     }
   } else if (cmd == "exec") {
+    if (sh.opt_restricted) {
+      std::fprintf(stderr, "%sexec: restricted\n", sh.err_prefix().c_str());
+      return 2;
+    }
     // Options: -a NAME (argv[0] for the command), -c (empty environment),
     // -l (login: prefix argv[0] with '-').
     size_t i = 1;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -63,6 +63,26 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
     dup2(newfd, fd);
   };
 
+  // A restricted shell forbids output redirections (creating/truncating/
+  // appending files, and fd duplication that writes).
+  if (sh.opt_restricted) {
+    switch (r.op) {
+      case RedirOp::OutputRedir:
+      case RedirOp::Clobber:
+      case RedirOp::AppendOutput:
+      case RedirOp::InputOutput:
+      case RedirOp::AndOutput:
+      case RedirOp::AndAppend: {
+        Expander rex(sh);
+        std::string fn = rex.expand_no_split(r.target.text, true);
+        std::fprintf(stderr, "%s%s: restricted: cannot redirect output\n",
+                     sh.err_prefix().c_str(), fn.c_str());
+        return false;
+      }
+      default: break;
+    }
+  }
+
   switch (r.op) {
     case RedirOp::InputRedir: {
       std::string fn = ex.expand_no_split(r.target.text, true);
@@ -547,7 +567,12 @@ int Executor::run_simple(const SimpleCommand *c) {
       if (o.size() < 2 || o[0] != '-') break;
       for (size_t j = 1; j < o.size(); j++) {
         if (o[j] == 'v' || o[j] == 'V') describe = true;
-        else if (o[j] == 'p') { /* use a default PATH: accepted, no-op here */ }
+        else if (o[j] == 'p') {  // default PATH; forbidden in a restricted shell
+          if (sh_.opt_restricted) {
+            std::fprintf(stderr, "%scommand: -p: restricted\n", sh_.err_prefix().c_str());
+            return (sh_.last_status = 2);
+          }
+        }
         else { bad = true; break; }
       }
       if (bad) break;
@@ -578,6 +603,15 @@ int Executor::run_simple(const SimpleCommand *c) {
     int status = 0;
     run_builtin(sh_, fgargv, &status);
     return (sh_.last_status = status);
+  }
+
+  // A restricted shell forbids a command name containing `/' (a builtin or
+  // function of that literal name would already have matched by exact name).
+  if (sh_.opt_restricted && argv[0].find('/') != std::string::npos &&
+      sh_.functions.find(argv[0]) == sh_.functions.end()) {
+    std::fprintf(stderr, "%s%s: restricted: cannot specify `/' in command names\n",
+                 sh_.err_prefix().c_str(), argv[0].c_str());
+    return (sh_.last_status = 126);
   }
 
   // Builtins and functions run in-process (with redirects applied/restored).
@@ -672,6 +706,20 @@ int Executor::run_simple(const SimpleCommand *c) {
     undo_temp();
   } else {
     undo_temp();  // not a builtin after all: the external path sets its own env
+    // A command name without `/' that has been hashed (`hash -p', BASH_CMDS)
+    // execs the remembered path, as bash does; execvp() still falls back to a
+    // $PATH search for the (unhashed) common case.
+    std::string exec_file = argv[0];
+    if (argv[0].find('/') == std::string::npos) {
+      auto h = sh_.hashed.find(argv[0]);
+      if (h != sh_.hashed.end()) exec_file = h->second;
+    }
+    // execvp searches $PATH for a name without `/', or uses a `/' path
+    // directly; a hashed name execs its remembered value, and reports that
+    // value's name on failure (bash's behavior for `hash'/BASH_CMDS entries).
+    auto do_exec = [&](std::vector<char *> &cargv) {
+      execvp(exec_file.c_str(), cargv.data());
+    };
     // external command.  If we are a disposable subshell child whose sole
     // command this is, exec it in place -- become the command with no second
     // fork/wait (exec_replace was consumed at the top of run_simple).
@@ -686,11 +734,12 @@ int Executor::run_simple(const SimpleCommand *c) {
       for (auto &a : argv) cargv.push_back(const_cast<char *>(a.c_str()));
       cargv.push_back(nullptr);
       std::fflush(nullptr);
-      execvp(cargv[0], cargv.data());
-      if (errno == ENOENT && argv[0].find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: command not found\n", sh_.err_prefix().c_str(), argv[0].c_str());
+      do_exec(cargv);
+      if (errno == ENOENT && exec_file.find('/') == std::string::npos)
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
+                     exec_file == argv[0] ? "command not found" : "not found");
       else
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), argv[0].c_str(), std::strerror(errno));
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
     // external command, in its own process group
@@ -713,12 +762,12 @@ int Executor::run_simple(const SimpleCommand *c) {
       std::vector<char *> cargv;
       for (auto &a : argv) cargv.push_back(const_cast<char *>(a.c_str()));
       cargv.push_back(nullptr);
-      execvp(cargv[0], cargv.data());
-      if (errno == ENOENT && argv[0].find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: command not found\n", sh_.err_prefix().c_str(),
-                     argv[0].c_str());
+      do_exec(cargv);
+      if (errno == ENOENT && exec_file.find('/') == std::string::npos)
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
+                     exec_file == argv[0] ? "command not found" : "not found");
       else
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), argv[0].c_str(),
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
                      std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -269,6 +269,13 @@ int main(int argc, char **argv) {
   // $0 defaults to argv[0] (as bash: `bash -c' shows "bash", "/bin/bash", etc.);
   // a script path or a -c name argument overrides it below.
   sh.arg0 = prog;
+  // Invoked as rbash / rsh / rksh (a leading `r'): a restricted shell.
+  {
+    auto sl = base.rfind('/');
+    std::string nm = sl == std::string::npos ? base : base.substr(sl + 1);
+    if (nm == "rbash" || nm == "rsh" || nm == "rksh" || nm == "rgnash")
+      sh.opt_restricted = true;
+  }
   const std::string prefix = base;
 
   // $SHELL is the execution path of the current shell (persona-independent).
@@ -331,7 +338,8 @@ int main(int argc, char **argv) {
         case 'f': sh.opt_noglob = set; break;
         case 'v': sh.opt_verbose = set; break;
         case 'n': sh.opt_noexec = set; break;  // read but don't execute
-        case 'r': case 'm': case 'B': case 'h': case 'H':
+        case 'r': if (set) sh.opt_restricted = true; break;  // restricted shell
+        case 'm': case 'B': case 'h': case 'H':
           break;  // accepted, not (yet) acted on
         case 'c': have_c = true; stop_after = true; break;
         case 'o': {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -366,6 +366,36 @@ std::string Shell::array_get(const std::string &n_in, const std::string &sub) co
 
 void Shell::array_set(const std::string &n_in, const std::string &sub, const std::string &val) {
   std::string n = deref(n_in);
+  // BASH_CMDS is the live command hash: BASH_CMDS[name]=value adds a hash
+  // entry.  A `/' value is rejected in a restricted shell; a value without a
+  // `/' is resolved through $PATH (and must be found) before it is stored.
+  if (n == "BASH_CMDS") {
+    if (val.find('/') != std::string::npos) {
+      if (opt_restricted) {
+        std::fprintf(stderr, "%s%s: restricted\n", err_prefix().c_str(), val.c_str());
+        return;
+      }
+      hashed[sub] = val;
+      return;
+    }
+    std::string path = get("PATH"), full;
+    size_t p = 0;
+    while (p <= path.size()) {
+      size_t q = path.find(':', p);
+      std::string dir = path.substr(p, q == std::string::npos ? std::string::npos : q - p);
+      if (dir.empty()) dir = ".";
+      std::string cand = dir + "/" + val;
+      if (access(cand.c_str(), X_OK) == 0) { full = cand; break; }
+      if (q == std::string::npos) break;
+      p = q + 1;
+    }
+    if (full.empty()) {
+      std::fprintf(stderr, "%s%s: not found\n", err_prefix().c_str(), val.c_str());
+      return;
+    }
+    hashed[sub] = full;
+    return;
+  }
   Variable &v = vars[n];
   if (v.readonly) return;
   if (v.kind == VarKind::Assoc) {
@@ -598,6 +628,11 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     seconds_base = static_cast<long long>(std::time(nullptr)) -
                    std::strtoll(v.c_str(), nullptr, 10);
     return true;
+  }
+  if (opt_restricted &&
+      (n == "PATH" || n == "SHELL" || n == "ENV" || n == "BASH_ENV")) {
+    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    return false;
   }
   Variable &var = vars[n];
   if (var.readonly) {


### PR DESCRIPTION
Fixes #91. Full rbash restricted mode plus hash-based command execution (a general gap) and writable BASH_CMDS. rsh.tests 27 to 0. All 22 ctest suites (incl. zsh/ksh/csh differentials) and 221 bash differential scripts pass.