### PR TITLE
casemod: ${var~}/${var~~} toggle and declare -c capcase

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -39,6 +39,7 @@ struct Variable {
   bool nameref = false;  // `declare -n': value is the name of another variable
   bool ucase = false;    // `declare -u': uppercase the value on every assignment
   bool lcase = false;    // `declare -l': lowercase the value on every assignment
+  bool capcase = false;  // `declare -c': capitalize the value on every assignment
 };
 
 class Shell {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -857,6 +857,7 @@ void declare_print_var(const std::string &name, const Variable &v) {
   if (v.nameref) f += 'n';
   if (v.readonly) f += 'r';
   if (v.exported) f += 'x';
+  if (v.capcase) f += 'c';
   if (v.lcase) f += 'l';
   if (v.ucase) f += 'u';
   std::string decl = "declare -" + (f.empty() ? std::string("-") : f);
@@ -1289,6 +1290,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   bool mk_array = false, mk_assoc = false, integer = false, readonly = force_ro;
   bool exported = false, global = false, local = force_local, nameref = false;
   bool lcase = false, ucase = false;  // -l lowercase / -u uppercase attribute
+  bool capcase = false;               // -c capitalize-first attribute
   bool funcs = false, funcnames = false;  // -f (definitions) / -F (names)
   bool fp = false;                        // -p (display reproducibly)
   size_t i = 1;
@@ -1308,6 +1310,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           case 'n': nameref = true; break;
           case 'l': lcase = true; break;
           case 'u': ucase = true; break;
+          case 'c': capcase = true; break;
           case 'p': fp = true; break;
           default: break;
         }
@@ -1376,6 +1379,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         if (integer) { bool ok = true; val = std::to_string(eval_arith(sh, val, &ok)); }
         if (lcase) for (char &c : val) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         else if (ucase) for (char &c : val) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+        else if (capcase) {
+          bool cfirst = true;
+          for (char &c : val) {
+            c = static_cast<char>(cfirst ? std::toupper(static_cast<unsigned char>(c))
+                                         : std::tolower(static_cast<unsigned char>(c)));
+            cfirst = false;
+          }
+        }
         sh.set(name, val);
       }
     }
@@ -1385,6 +1396,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (integer) v.integer = true;
     if (ucase) v.ucase = true;
     if (lcase) v.lcase = true;
+    if (capcase) v.capcase = true;
     // Mark the nameref last, so the assignment above stored the *target name*
     // as this variable's value rather than being redirected through it.
     if (nameref) v.nameref = true;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -329,7 +329,8 @@ static bool array_op_ref(const std::string &body, std::string &name, char &sel,
   rest = body.substr(p + 3);
   if (rest.empty()) return false;
   char c = rest[0];
-  return c == '^' || c == ',' || c == '#' || c == '%' || c == '/' || c == '@';
+  return c == '^' || c == ',' || c == '~' || c == '#' || c == '%' || c == '/' ||
+         c == '@';
 }
 
 // Detect array/positional slicing: NAME[@]:off[:len] / NAME[*]:off[:len] and
@@ -807,7 +808,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       // substitution /, case-mod ^/,, transform @) to each positional param.
       if ((body[0] == '@' || body[0] == '*') && body.size() > 1 &&
           (body[1] == '#' || body[1] == '%' || body[1] == '/' || body[1] == '^' ||
-           body[1] == ',' || body[1] == '@')) {
+           body[1] == ',' || body[1] == '~' || body[1] == '@')) {
         char psel = body[0];
         std::string prest = body.substr(1);
         std::vector<std::string> items = sh_.positional;
@@ -1291,6 +1292,27 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       if (m && (all || first))
         nc = up ? static_cast<char>(std::toupper(static_cast<unsigned char>(c)))
                 : static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+      if (!all && first) first = false;
+      out += nc;
+    }
+    return out;
+  }
+
+  // ${name~} ${name~~}  (case toggle: ~ the first matching char, ~~ all)
+  if (rest[0] == '~') {
+    bool all = rest.size() > 1 && rest[1] == '~';
+    std::string pat = ex.expand_pattern(rest.substr(all ? 2 : 1));
+    std::string out;
+    bool first = true;
+    for (char c : val) {
+      std::string cs(1, c);
+      bool m = pat.empty() ? true : pat_match(pat, cs);
+      char nc = c;
+      if (m && (all || first)) {
+        unsigned char uc = static_cast<unsigned char>(c);
+        if (std::isupper(uc)) nc = static_cast<char>(std::tolower(uc));
+        else if (std::islower(uc)) nc = static_cast<char>(std::toupper(uc));
+      }
       if (!all && first) first = false;
       out += nc;
     }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -690,11 +690,19 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     return false;
   }
   var.value = v;
-  // `declare -u' / `-l' fold the value's case on every assignment.
+  // `declare -u' / `-l' / `-c' fold the value's case on every assignment.
   if (var.ucase)
     for (char &c : var.value) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
   else if (var.lcase)
     for (char &c : var.value) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  else if (var.capcase) {  // capitalize first character, lowercase the rest
+    bool first = true;
+    for (char &c : var.value) {
+      c = static_cast<char>(first ? std::toupper(static_cast<unsigned char>(c))
+                                  : std::tolower(static_cast<unsigned char>(c)));
+      first = false;
+    }
+  }
   // Assigning HISTSIZE re-stifles the loaded history list, as bash does; a
   // non-numeric or empty value leaves the list unbounded.
   if (n == "HISTSIZE" && history_loaded) {


### PR DESCRIPTION
Implements the last casemod.tests divergences: the `${var~}`/`${var~~}` case-toggle expansions and the `declare -c` capitalize attribute (applied on every assignment, printed by `declare -p`).

Effect: casemod 8→0. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #101