### PR TITLE
getopts conformance: unset OPTARG when there is no option-argument

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -53,7 +53,9 @@ class Shell {
   bool set(const std::string &n, const std::string &v);
   void set_exported(const std::string &n, const std::string &v);
   void export_name(const std::string &n);
-  void unset(const std::string &n);
+  // Remove N.  A readonly variable is left in place unless FORCE is set
+  // (bash's unbind_variable_noref, used by getopts to clear OPTARG).
+  void unset(const std::string &n, bool force = false);
 
   // --- arrays ------------------------------------------------------------
   std::vector<std::string> array_values(const std::string &n) const;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1645,10 +1645,14 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
                      args[static_cast<size_t>(cur_ai)] == s_curarg;
   if (optind != s_optind || !arg_matches) { s_charidx = 1; s_optind = optind; }
 
+  // bash clears OPTARG with unbind_variable_noref, which removes even a
+  // readonly OPTARG (dropping the readonly attribute), so `${OPTARG-unset}'
+  // reports it unset and a later re-declaration is not blocked.
+  auto clear_optarg = [&]() { sh.unset("OPTARG", true); };
   auto badopt = [&](char c) {
     if (silent) { sh.set(name, "?"); sh.set("OPTARG", std::string(1, c)); }
     else {
-      sh.unset("OPTARG");
+      clear_optarg();
       sh.set(name, "?");
       std::fprintf(stderr, "%s: illegal option -- %c\n", sh.arg0.c_str(), c);
     }
@@ -1656,7 +1660,7 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
   auto needarg = [&](char c) {
     if (silent) { sh.set(name, ":"); sh.set("OPTARG", std::string(1, c)); }
     else {
-      sh.unset("OPTARG");
+      clear_optarg();
       sh.set(name, "?");
       std::fprintf(stderr, "%s: option requires an argument -- %c\n", sh.arg0.c_str(), c);
     }
@@ -1664,7 +1668,7 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
 
   for (;;) {
     int ai = optind - 1;  // 0-based index into args
-    if (ai >= static_cast<int>(args.size())) { sh.set(name, "?"); return 1; }
+    if (ai >= static_cast<int>(args.size())) { clear_optarg(); sh.set(name, "?"); return 1; }
     const std::string &arg = args[static_cast<size_t>(ai)];
 
     // Start of a fresh argument.
@@ -1674,10 +1678,11 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
         s_optind = optind;
         s_charidx = 1;
         sh.set("OPTIND", std::to_string(optind));
+        clear_optarg();
         sh.set(name, "?");
         return 1;
       }
-      if (arg.empty() || arg[0] != '-' || arg == "-") { sh.set(name, "?"); return 1; }
+      if (arg.empty() || arg[0] != '-' || arg == "-") { clear_optarg(); sh.set(name, "?"); return 1; }
       s_charidx = 1;
       s_curarg = arg;
     }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -661,13 +661,15 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
 
 void Shell::export_name(const std::string &n) { vars[n].exported = true; }
 
-void Shell::unset(const std::string &n_in) {
+void Shell::unset(const std::string &n_in, bool force) {
   if (n_in == "HISTSIZE" && history_loaded) unstifle_history();
   // `unset name' on a nameref removes the target; only `unset -n' (not modeled
   // here) removes the nameref itself.  Following the ref matches common usage.
-  std::string n = deref(n_in);
+  // FORCE mirrors bash's unbind_variable_noref: remove the named variable
+  // itself (no nameref following) even when it is readonly.
+  std::string n = force ? n_in : deref(n_in);
   auto it = vars.find(n);
-  if (it != vars.end() && !it->second.readonly) vars.erase(it);
+  if (it != vars.end() && (force || !it->second.readonly)) vars.erase(it);
 }
 
 std::string Shell::ifs() const {


### PR DESCRIPTION
Makes `getopts.tests` byte-identical to bash 5.3.

getopts now removes OPTARG (bash's `unbind_variable_noref`) at end-of-options and on non-silent errors, rather than leaving a stale/empty value. A new `force` mode on `Shell::unset` deletes the named variable without following a nameref and ignoring readonly.

Regression check: 22/22 ctest, all 221 differential scripts match bash.

Closes #95