### PR TITLE
Recognize $'...' ANSI-C quoting inside ${...}

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -49,6 +49,13 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close) {
   for (; i < t.size(); i++) {
     char c = t[i];
     if (c == '\\') { i++; continue; }
+    if (c == '$' && i + 1 < t.size() && t[i + 1] == '\'') {
+      // $'...': ANSI-C quoting, where a backslash escapes the next character
+      // (so \' is not a terminator).
+      i += 2;
+      while (i < t.size() && t[i] != '\'') { if (t[i] == '\\' && i + 1 < t.size()) i++; i++; }
+      continue;
+    }
     if (c == '\'') { while (++i < t.size() && t[i] != '\'') {} continue; }
     if (c == '"') {
       while (++i < t.size() && t[i] != '"')

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -161,6 +161,8 @@ struct Lexer {
         depth--;
         w += c;
         pos++;
+      } else if (c == '$' && pos + 1 < n && in[pos + 1] == '\'') {
+        scan_dollar_single(w);  // $'...' inside ${...}: backslash-aware
       } else if (c == '\'') {
         scan_single(w);
       } else if (c == '"') {


### PR DESCRIPTION
`$'...'` inside a `${...}` expansion was scanned as an ordinary single quote, so an escaped `\'` broke brace matching (spurious EOF error or unexpanded result). Both the lexer and the expander's balanced-brace scanner now treat `$'...'` as backslash-aware.

Effect: nquote 27→8. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #103