### PR TITLE
Implement the ERR trap (#148)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -151,6 +151,7 @@ class Shell {
   // Run the DEBUG trap; returns its exit status (extdebug: non-zero skips
   // the command about to run).
   int run_debug_trap(const std::string &cmd_text);
+  void run_err_trap(int status);              // run the ERR trap after a failure
 
   // --- job control -------------------------------------------------------
   struct Job {
@@ -308,6 +309,7 @@ class Shell {
   std::string bash_command;   // $BASH_COMMAND: the command currently executing
   int trap_sig = 0;           // $BASH_TRAPSIG: signal number while a trap runs
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
+  bool in_err_trap = false;   // guard: don't fire the ERR trap within itself
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV
   // Call-argument stack for $BASH_ARGC/$BASH_ARGV (only maintained under

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1058,6 +1058,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'v': sh.opt_verbose = on; break;
           case 'n': if (!sh.interactive) sh.opt_noexec = on; break;  // ignored when interactive
           case 'T': sh.opt_functrace = on; break;  // DEBUG/RETURN trap inheritance
+          case 'E': sh.opt_functrace = on; break;  // errtrace: ERR trap inheritance
           case 'H': sh.opt_histexpand = on; break;  // `!' history expansion
           case 'r':  // restricted: can be turned on, never off
             if (on) sh.opt_restricted = true;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -466,11 +466,13 @@ int Executor::run(const Command *c) {
   // A compound command (subshell, group, if, loop, ...) that returns non-zero
   // triggers errexit at its own level, e.g. `set -e; (exit 17)' exits the shell.
   // Conditions and negations are already exempted via errexit_suppress / the
-  // CMD_INVERT_RETURN guard in run().
-  if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+  // CMD_INVERT_RETURN guard in run().  The ERR trap fires for a subshell (a
+  // process boundary) but not for a transparent compound wrapper -- a group,
+  // if/while/for, or function body -- whose own commands already fired it.
+  if (st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
       !(c->flags & CMD_INVERT_RETURN)) {
-    sh_.exiting = true;
-    sh_.exit_status = st;
+    if (dynamic_cast<const Subshell *>(c)) sh_.run_err_trap(st);
+    if (sh_.opt_errexit) { sh_.exiting = true; sh_.exit_status = st; }
   }
   return st;
 }
@@ -587,6 +589,9 @@ int Executor::run_pipeline(const Connection *c) {
       if (prev_read != -1) { dup2(prev_read, 0); close(prev_read); }
       if (i + 1 < n) { close(pipefd[0]); dup2(pipefd[1], 1); close(pipefd[1]); }
       sh_.job_control = false;  // pipeline stage: no nested tty control
+      // A pipeline stage is a subshell: without errtrace it does not inherit the
+      // ERR trap (the whole pipeline fires it once in the parent instead).
+      if (!sh_.opt_functrace) sh_.traps.erase("ERR");
       // A simple command as a pipeline stage does not raise $BASH_SUBSHELL; a
       // compound one does.  An explicit ( ) subshell counts itself in
       // run_subshell, so don't double-count it here.
@@ -653,10 +658,10 @@ int Executor::run_pipeline(const Connection *c) {
   // A pipeline that returns non-zero triggers errexit (e.g. `set -e; true|false').
   // Suppressed contexts (conditions, `&&'/`||' non-final operands, `!') are
   // handled by errexit_suppress and the CMD_INVERT_RETURN guard in run().
-  if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+  if (st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
       !(c->flags & CMD_INVERT_RETURN)) {
-    sh_.exiting = true;
-    sh_.exit_status = st;
+    sh_.run_err_trap(st);
+    if (sh_.opt_errexit) { sh_.exiting = true; sh_.exit_status = st; }
   }
   return st;
 }
@@ -829,10 +834,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.last_status = st;
     // A failing command substitution in the RHS (`x=$(false)') triggers errexit
     // just like any other command's non-zero status.
-    if (sh_.opt_errexit && st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+    if (st != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
         !(c->flags & CMD_INVERT_RETURN)) {
-      sh_.exiting = true;
-      sh_.exit_status = st;
+      sh_.run_err_trap(st);
+      if (sh_.opt_errexit) { sh_.exiting = true; sh_.exit_status = st; }
     }
     return st;
   }
@@ -1062,10 +1067,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     restore_fds(saved);
   if (c->flags & CMD_INVERT_RETURN) status = status ? 0 : 1;
   sh_.last_status = status;
-  if (sh_.opt_errexit && status != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
+  if (status != 0 && sh_.errexit_suppress == 0 && !unwinding() &&
       !(c->flags & CMD_INVERT_RETURN)) {
-    sh_.exiting = true;
-    sh_.exit_status = status;
+    sh_.run_err_trap(status);
+    if (sh_.opt_errexit) { sh_.exiting = true; sh_.exit_status = status; }
   }
   return status;
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -260,6 +260,22 @@ int Shell::run_debug_trap(const std::string &cmd_text) {
   return st;
 }
 
+void Shell::run_err_trap(int status) {
+  auto it = traps.find("ERR");
+  if (it == traps.end() || it->second.empty() || in_err_trap) return;
+  // Without errtrace (`set -E'), the ERR trap is not inherited into functions
+  // or subshells (a forked child raises subshell_level); only the enclosing
+  // shell fires it for the function call / subshell / pipeline as a whole.
+  if (!opt_functrace && (in_function() || subshell_level > 0)) return;
+  in_err_trap = true;
+  int saved = last_status;
+  last_status = status;  // $? inside the ERR trap is the failing command's status
+  std::string body = it->second;
+  run_string(body);
+  last_status = saved;
+  in_err_trap = false;
+}
+
 void Shell::run_pending_traps() {
   if (in_trap) return;
   for (int s = 1; s < NSIG; s++) {


### PR DESCRIPTION
`trap ... ERR` was ignored. bash runs it after a command returns non-zero
in the same non-suppressed contexts as errexit, and under errtrace inside
functions/subshells.

`Shell::run_err_trap()` fires at each errexit decision point for simple
commands, pipelines, and subshells (not for transparent compound wrappers
whose own commands already fired it). Without errtrace it is reset in
forked children and gated by `in_function()`/`subshell_level`. `set -E` is
wired to errtrace.

```
$ gnash -c 'trap "echo ERRTRAP" ERR; false; false; echo done'
ERRTRAP
ERRTRAP
done
```

trap suite 54 → 40; trap7.sub matches. `ctest` 22/22, `run_diff` all 221 match.

Closes #148.