### PR TITLE
Dynamic variables: BASH_ARGV0/$0, function $LINENO, $BASH_COMMAND, FUNCNAME/GROUPS

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -130,6 +130,10 @@ class Shell {
   struct SrcFrame { std::string name; std::string source; int line; bool is_func; };
   std::vector<SrcFrame> src_frames;
   std::map<std::string, std::string> func_src;  // function name -> defining file
+  // Function name -> the lineno_base in effect where it was defined, so $LINENO
+  // inside the body reports absolute source lines even when the function is
+  // called from a different input block (which has its own lineno_base).
+  std::map<std::string, int> func_lineno_base;
   std::string current_source() const {          // file of the innermost frame
     return src_frames.empty() ? std::string() : src_frames.back().source;
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -484,6 +484,9 @@ int Executor::run_pipeline(const Connection *c) {
 
 int Executor::run_simple(const SimpleCommand *c) {
   if (c->line > 0) sh_.cur_lineno = sh_.lineno_base + c->line;  // $LINENO
+  // $BASH_COMMAND tracks the command currently executing (bash sets it before
+  // every command, not only inside a DEBUG trap).
+  sh_.bash_command = to_string(c);
   // Consume the exec-in-place permission for *this* command up front, so it
   // applies only to a direct external here -- never to commands that a builtin
   // (eval/source) or function invoked by this command goes on to run.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -687,7 +687,13 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
     sh_.push_scope();
     sh_.persona_restore.push_back(std::nullopt);  // for `personality -L' / `emulate -L'
+    // Run the body under the lineno_base captured at definition time so $LINENO
+    // reports absolute source lines regardless of the caller's input block.
+    int saved_lineno_base = sh_.lineno_base;
+    auto lbit = sh_.func_lineno_base.find(argv[0]);
+    if (lbit != sh_.func_lineno_base.end()) sh_.lineno_base = lbit->second;
     status = run(fit->second);
+    sh_.lineno_base = saved_lineno_base;
     if (!sh_.persona_restore.empty()) {
       if (sh_.persona_restore.back()) sh_.set_personality(*sh_.persona_restore.back());
       sh_.persona_restore.pop_back();
@@ -959,6 +965,7 @@ int Executor::run_case(const CaseCommand *c) {
 int Executor::run_funcdef(const FunctionDef *c) {
   sh_.functions[c->name] = c->body.get();
   sh_.func_src[c->name] = sh_.current_source();  // file it was defined in, for BASH_SOURCE
+  sh_.func_lineno_base[c->name] = sh_.lineno_base;  // for $LINENO inside the body
   return 0;
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -668,7 +668,6 @@ int Executor::run_simple(const SimpleCommand *c) {
   if (is_func) {
     apply_temp();
     std::vector<std::string> saved_pos = sh_.positional;
-    std::string saved_arg0 = sh_.arg0;
     sh_.positional.assign(argv.begin() + 1, argv.end());
     // Record the call for `caller': line of the call site, the function name,
     // and the source.
@@ -698,7 +697,6 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.pop_src_frame();
     sh_.call_stack.pop_back();
     sh_.positional = saved_pos;
-    sh_.arg0 = saved_arg0;
     if (sh_.returning) { sh_.returning = false; status = sh_.exit_status; }
     // In posix mode, assignments preceding a function call persist.
     if (sh_.opt_posix) restore.clear();

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -415,6 +415,10 @@ std::string Shell::array_get(const std::string &n_in, const std::string &sub) co
 
 void Shell::array_set(const std::string &n_in, const std::string &sub, const std::string &val) {
   std::string n = deref(n_in);
+  // GROUPS/FUNCNAME carry bash's att_noassign: an assignment is silently
+  // discarded (and does not fail).  Only in the bash family -- zsh has no such
+  // dynamic variables, so an assignment there is ordinary.
+  if ((n == "GROUPS" || n == "FUNCNAME") && !is_zsh()) return;
   // BASH_CMDS is the live command hash: BASH_CMDS[name]=value adds a hash
   // entry.  A `/' value is rejected in a restricted shell; a value without a
   // `/' is resolved through $PATH (and must be found) before it is stored.
@@ -684,6 +688,9 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
     return false;
   }
+  // GROUPS/FUNCNAME carry bash's att_noassign: a scalar assignment is silently
+  // discarded without error (bash family only; zsh has no such variables).
+  if ((n == "GROUPS" || n == "FUNCNAME") && !is_zsh()) return true;
   Variable &var = vars[n];
   if (var.readonly) {
     std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());


### PR DESCRIPTION
Four dynamic-variable fixes for dynvar.tests (one commit each):

- **BASH_ARGV0** — `$0` set via BASH_ARGV0 inside a function now persists after return (the call path no longer saves/restores arg0).
- **$LINENO** — function bodies report absolute source lines even when called from a different input block (definition-time lineno_base restored around the body).
- **$BASH_COMMAND** — maintained for every command, not only inside a DEBUG trap.
- **FUNCNAME/GROUPS** — assignments silently ignored (bash's att_noassign), bash family only.

Effect: dynvar 18→1 (remaining diff is bash's arithmetic `division by 0` message, a separate feature); dbg-support 426→384; nameref 644→636. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #113