### PR TITLE
case conformance: arith-error propagation and compound-command line tracking

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -271,6 +271,10 @@ class Shell {
 
   bool opt_posix = false;       // -o posix
   bool opt_restricted = false;  // -r / -o restricted / rbash: restricted shell
+  // Set when a top-level $((...)) / $[...] arithmetic expansion failed (bad
+  // expression or an assignment to a readonly variable); run_simple aborts the
+  // current command (bash aborts but the shell continues).
+  bool arith_error = false;
   // Turn on `-o history': the first enable loads $HISTFILE and applies the
   // $HISTSIZE stifle, as bash does.
   void enable_history();

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -403,7 +403,8 @@ long long ref_get(const Node *n, Ctx &ctx) {
 void ref_set(const Node *n, long long val, Ctx &ctx) {
   if (n->has_sub)
     ctx.sh.array_set(n->name, ctx.sh.zsh_subscript(n->name, n->sub), std::to_string(val));
-  else ctx.sh.set(n->name, std::to_string(val));
+  else if (!ctx.sh.set(n->name, std::to_string(val)))
+    ctx.ok = false;  // assignment to a readonly variable: the expansion fails
 }
 
 long long eval_node(const Node *n, Ctx &ctx) {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -313,6 +313,10 @@ int Executor::run(const Command *c) {
 
   sh_.run_pending_traps();  // deliver any signals received between commands
 
+  // $LINENO / error line for compound commands (run_simple sets its own).
+  if (c->line > 0 && !dynamic_cast<const SimpleCommand *>(c))
+    sh_.cur_lineno = sh_.lineno_base + c->line;
+
   if (auto *p = dynamic_cast<const SimpleCommand *>(c)) return run_simple(p);
   if (auto *p = dynamic_cast<const Connection *>(c)) return run_connection(p);
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -542,6 +542,14 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
   }
 
+  // A failed arithmetic expansion (bad expression, or assignment to a readonly
+  // variable) during word expansion aborts the command with status 1; the
+  // shell continues.
+  if (sh_.arith_error) {
+    sh_.arith_error = false;
+    return (sh_.last_status = 1);
+  }
+
   if (sh_.opt_xtrace) {
     std::string line = "+";
     for (const auto &a : assigns) line += " " + a.first + "=" + a.second;
@@ -909,6 +917,7 @@ int Executor::run_for(const ForCommand *c) {
 int Executor::run_case(const CaseCommand *c) {
   Expander ex(sh_);
   std::string word = ex.expand_no_split(c->word.text);
+  if (sh_.arith_error) { sh_.arith_error = false; return (sh_.last_status = 1); }
   int st = 0;
   size_t i = 0;
   while (i < c->clauses.size()) {
@@ -916,6 +925,7 @@ int Executor::run_case(const CaseCommand *c) {
     bool m = false;
     for (const Word &pat : cl.patterns) {
       std::string p = ex.expand_pattern(pat.text);
+      if (sh_.arith_error) { sh_.arith_error = false; return (sh_.last_status = 1); }
       std::string pp = p, ww = word;
       if (strmatch(pp.data(), ww.data(), FNM_EXTMATCH) == 0) {
         m = true;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -593,6 +593,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       std::string expr = t.substr(i + 3, (end - 1) - (i + 3));
       bool ok = true;
       long long v = eval_arith(sh_, expand_no_split(expr), &ok);
+      if (!ok) { sh_.arith_error = true; i = end + 1; return; }
       std::string s = std::to_string(v);
       for (char c : s) { out += c; mask += qm; }
       i = end + 1;
@@ -606,6 +607,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       std::string expr = t.substr(i + 2, end - (i + 2));
       bool ok = true;
       long long v = eval_arith(sh_, expand_no_split(expr), &ok);
+      if (!ok) { sh_.arith_error = true; i = end + 1; return; }
       std::string s = std::to_string(v);
       for (char c : s) { out += c; mask += qm; }
       i = end + 1;

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -806,8 +806,10 @@ struct Parser {
   }
 
   CommandPtr parse_case() {
+    int case_line = cur().line;  // $LINENO / error line of the case command
     expect_reserved("case");
     auto n = std::make_unique<CaseCommand>();
+    n->line = case_line;
     if (cur().type != Tok::Word) {
       fail("expected word after `case'");
       return n;


### PR DESCRIPTION
Makes `case.tests` byte-identical to bash 5.3.

- **Abort command on failed arithmetic expansion** — a bad `$((...))`/`$[...]` expression or an assignment to a readonly variable now aborts the current command with status 1 while the shell continues.
- **Track line numbers for compound commands** — `cur_lineno` is refreshed for non-simple commands so $LINENO and error diagnostics point at the right line.

Regression check: 22/22 ctest, all 221 differential scripts match bash, zsh/ksh/csh differentials unaffected.

Closes #93