### PR TITLE
Errexit, IFS, expansion, braces, and local/env conformance (batch 39)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -27,7 +27,8 @@ class Expander {
   // Expand a single word without word-splitting (redirect targets, here-doc
   // bodies with `do_expand`, case subjects).  `do_glob` controls pathname
   // expansion (used for redirect filenames).
-  std::string expand_no_split(const std::string &text, bool do_glob = false);
+  std::string expand_no_split(const std::string &text, bool do_glob = false,
+                              bool do_procsub = true);
 
   // Expand a word that will be used as a match pattern (case patterns,
   // [[ == ]] right sides): quoted characters are backslash-escaped in the

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -268,6 +268,7 @@ class Shell {
   void note_cmdsub(int st) { last_cmdsub_status = st; cmdsub_ran = true; }
   bool opt_errexit = false;   // -e
   bool opt_keyword = false;   // -k: assignment-form words anywhere are assignments
+  bool opt_physical = false;  // -P: resolve symlinks in cd/pwd; shown in $-/SHELLOPTS
   bool opt_xtrace = false;    // -x
   bool opt_nounset = false;   // -u
   bool opt_noglob = false;    // -f

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -267,6 +267,7 @@ class Shell {
   bool cmdsub_ran = false;
   void note_cmdsub(int st) { last_cmdsub_status = st; cmdsub_ran = true; }
   bool opt_errexit = false;   // -e
+  bool opt_keyword = false;   // -k: assignment-form words anywhere are assignments
   bool opt_xtrace = false;    // -x
   bool opt_nounset = false;   // -u
   bool opt_noglob = false;    // -f

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -611,6 +611,18 @@ long long eval_arith_msg(Shell &sh, const std::string &expr, const char *cmd_nam
     while (lead < expr.size() && std::isspace(static_cast<unsigned char>(expr[lead]))) lead++;
     std::string display = expr.substr(lead);
     std::string token = expr.substr(ctx.err_pos);
+    // A malformed numeric constant's error token is the number itself, without
+    // the trailing whitespace that padded the expression (`$(( 3425#56 ))' ->
+    // `3425#56', not `3425#56 ').  Operator/operand-expected errors keep their
+    // trailing space, so only trim for the number-constant diagnostics.
+    if (ctx.err_msg == arith_err::kBadBase || ctx.err_msg == arith_err::kBadConst ||
+        ctx.err_msg == arith_err::kBadNumber || ctx.err_msg == arith_err::kTooGreat) {
+      auto rtrim = [](std::string &s) {
+        while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) s.pop_back();
+      };
+      rtrim(display);
+      rtrim(token);
+    }
     std::string prefix = (cmd_name && cmd_name[0]) ? std::string(cmd_name) + ": " : "";
     std::fprintf(stderr, "%s%s%s: %s (error token is \"%s\")\n", sh.err_prefix().c_str(),
                  prefix.c_str(), display.c_str(), ctx.err_msg.c_str(), token.c_str());

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1441,6 +1441,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       bool subscript = nend != std::string::npos && a[nend] == '[';
       if (arraylit || subscript) {
         apply_assignment_word(sh, a);  // NAME=(...) or NAME[i]=...
+      } else if (nameref) {
+        // `declare -n ref=target': store the target NAME as ref's own value.
+        // Bypass Shell::set's deref so retargeting an existing nameref rewrites
+        // the reference itself rather than writing through to its old target.
+        Expander ex(sh);
+        val = ex.expand_assignment(val);
+        Variable &rv = sh.vars[name];
+        if (rv.readonly) {
+          std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
+                       name.c_str());
+          return 1;
+        }
+        rv.value = append ? rv.value + val : val;
       } else {
         Expander ex(sh);
         val = ex.expand_assignment(val);  // arg arrives raw (assignment builtin)

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1482,6 +1482,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // the `+' is part of neither the name nor the value.
     bool append = eq != std::string::npos && eq > 0 && a[eq - 1] == '+';
     if (append && nend == eq) name = a.substr(0, eq - 1);
+    // For a plain scalar assignment, expand the RHS in the ENCLOSING scope
+    // before the variable is localized, so `local x=${x-10}' / `local x=$x'
+    // reference the outer (or temporary-environment) value, as bash does.
+    bool arraylit0 = eq != std::string::npos && a.size() > eq + 2 &&
+                     a[eq + 1] == '(' && a.back() == ')';
+    bool subscript0 = nend != std::string::npos && a[nend] == '[';
+    bool scalar_pre = eq != std::string::npos && !arraylit0 && !subscript0 && !nameref;
+    std::string pre_val;
+    if (scalar_pre) { Expander ex(sh); pre_val = ex.expand_assignment(a.substr(eq + 1)); }
     if (local && !global) sh.make_local(name);
     if (mk_assoc) sh.make_array(name, true);
     else if (mk_array) sh.make_array(name, false);
@@ -1505,8 +1514,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         }
         rv.value = append ? rv.value + val : val;
       } else {
-        Expander ex(sh);
-        val = ex.expand_assignment(val);  // arg arrives raw (assignment builtin)
+        val = pre_val;  // expanded above, in the enclosing scope, before localizing
         // Honor a pre-existing integer attribute too (e.g. `readonly x+=7' on a
         // variable already declared `-i'), not just an `-i' on this command.
         auto exv = sh.vars.find(name);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1401,7 +1401,21 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   if (fp && !funcs && !funcnames) {
     int st = 0;
     if (i >= argv.size()) {
-      for (const auto &kv : sh.vars) declare_print_var(kv.first, kv.second);
+      if (force_local) {
+        // `local -p': only the variables local to the current function scope,
+        // in declaration order (bash), not every shell variable.
+        if (!sh.local_stack.empty()) {
+          std::vector<std::string> seen;
+          for (const auto &pr : sh.local_stack.back()) {
+            if (std::find(seen.begin(), seen.end(), pr.first) != seen.end()) continue;
+            seen.push_back(pr.first);
+            auto it = sh.vars.find(pr.first);
+            if (it != sh.vars.end()) declare_print_var(pr.first, it->second);
+          }
+        }
+      } else {
+        for (const auto &kv : sh.vars) declare_print_var(kv.first, kv.second);
+      }
     } else {
       for (; i < argv.size(); i++) {
         auto it = sh.vars.find(argv[i]);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1473,6 +1473,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     return 0;
   }
 
+  int ret = 0;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     size_t nend = a.find_first_of("[=");
@@ -1492,6 +1493,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     std::string pre_val;
     if (scalar_pre) { Expander ex(sh); pre_val = ex.expand_assignment(a.substr(eq + 1)); }
     if (local && !global) sh.make_local(name);
+    // An array cannot be switched between indexed and associative in place; bash
+    // rejects the redeclaration and leaves the variable unchanged.
+    if (mk_array || mk_assoc) {
+      auto av = sh.vars.find(name);
+      if (av != sh.vars.end()) {
+        if (mk_assoc && av->second.kind == VarKind::Indexed) {
+          std::fprintf(stderr, "%s%s: %s: cannot convert indexed to associative array\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+          ret = 1;
+          continue;
+        }
+        if (mk_array && av->second.kind == VarKind::Assoc) {
+          std::fprintf(stderr, "%s%s: %s: cannot convert associative to indexed array\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+          ret = 1;
+          continue;
+        }
+      }
+    }
     if (mk_assoc) sh.make_array(name, true);
     else if (mk_array) sh.make_array(name, false);
     if (eq != std::string::npos) {
@@ -1561,7 +1581,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (rm_lcase) v.lcase = false;
     if (rm_capcase) v.capcase = false;
   }
-  return 0;
+  return ret;
 }
 
 int bi_let(Shell &sh, const std::vector<std::string> &argv) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -978,6 +978,7 @@ void set_print_var(const std::string &name, const Variable &v) {
 bool set_o_option(Shell &sh, const std::string &o, bool on) {
   if (o == "errexit") sh.opt_errexit = on;
   else if (o == "keyword") sh.opt_keyword = on;
+  else if (o == "physical") sh.opt_physical = on;
   else if (o == "xtrace") sh.opt_xtrace = on;
   else if (o == "nounset") sh.opt_nounset = on;
   else if (o == "noglob") sh.opt_noglob = on;
@@ -1000,12 +1001,16 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   return true;
 }
 
-// The `set -o'/`set +o' option table with each option's current state.
+}  // namespace (close anon: set_option_states needs external linkage for SHELLOPTS)
+
+// The `set -o'/`set +o' option table with each option's current state.  Also
+// used by Shell::dynamic_var to build $SHELLOPTS, so it lives at namespace
+// scope rather than in the anonymous namespace.
 std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
   bool i = sh.interactive;
   return {
       {"allexport", false},   {"braceexpand", true},
-      {"emacs", rl_editing_mode == 1}, {"errexit", sh.opt_errexit},
+      {"emacs", i && rl_editing_mode == 1}, {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
       {"hashall", true},      {"histexpand", sh.opt_histexpand},
       {"history", sh.opt_history}, {"ignoreeof", false},
@@ -1014,11 +1019,13 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
       {"nounset", sh.opt_nounset}, {"onecmd", false},
-      {"physical", false},    {"pipefail", sh.opt_pipefail},
+      {"physical", sh.opt_physical}, {"pipefail", sh.opt_pipefail},
       {"posix", sh.opt_posix}, {"privileged", false},
-      {"verbose", sh.opt_verbose}, {"vi", rl_editing_mode == 0},
+      {"verbose", sh.opt_verbose}, {"vi", i && rl_editing_mode == 0},
       {"xtrace", sh.opt_xtrace}};
 }
+
+namespace {  // reopen the anonymous namespace for the remaining file-local helpers
 
 int bi_set(Shell &sh, const std::vector<std::string> &argv) {
   // No arguments: list all shell variables (name=value), names sorted.
@@ -1044,6 +1051,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
         switch (a[k]) {
           case 'e': sh.opt_errexit = on; break;
           case 'k': sh.opt_keyword = on; break;  // keyword: assignments anywhere
+          case 'P': sh.opt_physical = on; break;  // physical: resolve symlinks
           case 'x': sh.opt_xtrace = on; break;
           case 'u': sh.opt_nounset = on; break;
           case 'f': sh.opt_noglob = on; break;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1423,6 +1423,28 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     return st;
   }
 
+  // Attribute flags with no name arguments list every variable that carries all
+  // of the requested attributes, in `declare -p' form: `typeset -n' lists all
+  // namerefs, `declare -i' all integers, and so on.
+  if (i >= argv.size() &&
+      (nameref || readonly || integer || exported || mk_array || mk_assoc ||
+       lcase || ucase || capcase)) {
+    for (const auto &kv : sh.vars) {
+      const Variable &v = kv.second;
+      if (nameref && !v.nameref) continue;
+      if (readonly && !v.readonly) continue;
+      if (integer && !v.integer) continue;
+      if (exported && !v.exported) continue;
+      if (mk_array && v.kind != VarKind::Indexed) continue;
+      if (mk_assoc && v.kind != VarKind::Assoc) continue;
+      if (lcase && !v.lcase) continue;
+      if (ucase && !v.ucase) continue;
+      if (capcase && !v.capcase) continue;
+      declare_print_var(kv.first, v);
+    }
+    return 0;
+  }
+
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     size_t nend = a.find_first_of("[=");

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1492,6 +1492,27 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     bool scalar_pre = eq != std::string::npos && !arraylit0 && !subscript0 && !nameref;
     std::string pre_val;
     if (scalar_pre) { Expander ex(sh); pre_val = ex.expand_assignment(a.substr(eq + 1)); }
+    // `declare -g name' assigns to the GLOBAL binding even when a local of the
+    // same name shadows it.  Temporarily swap the saved global binding into
+    // `vars', run the normal assignment against it, and restore the local at
+    // the end of the loop body.  (The RHS was already expanded above against the
+    // still-visible local, matching bash.)
+    std::optional<Variable> *gslot = nullptr;
+    Variable held_local;
+    bool had_local = false;
+    if (global) {
+      for (auto &scope : sh.local_stack) {
+        for (auto &e : scope)
+          if (e.first == name) { gslot = &e.second; break; }
+        if (gslot) break;
+      }
+      if (gslot) {
+        auto vit = sh.vars.find(name);
+        if ((had_local = (vit != sh.vars.end()))) held_local = vit->second;
+        if (gslot->has_value()) sh.vars[name] = gslot->value();
+        else sh.vars.erase(name);
+      }
+    }
     if (local && !global) sh.make_local(name);
     // An array cannot be switched between indexed and associative in place; bash
     // rejects the redeclaration and leaves the variable unchanged.
@@ -1580,6 +1601,13 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (rm_ucase) v.ucase = false;
     if (rm_lcase) v.lcase = false;
     if (rm_capcase) v.capcase = false;
+    // Restore the local shadow after a `declare -g' assignment to the global.
+    if (gslot) {
+      auto vit = sh.vars.find(name);
+      *gslot = (vit != sh.vars.end()) ? std::optional<Variable>(vit->second) : std::nullopt;
+      if (had_local) sh.vars[name] = held_local;
+      else sh.vars.erase(name);
+    }
   }
   return ret;
 }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1358,23 +1358,27 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   bool funcs = false, funcnames = false;  // -f (definitions) / -F (names)
   bool fp = false;                        // -p (display reproducibly)
   size_t i = 1;
+  // `+X' flags remove an attribute rather than adding it (`typeset +n foo').
+  bool rm_integer = false, rm_readonly = false, rm_exported = false;
+  bool rm_nameref = false, rm_lcase = false, rm_ucase = false, rm_capcase = false;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
-    if (a.size() >= 2 && a[0] == '-') {
+    if (a.size() >= 2 && (a[0] == '-' || a[0] == '+')) {
+      bool add = a[0] == '-';
       for (size_t k = 1; k < a.size(); k++) {
         switch (a[k]) {
           case 'f': funcs = true; break;
           case 'F': funcnames = true; break;
           case 'a': mk_array = true; break;
           case 'A': mk_assoc = true; break;
-          case 'i': integer = true; break;
-          case 'r': readonly = true; break;
-          case 'x': exported = true; break;
+          case 'i': (add ? integer : rm_integer) = true; break;
+          case 'r': (add ? readonly : rm_readonly) = true; break;
+          case 'x': (add ? exported : rm_exported) = true; break;
           case 'g': global = true; break;
-          case 'n': nameref = true; break;
-          case 'l': lcase = true; break;
-          case 'u': ucase = true; break;
-          case 'c': capcase = true; break;
+          case 'n': (add ? nameref : rm_nameref) = true; break;
+          case 'l': (add ? lcase : rm_lcase) = true; break;
+          case 'u': (add ? ucase : rm_ucase) = true; break;
+          case 'c': (add ? capcase : rm_capcase) = true; break;
           case 'p': fp = true; break;
           default: break;
         }
@@ -1514,6 +1518,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // Mark the nameref last, so the assignment above stored the *target name*
     // as this variable's value rather than being redirected through it.
     if (nameref) v.nameref = true;
+    // `+X' removes attributes.  Applied after the assignment so `typeset +n
+    // foo=other' writes through the still-active nameref to its target before
+    // the reference is torn down, matching bash.
+    if (rm_readonly) v.readonly = false;
+    if (rm_exported) v.exported = false;
+    if (rm_integer) v.integer = false;
+    if (rm_nameref) v.nameref = false;
+    if (rm_ucase) v.ucase = false;
+    if (rm_lcase) v.lcase = false;
+    if (rm_capcase) v.capcase = false;
   }
   return 0;
 }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -977,6 +977,7 @@ void set_print_var(const std::string &name, const Variable &v) {
 // Apply one `set -o NAME' / `set +o NAME'; false if NAME is unknown.
 bool set_o_option(Shell &sh, const std::string &o, bool on) {
   if (o == "errexit") sh.opt_errexit = on;
+  else if (o == "keyword") sh.opt_keyword = on;
   else if (o == "xtrace") sh.opt_xtrace = on;
   else if (o == "nounset") sh.opt_nounset = on;
   else if (o == "noglob") sh.opt_noglob = on;
@@ -1008,7 +1009,7 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
       {"hashall", true},      {"histexpand", sh.opt_histexpand},
       {"history", sh.opt_history}, {"ignoreeof", false},
-      {"interactive-comments", true}, {"keyword", false},
+      {"interactive-comments", true}, {"keyword", sh.opt_keyword},
       {"monitor", i},         {"noclobber", false},
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
@@ -1042,6 +1043,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
       for (size_t k = 1; k < a.size(); k++) {
         switch (a[k]) {
           case 'e': sh.opt_errexit = on; break;
+          case 'k': sh.opt_keyword = on; break;  // keyword: assignments anywhere
           case 'x': sh.opt_xtrace = on; break;
           case 'u': sh.opt_nounset = on; break;
           case 'f': sh.opt_noglob = on; break;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -431,6 +431,16 @@ int Executor::run(const Command *c) {
   if (c->line > 0 && !dynamic_cast<const SimpleCommand *>(c))
     sh_.cur_lineno = sh_.lineno_base + c->line;
 
+  // A negated command (`! cmd') never triggers errexit, and neither do the
+  // commands nested within it -- bash exempts the entire subtree, so that e.g.
+  // the `false' inside `! eval false' does not exit a `set -e' shell.  Suppress
+  // errexit for the duration of the negated command's execution.
+  struct ErrexitGuard {
+    Shell &sh; bool active;
+    ErrexitGuard(Shell &s, bool a) : sh(s), active(a) { if (active) sh.errexit_suppress++; }
+    ~ErrexitGuard() { if (active) sh.errexit_suppress--; }
+  } eg(sh_, (c->flags & CMD_INVERT_RETURN) != 0);
+
   if (auto *p = dynamic_cast<const SimpleCommand *>(c)) return run_simple(p);
   if (auto *p = dynamic_cast<const Connection *>(c)) return run_connection(p);
 
@@ -453,6 +463,15 @@ int Executor::run(const Command *c) {
   restore_fds(saved);
   if (c->flags & CMD_INVERT_RETURN) st = st ? 0 : 1;
   sh_.last_status = st;
+  // A compound command (subshell, group, if, loop, ...) that returns non-zero
+  // triggers errexit at its own level, e.g. `set -e; (exit 17)' exits the shell.
+  // Conditions and negations are already exempted via errexit_suppress / the
+  // CMD_INVERT_RETURN guard in run().
+  if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+      !(c->flags & CMD_INVERT_RETURN)) {
+    sh_.exiting = true;
+    sh_.exit_status = st;
+  }
   return st;
 }
 
@@ -631,6 +650,14 @@ int Executor::run_pipeline(const Connection *c) {
 
   if (c->flags & CMD_INVERT_RETURN) st = st ? 0 : 1;
   sh_.last_status = st;
+  // A pipeline that returns non-zero triggers errexit (e.g. `set -e; true|false').
+  // Suppressed contexts (conditions, `&&'/`||' non-final operands, `!') are
+  // handled by errexit_suppress and the CMD_INVERT_RETURN guard in run().
+  if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+      !(c->flags & CMD_INVERT_RETURN)) {
+    sh_.exiting = true;
+    sh_.exit_status = st;
+  }
   return st;
 }
 
@@ -766,7 +793,15 @@ int Executor::run_simple(const SimpleCommand *c) {
     restore_fds(saved);
     int st = sh_.cmdsub_ran ? sh_.last_cmdsub_status : 0;
     if (c->flags & CMD_INVERT_RETURN) st = st ? 0 : 1;  // a bare `!'
-    return (sh_.last_status = st);
+    sh_.last_status = st;
+    // A failing command substitution in the RHS (`x=$(false)') triggers errexit
+    // just like any other command's non-zero status.
+    if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+        !(c->flags & CMD_INVERT_RETURN)) {
+      sh_.exiting = true;
+      sh_.exit_status = st;
+    }
+    return st;
   }
 
   // A bare job spec in command position (`%1', `%', `%%', `%-', `%name') is a

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -715,8 +715,22 @@ int Executor::run_simple(const SimpleCommand *c) {
         // scalar field.
         bool is_arr = vit != sh_.vars.end() &&
                       (vit->second.kind == VarKind::Indexed || vit->second.kind == VarKind::Assoc);
+        // A preceding assignment in the same command is visible to this RHS
+        // (`A=1 B=$A'): apply the already-collected assignments, expand, then
+        // roll them back so command arguments still see the original values.
+        std::vector<std::pair<std::string, std::optional<Variable>>> prior;
+        for (const auto &pa : assigns) {
+          auto pv = sh_.vars.find(pa.first);
+          prior.push_back({pa.first, pv == sh_.vars.end() ? std::nullopt
+                                                          : std::optional<Variable>(pv->second)});
+          sh_.set(pa.first, pa.second);
+        }
         std::string v = ex.expand_assignment(a.value);
         std::string cur = is_arr ? sh_.array_get(a.name, "0") : sh_.get(a.name);
+        for (auto it = prior.rbegin(); it != prior.rend(); ++it) {
+          if (it->second) sh_.vars[it->first] = *it->second;
+          else sh_.vars.erase(it->first);
+        }
         if (integer) {
           bool ok = true;
           long long rv = eval_arith(sh_, v, &ok);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -696,7 +696,13 @@ int Executor::run_simple(const SimpleCommand *c) {
   // command takes the status of the last one (bash), or 0 if there were none.
   sh_.cmdsub_ran = false;
   for (const Word &w : c->words) {
-    if (prefix && (w.flags & W_ASSIGNMENT)) {
+    // Under `set -k' (keyword mode) an assignment-form word ANYWHERE in the
+    // command is an assignment, not just those preceding the command name.
+    // Checked at run time (the flag can be toggled mid-script) via the word
+    // text, since the parser only marks leading words as W_ASSIGNMENT.
+    bool assign_here = (prefix && (w.flags & W_ASSIGNMENT)) ||
+                       (sh_.opt_keyword && is_assignment_word_text(w.text));
+    if (assign_here) {
       Assign a;
       parse_assign(w.text, a);
       if (a.sub || a.is_array) {

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1836,6 +1836,9 @@ std::vector<std::string> brace_expand(const std::string &text) {
     if (c == '\\') { i++; continue; }
     if (c == '\'' ) { while (++i < text.size() && text[i] != '\'') {} continue; }
     if (c == '"') { while (++i < text.size() && text[i] != '"') { if (text[i]=='\\') i++; } continue; }
+    // A `...` command substitution is opaque to outer brace expansion: its
+    // `{'/`,' belong to the nested command, not this word.
+    if (c == '`') { while (++i < text.size() && text[i] != '`') { if (text[i]=='\\') i++; } continue; }
     // Skip $-constructs so their `{'/`,' aren't treated as brace expansion.
     if (c == '$' && i + 1 < text.size() && (text[i + 1] == '{' || text[i + 1] == '(')) {
       char oc = text[i + 1], cc = oc == '{' ? '}' : ')';
@@ -1933,6 +1936,26 @@ std::vector<std::string> brace_expand(const std::string &text) {
                 out.push_back(pre + tail);
               }
             return out;
+          }
+          // The outer {...} is not itself a brace expression (no top-level comma
+          // or valid range), so its braces are literal -- but an inner brace may
+          // still expand: `a-{b{d,e}}-c' -> a-{bd}-c a-{be}-c.  Recurse on the
+          // interior; if it expands, keep the literal outer braces around each
+          // result and combine with the (recursively expanded) postscript.
+          {
+            std::vector<std::string> inner = brace_expand(inside);
+            bool changed = inner.size() > 1 || (inner.size() == 1 && inner[0] != inside);
+            if (changed) {
+              std::string pre = text.substr(0, open);
+              std::string post = text.substr(i + 1);
+              std::vector<std::string> out;
+              for (const std::string &ie : inner)
+                for (const std::string &tail : brace_expand(post)) {
+                  if (out.size() >= kMaxBraceItems) return {text};
+                  out.push_back(pre + "{" + ie + "}" + tail);
+                }
+              return out;
+            }
           }
           open = std::string::npos;
         }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1102,6 +1102,9 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   bool length = false;
   std::string b = body;
   if (b.size() > 1 && b[0] == '#') { length = true; b = b.substr(1); }
+  // ${#@} and ${#*} are the count of positional parameters (like $#), not the
+  // character length of the expanded list.
+  if (length && (b == "@" || b == "*")) return std::to_string(sh.positional.size());
 
   // ${!name} indirection and ${!prefix*}/${!prefix@} name listing.  A `['
   // after the name is the ${!arr[@]} keys form, handled by the array path.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1869,31 +1869,54 @@ std::vector<std::string> brace_expand(const std::string &text) {
           if (comma) {
             items = parts;
           } else {
-            // numeric or char range {a..b}
-            size_t dots = inside.find("..");
-            if (dots != std::string::npos) {
-              std::string a = inside.substr(0, dots), b = inside.substr(dots + 2);
-              char *ea = nullptr, *eb = nullptr;
+            // Sequence range {start..end} or {start..end..step}.  The step is
+            // taken as a magnitude (its sign is ignored; direction runs from
+            // start to end); a 0 or absent step means 1.
+            size_t d1 = inside.find("..");
+            if (d1 != std::string::npos) {
+              std::string a = inside.substr(0, d1);
+              std::string rest = inside.substr(d1 + 2);
+              size_t d2 = rest.find("..");
+              std::string b = (d2 == std::string::npos) ? rest : rest.substr(0, d2);
+              std::string stepstr = (d2 == std::string::npos) ? std::string() : rest.substr(d2 + 2);
+              char *ea = nullptr, *eb = nullptr, *es = nullptr;
               long va = std::strtol(a.c_str(), &ea, 10), vb = std::strtol(b.c_str(), &eb, 10);
-              if (ea && *ea == '\0' && eb && *eb == '\0' && !a.empty() && !b.empty()) {
-                // Cap the range length: an enormous {a..b} would otherwise build
-                // billions of strings and abort the shell on bad_alloc.  Beyond
-                // the cap, leave the word unexpanded rather than crash.  (span is
-                // the element count minus one; computed via unsigned to avoid
-                // signed overflow on a huge span.)
+              long step = stepstr.empty() ? 1 : std::strtol(stepstr.c_str(), &es, 10);
+              bool step_ok = stepstr.empty() || (es && *es == '\0');
+              if (step == 0) step = 1;
+              else if (step < 0) step = -step;
+              bool a_num = ea && *ea == '\0' && !a.empty();
+              bool b_num = eb && *eb == '\0' && !b.empty();
+              if (a_num && b_num && step_ok) {
+                // Zero-pad the terms to a common width when either bound is
+                // written with a leading zero (`{00..10}' -> 00 01 ... 10).
+                auto digits = [](const std::string &s) {
+                  size_t p = (!s.empty() && (s[0] == '-' || s[0] == '+')) ? 1 : 0;
+                  return s.substr(p);
+                };
+                std::string da = digits(a), db = digits(b);
+                bool pad = (da.size() > 1 && da[0] == '0') || (db.size() > 1 && db[0] == '0');
+                size_t width = std::max(da.size(), db.size());
+                auto fmt = [&](long v) {
+                  if (!pad) return std::to_string(v);
+                  bool neg = v < 0;
+                  std::string d = std::to_string(neg ? -v : v);
+                  while (d.size() < width) d = "0" + d;
+                  return (neg ? "-" : "") + d;
+                };
                 unsigned long long span =
                     (va <= vb) ? static_cast<unsigned long long>(vb) - static_cast<unsigned long long>(va)
                                : static_cast<unsigned long long>(va) - static_cast<unsigned long long>(vb);
-                if (span < kMaxBraceItems) {
-                  if (va <= vb) for (long v = va; v <= vb; v++) items.push_back(std::to_string(v));
-                  else for (long v = va; v >= vb; v--) items.push_back(std::to_string(v));
+                if (span / static_cast<unsigned long long>(step) < kMaxBraceItems) {
+                  if (va <= vb) for (long v = va; v <= vb; v += step) items.push_back(fmt(v));
+                  else for (long v = va; v >= vb; v -= step) items.push_back(fmt(v));
                 }
-              } else if (a.size() == 1 && b.size() == 1 &&
+              } else if (a.size() == 1 && b.size() == 1 && step_ok &&
                          std::isalpha(static_cast<unsigned char>(a[0])) &&
                          std::isalpha(static_cast<unsigned char>(b[0]))) {
                 char ca = a[0], cb = b[0];
-                if (ca <= cb) for (char v = ca; v <= cb; v++) items.push_back(std::string(1, v));
-                else for (char v = ca; v >= cb; v--) items.push_back(std::string(1, v));
+                if (ca <= cb) for (int v = ca; v <= cb; v += step) items.push_back(std::string(1, static_cast<char>(v)));
+                else for (int v = ca; v >= cb; v -= step) items.push_back(std::string(1, static_cast<char>(v)));
               }
             }
           }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1856,6 +1856,9 @@ std::vector<std::string> brace_expand(const std::string &text) {
           bool comma = false;
           for (size_t k = 0; k < inside.size(); k++) {
             char ic = inside[k];
+            // A backslash escapes the next character (`{abc\,def}' is a single
+            // item, not two): keep both so later quote removal strips the `\'.
+            if (ic == '\\' && k + 1 < inside.size()) { cur += ic; cur += inside[++k]; continue; }
             if (ic == '{') d++;
             else if (ic == '}') d--;
             if (ic == ',' && d == 0) { parts.push_back(cur); cur.clear(); comma = true; }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -663,6 +663,35 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
 
+      // ${@} / ${*}: a bare positional list, identical to $@ / $*.  Handle it
+      // here so `"${@}"' keeps its per-parameter field structure rather than
+      // being flattened to a single word by the generic scalar path below.
+      if (body == "@" || body == "*") {
+        const auto &pos = sh_.positional;
+        if (body[0] == '@' && dq) {
+          absorb_qnull();
+          for (size_t k = 0; k < pos.size(); k++) {
+            if (k) { out += FIELD_SEP; mask += MMARK; }
+            out += QNULL; mask += MMARK;
+            for (char c : pos[k]) { out += c; mask += '1'; }
+          }
+        } else if (body[0] == '*' && dq) {
+          std::string sep = sh_.ifs();
+          std::string joiner = sep.empty() ? std::string() : std::string(1, sep[0]);
+          for (size_t k = 0; k < pos.size(); k++) {
+            if (k) for (char c : joiner) { out += c; mask += '1'; }
+            for (char c : pos[k]) { out += c; mask += '1'; }
+          }
+        } else {
+          for (size_t k = 0; k < pos.size(); k++) {
+            if (k) { out += FIELD_SEP; mask += MMARK; }
+            for (char c : pos[k]) { out += c; mask += '0'; }
+          }
+        }
+        i = end + 1;
+        return;
+      }
+
       // ${name-word} / ${name+word} (and the `:' forms) with the operator
       // firing: expand WORD by re-processing it here, so an embedded "$@"
       // keeps its field structure (a flat string would lose empty fields).

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1862,6 +1862,23 @@ std::vector<std::string> brace_expand(const std::string &text) {
             // A backslash escapes the next character (`{abc\,def}' is a single
             // item, not two): keep both so later quote removal strips the `\'.
             if (ic == '\\' && k + 1 < inside.size()) { cur += ic; cur += inside[++k]; continue; }
+            // A quoted comma is not a separator (`{"x,x"}' is one item): copy the
+            // quoted span verbatim, leaving the quotes for later removal.
+            if (ic == '\'') {
+              cur += ic;
+              while (++k < inside.size() && inside[k] != '\'') cur += inside[k];
+              if (k < inside.size()) cur += inside[k];
+              continue;
+            }
+            if (ic == '"') {
+              cur += ic;
+              while (++k < inside.size() && inside[k] != '"') {
+                if (inside[k] == '\\' && k + 1 < inside.size()) cur += inside[k++];
+                cur += inside[k];
+              }
+              if (k < inside.size()) cur += inside[k];
+              continue;
+            }
             if (ic == '{') d++;
             else if (ic == '}') d--;
             if (ic == ',' && d == 0) { parts.push_back(cur); cur.clear(); comma = true; }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1556,39 +1556,41 @@ std::vector<std::pair<std::string, std::string>> Expander::split_ifs(const std::
   bool zsh = sh_.is_zsh();
   auto splittable = [&](char m) { return m == '4' || (m == '0' && !zsh); };
   std::vector<std::pair<std::string, std::string>> fields;
-  std::string cur, curm;
-  bool have = false;
   auto is_ifs = [&](char c) { return ifs.find(c) != std::string::npos; };
   auto is_ws = [&](char c) { return c == ' ' || c == '\t' || c == '\n'; };
-  auto flush = [&]() { fields.emplace_back(cur, curm); cur.clear(); curm.clear(); have = false; };
-  size_t i = 0;
-  while (i < s.size()) {
-    char c = s[i];
-    // Quoted ('1') and literal ('2') text is never split, even when it contains
-    // IFS characters; '0'/'4' expansion output is (subject to the rule above).
-    bool q = mask[i] == '1' || mask[i] == '2';
-    (void)q;
-    if (mask[i] == MMARK && c == FIELD_SEP) {
-      flush();
+  auto soft_ifs = [&](size_t i) { return splittable(mask[i]) && is_ifs(s[i]); };
+  auto soft_ws = [&](size_t i) { return soft_ifs(i) && is_ws(s[i]); };
+  // bash's list_string algorithm (lib/sh/split.c): leading IFS whitespace is
+  // skipped, then each iteration extracts one field and consumes a single
+  // delimiter of the form [IFS ws]* [one IFS non-ws]? [IFS ws]*.  This makes
+  // ` :' (whitespace then a non-whitespace IFS char) a single delimiter, so
+  // `IFS=": "; set -- $x' on x="a :" yields just "a" rather than "a" plus a
+  // spurious empty field.  Quoted ('1') and literal ('2') text is never a
+  // delimiter, even when it contains IFS characters.  FIELD_SEP marks a hard
+  // array/`$@' element boundary that always splits (empty elements preserved).
+  size_t n = s.size(), i = 0;
+  while (i < n && soft_ws(i)) i++;  // strip leading IFS whitespace
+  while (i < n) {
+    std::string cur, curm;
+    while (i < n && !soft_ifs(i) && !(mask[i] == MMARK && s[i] == FIELD_SEP)) {
+      cur += s[i];
+      curm += mask[i];
       i++;
+    }
+    fields.emplace_back(cur, curm);
+    if (i >= n) break;
+    if (mask[i] == MMARK && s[i] == FIELD_SEP) {
+      i++;  // hard boundary; skip any IFS whitespace leading the next element
+      while (i < n && soft_ws(i)) i++;
       continue;
     }
-    if (splittable(mask[i]) && is_ifs(c)) {
-      if (is_ws(c)) {
-        if (have) flush();
-        while (i < s.size() && splittable(mask[i]) && is_ifs(s[i]) && is_ws(s[i])) i++;
-      } else {
-        flush();
-        i++;
-      }
-      continue;
+    // Soft IFS delimiter: [ws]* [one non-ws]? [ws]*.
+    while (i < n && soft_ws(i)) i++;
+    if (i < n && soft_ifs(i) && !is_ws(s[i])) {
+      i++;
+      while (i < n && soft_ws(i)) i++;
     }
-    cur += c;
-    curm += mask[i];
-    have = true;
-    i++;
   }
-  if (have) flush();
   return fields;
 }
 

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1979,6 +1979,23 @@ std::vector<std::string> brace_expand(const std::string &text) {
       }
     }
   }
+  // An unmatched `{' (never balanced by a `}') is literal, but a balanced brace
+  // nested after it may still expand: `a-{bdef-{g,i}-c' -> a-{bdef-g-c
+  // a-{bdef-i-c'.  Re-expand the text following the stray `{' and keep it as a
+  // literal prefix.
+  if (open != std::string::npos && open + 1 < text.size()) {
+    std::string rest = text.substr(open + 1);
+    std::vector<std::string> re = brace_expand(rest);
+    if (re.size() > 1 || (re.size() == 1 && re[0] != rest)) {
+      std::string pre = text.substr(0, open + 1);
+      std::vector<std::string> out;
+      for (const std::string &r : re) {
+        if (out.size() >= kMaxBraceItems) return {text};
+        out.push_back(pre + r);
+      }
+      return out;
+    }
+  }
   return {text};
 }
 

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -255,6 +255,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_noglob) f += 'f';
     f += 'h';                       // hashall: on by default
     if (sh_.interactive) f += 'i';  // rc files test `case $- in *i*)'
+    if (sh_.opt_keyword) f += 'k';  // keyword: assignments anywhere
     if (sh_.job_control) f += 'm';  // monitor: interactive job control
     if (sh_.opt_noexec) f += 'n';
     if (sh_.opt_nounset) f += 'u';
@@ -262,6 +263,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_xtrace) f += 'x';
     f += 'B';                       // braceexpand: on by default
     if (sh_.opt_histexpand) f += 'H';  // histexpand (set -H; interactive default)
+    if (sh_.opt_physical) f += 'P';    // physical: resolve symlinks in cd/pwd
     if (sh_.invocation_char) f += sh_.invocation_char;
     return f;
   }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -532,10 +532,10 @@ void Expander::emit_zsh_subscript(const std::string &name, const std::string &su
     bool ok = true;
     long long lo, hi;
     if (comma != std::string::npos) {
-      lo = eval_arith(sh_, expand_no_split(sub.substr(0, comma)), &ok);
-      hi = eval_arith(sh_, expand_no_split(sub.substr(comma + 1)), &ok);
+      lo = eval_arith(sh_, expand_no_split(sub.substr(0, comma), false, false), &ok);
+      hi = eval_arith(sh_, expand_no_split(sub.substr(comma + 1), false, false), &ok);
     } else {
-      lo = hi = eval_arith(sh_, expand_no_split(sub), &ok);
+      lo = hi = eval_arith(sh_, expand_no_split(sub, false, false), &ok);
     }
     if (lo < 0) lo += n + 1;
     if (hi < 0) hi += n + 1;
@@ -548,8 +548,8 @@ void Expander::emit_zsh_subscript(const std::string &name, const std::string &su
     std::vector<std::string> all = sh_.array_values(name);
     long long n = static_cast<long long>(all.size());
     bool ok = true;
-    long long lo = eval_arith(sh_, expand_no_split(sub.substr(0, comma)), &ok);
-    long long hi = eval_arith(sh_, expand_no_split(sub.substr(comma + 1)), &ok);
+    long long lo = eval_arith(sh_, expand_no_split(sub.substr(0, comma), false, false), &ok);
+    long long hi = eval_arith(sh_, expand_no_split(sub.substr(comma + 1), false, false), &ok);
     if (lo < 0) lo += n + 1;  // -1 == last element (position n)
     if (hi < 0) hi += n + 1;
     std::vector<std::string> items;
@@ -600,7 +600,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     if (end != std::string::npos) {
       std::string expr = t.substr(i + 3, (end - 1) - (i + 3));
       bool ok = true;
-      long long v = eval_arith_msg(sh_, expand_no_split(expr), "", &ok);
+      long long v = eval_arith_msg(sh_, expand_no_split(expr, false, false), "", &ok);
       if (!ok) { sh_.arith_error = true; i = end + 1; return; }
       std::string s = std::to_string(v);
       for (char c : s) { out += c; mask += qm; }
@@ -614,7 +614,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     if (end != std::string::npos) {
       std::string expr = t.substr(i + 2, end - (i + 2));
       bool ok = true;
-      long long v = eval_arith_msg(sh_, expand_no_split(expr), "", &ok);
+      long long v = eval_arith_msg(sh_, expand_no_split(expr, false, false), "", &ok);
       if (!ok) { sh_.arith_error = true; i = end + 1; return; }
       std::string s = std::to_string(v);
       for (char c : s) { out += c; mask += qm; }
@@ -908,12 +908,12 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
         }
         long long n = static_cast<long long>(list.size());
         bool ok = true;
-        long long off = eval_arith(sh_, expand_no_split(soffx), &ok);
+        long long off = eval_arith(sh_, expand_no_split(soffx, false, false), &ok);
         if (!ok) off = 0;
         if (off < 0) { off += n; if (off < 0) off = 0; }
         long long count;
         if (shaslen) {
-          long long len = eval_arith(sh_, expand_no_split(slenx), &ok);
+          long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
           if (!ok) len = 0;
           count = (len < 0) ? (n + len - off) : len;  // negative len = offset from end
         } else {
@@ -1727,6 +1727,26 @@ void Expander::extract_procsubs(std::string &word) {
     if (c == '\\') { i += 2; continue; }
     if (c == '\'') { i++; while (i < word.size() && word[i] != '\'') i++; if (i < word.size()) i++; continue; }
     if (c == '"') { i++; while (i < word.size() && word[i] != '"') { if (word[i] == '\\') i++; i++; } if (i < word.size()) i++; continue; }
+    // Skip $(...) / $((...)) / ${...} and `...`: a `<('/`>(' inside them is not
+    // this word's process substitution (an arithmetic `4>(2+3)' is a comparison,
+    // and a nested command runs its own procsubs when it executes).
+    if (c == '$' && (word[i + 1] == '(' || word[i + 1] == '{')) {
+      char oc = word[i + 1], cc = oc == '(' ? ')' : '}';
+      int depth = 0;
+      size_t j = i + 1;
+      for (; j < word.size(); j++) {
+        if (word[j] == oc) depth++;
+        else if (word[j] == cc) { if (--depth == 0) { j++; break; } }
+      }
+      i = j;
+      continue;
+    }
+    if (c == '`') {
+      size_t j = i + 1;
+      while (j < word.size() && word[j] != '`') { if (word[j] == '\\') j++; j++; }
+      i = (j < word.size()) ? j + 1 : j;
+      continue;
+    }
     if ((c == '<' || c == '>') && word[i + 1] == '(') {
       int depth = 0;
       size_t j = i + 1;
@@ -1810,9 +1830,11 @@ std::string Expander::expand_pattern(const std::string &text) {
   return r;
 }
 
-std::string Expander::expand_no_split(const std::string &text, bool do_glob) {
+std::string Expander::expand_no_split(const std::string &text, bool do_glob, bool do_procsub) {
   std::string src = expand_leading_tilde(sh_, text);  // case subjects, redirects
-  extract_procsubs(src);  // e.g. a redirect target: < <(cmd)
+  // Arithmetic contexts pass do_procsub=false: there `4>(2+3)' is a comparison,
+  // not a `>(cmd)' process substitution.
+  if (do_procsub) extract_procsubs(src);  // e.g. a redirect target: < <(cmd)
   std::string out, mask;
   process(src, out, mask, false);
   // drop internal markers: field separators become spaces, quoted-nulls vanish

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -180,6 +180,35 @@ struct Lexer {
     } while (pos < n && depth > 0);
     if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = '}'; }
   }
+  void scan_square(std::string &w) {  // pos at '[' of $[...] arithmetic
+    int depth = 0;
+    do {
+      char c = in[pos];
+      if (c == '[') {
+        depth++;
+        w += c;
+        pos++;
+      } else if (c == ']') {
+        depth--;
+        w += c;
+        pos++;
+      } else if (c == '\'') {
+        scan_single(w);
+      } else if (c == '"') {
+        scan_double(w);
+      } else if (c == '`') {
+        scan_backtick(w);
+      } else if (c == '\\') {
+        w += c;
+        pos++;
+        if (pos < n) w += in[pos++];
+      } else {
+        w += c;
+        pos++;
+      }
+    } while (pos < n && depth > 0);
+    if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = ']'; }
+  }
   void scan_double(std::string &w) {
     w += in[pos++];  // "
     while (pos < n && in[pos] != '"') {
@@ -300,6 +329,12 @@ struct Lexer {
           w += '$';
           pos++;
           scan_brace(w);
+          continue;
+        }
+        if (pos + 1 < n && in[pos + 1] == '[') {
+          w += '$';
+          pos++;
+          scan_square(w);  // $[...] deprecated arithmetic: span internal spaces
           continue;
         }
         w += c;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -342,7 +342,10 @@ int main(int argc, char **argv) {
         case 'r': if (set) sh.opt_restricted = true; break;  // restricted shell
         case 'm': case 'B': case 'h': case 'H':
           break;  // accepted, not (yet) acted on
-        case 'c': have_c = true; stop_after = true; break;
+        // `-c' takes its command from the next word, but other flags grouped in
+        // the same word still apply -- `-ce cmd' means both `-c' and `-e'.  So
+        // mark have_c and keep scanning the remaining letters of this word.
+        case 'c': have_c = true; break;
         case 'o': {
           std::string name = (k + 1 < a.size()) ? a.substr(k + 1)
                              : (idx + 1 < args.size() ? args[++idx] : "");

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1283,6 +1283,11 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     job_control = false;  // command substitution: no nested tty control
     subshell_level++;  // $BASH_SUBSHELL
     subshell_leaf = true;  // a lone external here can exec in place (no 2nd fork)
+    // Command substitution unsets errexit in the subshell unless the caller has
+    // enabled `shopt -s inherit_errexit'; so `$(false; echo ok)' still runs the
+    // `echo' under `set -e'.  POSIX mode inherits errexit into the subshell, so
+    // there `z=$(false; echo foo)' exits silently before the `echo'.
+    if (opt_errexit && !opt_posix && !shopt_opts["inherit_errexit"]) opt_errexit = false;
     int st = run_string(script);
     std::fflush(stdout);
     _exit(st & 0xff);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -86,9 +86,12 @@ const std::vector<std::string> &Shell::special_var_names() {
   static const std::vector<std::string> names = {
       "RANDOM", "SECONDS", "LINENO", "BASHPID", "BASH_SUBSHELL",
       "EPOCHSECONDS", "EPOCHREALTIME", "BASH_MONOSECONDS", "HISTCMD",
-      "BASHOPTS", "BASH_ALIASES", "BASH_CMDS", "BASH_ARGC", "BASH_ARGV"};
+      "BASHOPTS", "SHELLOPTS", "BASH_ALIASES", "BASH_CMDS", "BASH_ARGC", "BASH_ARGV"};
   return names;
 }
+
+// Defined in builtins.cpp: the state of every `set -o' option, in name order.
+std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh);
 
 // Dynamic variables computed on each reference.  Returns false for names that
 // are not dynamic (the caller then looks them up as ordinary variables).
@@ -126,6 +129,13 @@ bool Shell::dynamic_var(const std::string &name, std::string &out) {
   if (name == "BASHOPTS") {  // colon-separated list of the enabled shopt options
     std::string r;
     for (const auto &kv : shopt_opts) if (kv.second) { if (!r.empty()) r += ':'; r += kv.first; }
+    out = r;
+    return true;
+  }
+  if (name == "SHELLOPTS") {  // colon-separated list of the enabled `set -o' options
+    std::string r;
+    for (const auto &o : set_option_states(*this))
+      if (o.second) { if (!r.empty()) r += ':'; r += o.first; }
     out = r;
     return true;
   }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -456,6 +456,10 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
     assoc_put(v, sub, val);
     return;
   }
+  // A subscripted assignment to an existing scalar promotes it to an indexed
+  // array, keeping the old value as element 0 (`a=abcde; a[2]=x' yields
+  // ([0]=abcde [2]=x)), matching bash.
+  if (v.kind == VarKind::Scalar && !v.value.empty() && v.idx.empty()) v.idx[0] = v.value;
   v.kind = VarKind::Indexed;
   bool ok = true;
   long long k = eval_arith(*this, sub, &ok);
@@ -502,7 +506,17 @@ int Shell::array_count(const std::string &n_in) const {
 void Shell::make_array(const std::string &n_in, bool assoc) {
   std::string n = deref(n_in);
   Variable &v = vars[n];
-  if (v.kind == VarKind::Scalar) v.kind = assoc ? VarKind::Assoc : VarKind::Indexed;
+  if (v.kind == VarKind::Scalar) {
+    // Converting an existing scalar to an indexed array keeps its value as
+    // element 0 (`a=abcde; declare -a a' leaves ${a[0]} == abcde), matching
+    // bash.  An associative array has no natural key for the old value, so bash
+    // discards it there.
+    if (!assoc && !v.value.empty()) {
+      v.idx[0] = v.value;
+      v.value.clear();
+    }
+    v.kind = assoc ? VarKind::Assoc : VarKind::Indexed;
+  }
 }
 
 void Shell::array_assign(


### PR DESCRIPTION
Conformance batch covering errexit, IFS/word-splitting, expansion, braces,
arithmetic, namerefs, arrays, and local/environment semantics.

Byte-for-byte results vs bash 5.3's test suite: **set-e 48→0** and
**ifs-posix 886→0** (now perfect); exp 839→68, braces 64→6, arith 191→170,
varenv 399→205, plus assoc/array/nameref improvements.

**Execution / errexit**
- Apply grouped short options after `-c` (`bash -ce` now enables `-e`)
- Trigger and exempt errexit to match bash (compound/pipeline/assignment
  triggers; `!`-subtree and command-substitution exemptions)

**Word splitting & expansion**
- Rewrite IFS splitting to bash's `list_string` algorithm (no spurious empty
  field from a whitespace-adjacent delimiter)
- Lex `$[...]` arithmetic as a single word
- Expand `${@}`/`${*}`; return the positional count for `${#@}`/`${#*}`
- Do not process-substitute `>(`/`<(` inside arithmetic

**Brace expansion**
- `..step` increment and zero-padding; escaped and quoted commas; inner braces
  of a non-expanding or unmatched outer brace; backtick opacity

**Arithmetic**
- Trim trailing space from numeric error tokens

**declare / local / environment**
- Retarget a nameref without writing through its old target; `+X` attribute
  removal; list variables by attribute for a bare `declare -<attr>`
- Preserve a scalar's value as element 0 when it becomes an array; reject
  indexed↔associative conversion
- `set -k` keyword mode; `$SHELLOPTS`, `set -P`, and the `k`/`P` flags in `$-`
- Restrict `local -p` to the current scope; expand a `local` RHS before
  localizing; `declare -g` assigns through a local shadow; a preceding
  assignment is visible to a later RHS in the same command

Regression-checked throughout: ctest 22/22, run_diff 221/221 byte-identical.

Stacked on #143.
