### PR TITLE
Array fixes: declare -p assoc trailing space; integer-array arithmetic

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -879,7 +879,8 @@ void declare_print_var(const std::string &name, const Variable &v) {
       first = false;
       decl += "[" + k + "]=" + declare_quote(v.assoc.at(k));
     }
-    decl += ")";
+    // bash prints a space before the closing paren for a non-empty assoc.
+    decl += first ? ")" : " )";
   } else if (!v.value.empty() || v.integer) {
     decl += "=" + declare_quote(v.value);
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -246,16 +246,33 @@ parse_array_elems(Expander &ex, const std::string &parenval) {
 }
 
 void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
+  // An integer-attributed array (`declare -i') evaluates each element value as
+  // an arithmetic expression, and `+=' adds rather than string-appends.
+  auto vit = sh.vars.find(a.name);
+  bool integer = vit != sh.vars.end() && vit->second.integer;
   if (a.sub) {
     // zsh array subscripts are 1-based; translate to the internal 0-based index
     // (a no-op under other personalities / for associative arrays).
     std::string sub = sh.zsh_subscript(a.name, ex.expand_no_split(*a.sub));
     std::string val = ex.expand_assignment(a.value);
-    if (a.append) val = sh.array_get(a.name, sub) + val;
+    if (integer) {
+      bool ok = true;
+      long long rhs = eval_arith(sh, val, &ok);
+      long long base = a.append ? eval_arith(sh, sh.array_get(a.name, sub), &ok) : 0;
+      val = std::to_string(base + rhs);
+    } else if (a.append) {
+      val = sh.array_get(a.name, sub) + val;
+    }
     sh.array_set(a.name, sub, val);
   } else {  // is_array
     bool assoc = sh.vars.count(a.name) && sh.vars[a.name].kind == VarKind::Assoc;
-    sh.array_assign(a.name, parse_array_elems(ex, a.value), a.append, assoc);
+    auto elems = parse_array_elems(ex, a.value);
+    if (integer)
+      for (auto &e : elems) {
+        bool ok = true;
+        e.second = std::to_string(eval_arith(sh, e.second, &ok));
+      }
+    sh.array_assign(a.name, elems, a.append, assoc);
   }
 }
 


### PR DESCRIPTION
Two array fixes:
- `declare -p` prints the trailing space before `)` for non-empty associative arrays.
- Integer-attributed arrays evaluate element assignments (and `+=`) arithmetically.

Effect: appendop 33→25, assoc 439→427, array 640→624, varenv 411→403, nameref 636→628. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #119