### PR TITLE
Set $BASH_TRAPSIG while a signal trap runs (#150)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -306,6 +306,7 @@ class Shell {
   void append_history_line(const std::string &line, bool heredoc = false);
   int errexit_suppress = 0;   // >0 while a command's status is being checked
   std::string bash_command;   // $BASH_COMMAND: the command currently executing
+  int trap_sig = 0;           // $BASH_TRAPSIG: signal number while a trap runs
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -117,6 +117,7 @@ bool Shell::dynamic_var(const std::string &name, std::string &out) {
   if (name == "BASHPID") { out = std::to_string(static_cast<long>(getpid())); return true; }
   if (name == "BASH_ARGV0") { out = arg0; return true; }  // reflects $0; always set
   if (name == "BASH_COMMAND") { out = bash_command; return true; }  // command being run
+  if (name == "BASH_TRAPSIG") { out = trap_sig ? std::to_string(trap_sig) : ""; return true; }
   if (name == "HISTCMD") { out = std::to_string(history_length); return true; }  // history number
   if (name == "BASH_SUBSHELL") { out = std::to_string(subshell_level); return true; }
   if (name == "EPOCHSECONDS") {
@@ -270,8 +271,11 @@ void Shell::run_pending_traps() {
     if (it == traps.end() || it->second.empty()) continue;
     in_trap = true;
     int saved = last_status;  // the interrupted command's $?
+    int saved_sig = trap_sig;
+    trap_sig = s;             // $BASH_TRAPSIG names the delivering signal
     std::string cmd = it->second;
     run_string(cmd);
+    trap_sig = saved_sig;
     last_status = saved;
     in_trap = false;
   }


### PR DESCRIPTION
Inside a signal trap, bash exposes the delivering signal's number as
`$BASH_TRAPSIG`; gnash left it empty. Track it in `Shell::trap_sig` around
the handler in `run_pending_traps` and report it via `dynamic_var`.

```
$ gnash -c 'trap '\''echo sig=$BASH_TRAPSIG'\'' USR1; kill -USR1 $$'
sig=30
```

`ctest` 22/22, `run_diff` all 221 match.

Closes #150.