### PR TITLE
Handle name+=value in declare/typeset

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1365,6 +1365,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     size_t nend = a.find_first_of("[=");
     std::string name = (nend == std::string::npos) ? a : a.substr(0, nend);
     size_t eq = a.find('=');
+    // A `+=' just before the `=' means append.  For a bare scalar (`name+=')
+    // the `+' is part of neither the name nor the value.
+    bool append = eq != std::string::npos && eq > 0 && a[eq - 1] == '+';
+    if (append && nend == eq) name = a.substr(0, eq - 1);
     if (local && !global) sh.make_local(name);
     if (mk_assoc) sh.make_array(name, true);
     else if (mk_array) sh.make_array(name, false);
@@ -1377,7 +1381,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       } else {
         Expander ex(sh);
         val = ex.expand_assignment(val);  // arg arrives raw (assignment builtin)
-        if (integer) { bool ok = true; val = std::to_string(eval_arith(sh, val, &ok)); }
+        if (integer) {
+          bool ok = true;
+          long long rhs = eval_arith(sh, val, &ok);
+          long long base = append ? eval_arith(sh, sh.get(name), &ok) : 0;
+          val = std::to_string(base + rhs);
+        } else if (append) {
+          val = sh.get(name) + val;
+        }
         if (lcase) for (char &c : val) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         else if (ucase) for (char &c : val) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
         else if (capcase) {


### PR DESCRIPTION
`declare`/`typeset`/`local`/`readonly` didn't recognize `+=`, so `typeset x+=4` used name `x+`. Now appends to the current value (arithmetically for integer variables).

Effect: appendop 33→16. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #123