### PR TITLE
Implement exported functions via the environment

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -318,6 +318,10 @@ class Shell {
   // --- functions ---------------------------------------------------------
   std::map<std::string, const Command *> functions;
   std::vector<CommandPtr> retained;  // keeps eval/source/def trees alive
+  std::set<std::string> exported_functions;  // `export -f': passed to children
+  // Import `BASH_FUNC_name%%=() {...}' definitions from the environment (called
+  // once at startup); parses each safely, ignoring any trailing commands.
+  void import_env_functions();
 
   // --- control-flow signals (set by builtins, honored by the executor) ---
   int break_count = 0;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -790,14 +790,32 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
 }
 
 int bi_export(Shell &sh, const std::vector<std::string> &argv) {
+  bool funcs = false;
+  int st = 0;
   for (size_t i = 1; i < argv.size(); i++) {
-    size_t eq = argv[i].find('=');
+    const std::string &a = argv[i];
+    if (a == "-f") { funcs = true; continue; }
+    if (a == "-n" || a == "-p" || a == "--") continue;  // (unmodeled here / no-op)
+    if (funcs) {
+      // `export -f name': mark a function for the environment of children.  A
+      // name that cannot encode as BASH_FUNC_<name>%% (it contains `=' or `/')
+      // cannot be exported, even though it is a valid function name.
+      if (a.find('=') != std::string::npos || a.find('/') != std::string::npos) {
+        std::fprintf(stderr, "%sexport: %s: cannot export\n", sh.err_prefix().c_str(),
+                     a.c_str());
+        st = 1;
+      } else if (sh.functions.count(a)) {
+        sh.exported_functions.insert(a);
+      }
+      continue;
+    }
+    size_t eq = a.find('=');
     if (eq != std::string::npos)
-      sh.set_exported(argv[i].substr(0, eq), argv[i].substr(eq + 1));
+      sh.set_exported(a.substr(0, eq), a.substr(eq + 1));
     else
-      sh.export_name(argv[i]);
+      sh.export_name(a);
   }
-  return 0;
+  return st;
 }
 
 int bi_unset(Shell &sh, const std::vector<std::string> &argv) {

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -256,6 +256,7 @@ void configure_persona(Shell &sh, const std::string &personality, const std::str
 int main(int argc, char **argv) {
   Shell sh;
   shopt_seed(sh);  // seed default shopt states so $BASHOPTS is populated
+  sh.import_env_functions();  // pull in any BASH_FUNC_*%% exported functions
 
   // Invocation name: basename of argv[0], minus a leading '-' (which marks a
   // login shell).  Drives error-message prefixes and startup-file names.

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -756,7 +756,41 @@ std::vector<std::string> Shell::environ_block() const {
   std::vector<std::string> out;
   for (const auto &kv : vars)
     if (kv.second.exported) out.push_back(kv.first + "=" + kv.second.value);
+  // Exported functions travel as BASH_FUNC_<name>%%=() {  body  }, which a
+  // child bash/gnash re-imports at startup.
+  for (const auto &name : exported_functions) {
+    auto it = functions.find(name);
+    if (it == functions.end()) continue;
+    std::string s = named_function_string(name, it->second);  // "name () \n{...}"
+    size_t br = s.find('(');  // drop the leading "name " so the value is "() {...}"
+    if (br == std::string::npos) continue;
+    out.push_back("BASH_FUNC_" + name + "%%=" + s.substr(br));
+  }
   return out;
+}
+
+void Shell::import_env_functions() {
+  // Collect first, then mutate `vars' (we erase the BASH_FUNC_ entries).
+  std::vector<std::pair<std::string, std::string>> found;
+  for (const auto &kv : vars) {
+    const std::string &k = kv.first;
+    if (k.compare(0, 10, "BASH_FUNC_") == 0 && k.size() > 12 &&
+        k.compare(k.size() - 2, 2, "%%") == 0)
+      found.emplace_back(k.substr(10, k.size() - 12), kv.second.value);
+  }
+  for (const auto &f : found) {
+    const std::string &name = f.first;
+    // Parse `name value' (value is "() {...}").  Accept only a lone function
+    // definition -- any trailing command (a Shellshock payload) is rejected.
+    ParseResult r = parse(name + " " + f.second);
+    if (r.ok && r.command && dynamic_cast<const FunctionDef *>(r.command.get())) {
+      const auto *fd = static_cast<const FunctionDef *>(r.command.get());
+      functions[fd->name] = fd->body.get();
+      func_lineno_base[fd->name] = 0;
+      retained.push_back(std::move(r.command));
+    }
+    vars.erase("BASH_FUNC_" + name + "%%");  // not a real environment variable
+  }
 }
 
 void Shell::set_personality(const std::string &name) {


### PR DESCRIPTION
`export -f` now passes functions to children as `BASH_FUNC_name%%=() {...}`, and children import them at startup (Shellshock-safe: trailing commands ignored). `export -f` rejects un-encodable names (`=`/`/`) with "cannot export".

Effect: exportfunc 15→7, func 212→173. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #127