### PR TITLE
Complete array/assignment append semantics

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -842,9 +842,22 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       continue;
     }
     size_t eq = a.find('=');
-    if (eq != std::string::npos)
-      sh.set_exported(a.substr(0, eq), a.substr(eq + 1));
-    else
+    if (eq != std::string::npos) {
+      // `export name+=value' appends to the current value.
+      bool append = eq > 0 && a[eq - 1] == '+';
+      std::string nm = a.substr(0, append ? eq - 1 : eq);
+      std::string val = a.substr(eq + 1);
+      auto exv = sh.vars.find(nm);
+      if (exv != sh.vars.end() && exv->second.integer) {
+        bool ok = true;
+        long long rhs = eval_arith(sh, val, &ok);
+        long long base = append ? eval_arith(sh, sh.get(nm), &ok) : 0;
+        val = std::to_string(base + rhs);
+      } else if (append) {
+        val = sh.get(nm) + val;
+      }
+      sh.set_exported(nm, val);
+    } else
       sh.export_name(a);
   }
   return st;
@@ -1431,7 +1444,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       } else {
         Expander ex(sh);
         val = ex.expand_assignment(val);  // arg arrives raw (assignment builtin)
-        if (integer) {
+        // Honor a pre-existing integer attribute too (e.g. `readonly x+=7' on a
+        // variable already declared `-i'), not just an `-i' on this command.
+        auto exv = sh.vars.find(name);
+        bool eff_integer = integer || (exv != sh.vars.end() && exv->second.integer);
+        if (eff_integer) {
           bool ok = true;
           long long rhs = eval_arith(sh, val, &ok);
           long long base = append ? eval_arith(sh, sh.get(name), &ok) : 0;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -5,6 +5,7 @@
 
 #include "gnash/core/executor.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <cerrno>
 #include <csignal>
@@ -224,7 +225,8 @@ bool parse_assign(const std::string &w, Assign &a) {
 }
 
 std::vector<std::pair<std::optional<std::string>, std::string>>
-parse_array_elems(Expander &ex, const std::string &parenval) {
+parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer,
+                  bool whole_append, const std::string &parenval) {
   std::vector<std::pair<std::optional<std::string>, std::string>> out;
   std::string inner = parenval.substr(1, parenval.size() - 2);
   for (const Token &t : tokenize(inner)) {
@@ -233,9 +235,24 @@ parse_array_elems(Expander &ex, const std::string &parenval) {
     const std::string &e = t.text;
     if (!e.empty() && e[0] == '[') {
       size_t rb = e.find(']');
-      if (rb != std::string::npos && rb + 1 < e.size() && e[rb + 1] == '=') {
-        out.emplace_back(ex.expand_no_split(e.substr(1, rb - 1)),
-                         ex.expand_no_split(e.substr(rb + 2)));
+      // [sub]=value or [sub]+=value (append to that element).
+      bool app = rb != std::string::npos && rb + 2 < e.size() && e[rb + 1] == '+' &&
+                 e[rb + 2] == '=';
+      bool plain = rb != std::string::npos && rb + 1 < e.size() && e[rb + 1] == '=';
+      if (app || plain) {
+        std::string sub = ex.expand_no_split(e.substr(1, rb - 1));
+        std::string val = ex.expand_no_split(e.substr(rb + (app ? 3 : 2)));
+        if (app) {  // resolve against the current element (fresh assign cleared
+                    // it, so the base is 0 unless this is a whole-array append)
+          std::string base = whole_append ? sh.array_get(name, sh.zsh_subscript(name, sub)) : "0";
+          if (integer) {
+            bool ok = true;
+            val = std::to_string(eval_arith(sh, base, &ok) + eval_arith(sh, val, &ok));
+          } else {
+            val = base + val;
+          }
+        }
+        out.emplace_back(sub, val);
         continue;
       }
     }
@@ -266,7 +283,7 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
     sh.array_set(a.name, sub, val);
   } else {  // is_array
     bool assoc = sh.vars.count(a.name) && sh.vars[a.name].kind == VarKind::Assoc;
-    auto elems = parse_array_elems(ex, a.value);
+    auto elems = parse_array_elems(sh, ex, a.name, integer, a.append, a.value);
     if (integer)
       for (auto &e : elems) {
         bool ok = true;
@@ -886,7 +903,14 @@ int Executor::run_simple(const SimpleCommand *c) {
     // fork/wait (exec_replace was consumed at the top of run_simple).
     if (exec_replace) {
       std::vector<std::string> envs = sh_.environ_block();
-      for (const auto &a : assigns) envs.push_back(a.first + "=" + a.second);
+      for (const auto &a : assigns) {
+        // A temporary assignment overrides any exported value of the same name.
+        std::string pre = a.first + "=";
+        envs.erase(std::remove_if(envs.begin(), envs.end(),
+                                  [&](const std::string &e) { return e.compare(0, pre.size(), pre) == 0; }),
+                   envs.end());
+        envs.push_back(a.first + "=" + a.second);
+      }
       std::vector<char *> envp;
       for (auto &e : envs) envp.push_back(const_cast<char *>(e.c_str()));
       envp.push_back(nullptr);
@@ -915,7 +939,14 @@ int Executor::run_simple(const SimpleCommand *c) {
         signal(SIGTTOU, SIG_DFL);
       }
       std::vector<std::string> envs = sh_.environ_block();
-      for (const auto &a : assigns) envs.push_back(a.first + "=" + a.second);
+      for (const auto &a : assigns) {
+        // A temporary assignment overrides any exported value of the same name.
+        std::string pre = a.first + "=";
+        envs.erase(std::remove_if(envs.begin(), envs.end(),
+                                  [&](const std::string &e) { return e.compare(0, pre.size(), pre) == 0; }),
+                   envs.end());
+        envs.push_back(a.first + "=" + a.second);
+      }
       std::vector<char *> envp;
       for (auto &e : envs) envp.push_back(const_cast<char *>(e.c_str()));
       envp.push_back(nullptr);


### PR DESCRIPTION
Handles the remaining append forms: `[sub]+=` in array literals, integer-attribute-aware `declare/readonly x+=`, `export name+=`, and temporary assignments overriding exported values in the child environment.

Effect: appendop 33→0. array 682→603, assoc 439→417, varenv improved. No file regressed; 22/22 ctest, all 221 differential scripts match bash.

Closes #137