### PR TITLE
Implement the RETURN trap (#158)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -152,6 +152,7 @@ class Shell {
   // the command about to run).
   int run_debug_trap(const std::string &cmd_text);
   void run_err_trap(int status);              // run the ERR trap after a failure
+  int run_return_trap(int status);            // run the RETURN trap on func/source return
 
   // --- job control -------------------------------------------------------
   struct Job {
@@ -310,6 +311,7 @@ class Shell {
   int trap_sig = 0;           // $BASH_TRAPSIG: signal number while a trap runs
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
   bool in_err_trap = false;   // guard: don't fire the ERR trap within itself
+  bool in_return_trap = false;// guard: don't fire the RETURN trap within itself
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV
   // Call-argument stack for $BASH_ARGC/$BASH_ARGV (only maintained under

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -931,7 +931,29 @@ int Executor::run_simple(const SimpleCommand *c) {
     // whole on entry, before the per-command traps inside it.
     if (sh_.opt_functrace && sh_.traps.count("DEBUG") && !sh_.in_debug_trap)
       sh_.run_debug_trap(to_string(fit->second));
+    // Snapshot the RETURN trap so we can tell one the function installs for
+    // itself from an inherited one (only inherited under functrace).
+    auto rtit = sh_.traps.find("RETURN");
+    bool had_return = rtit != sh_.traps.end();
+    std::string return_before = had_return ? rtit->second : std::string();
     status = unwinding() ? sh_.last_status : run(fit->second);
+    // The RETURN trap fires when the function returns, in its own scope, with $?
+    // set to the return status.  It runs when inherited (functrace) or installed
+    // inside the function.
+    {
+      auto rt = sh_.traps.find("RETURN");
+      bool set_now = rt != sh_.traps.end() && !rt->second.empty();
+      bool set_inside = set_now && (!had_return || rt->second != return_before);
+      if (set_now && (sh_.opt_functrace || set_inside)) {
+        int ret_status = sh_.returning ? sh_.exit_status : status;
+        bool save_ret = sh_.returning;
+        int save_es = sh_.exit_status;
+        sh_.returning = false;  // let the trap body run rather than unwind
+        sh_.run_return_trap(ret_status);
+        sh_.returning = save_ret;
+        sh_.exit_status = save_es;
+      }
+    }
     sh_.lineno_base = saved_lineno_base;
     if (!sh_.persona_restore.empty()) {
       if (sh_.persona_restore.back()) sh_.set_personality(*sh_.persona_restore.back());

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -276,6 +276,19 @@ void Shell::run_err_trap(int status) {
   in_err_trap = false;
 }
 
+int Shell::run_return_trap(int status) {
+  auto it = traps.find("RETURN");
+  if (it == traps.end() || it->second.empty() || in_return_trap) return 0;
+  in_return_trap = true;
+  int saved = last_status;
+  last_status = status;  // $? inside the RETURN trap is the function's return status
+  std::string body = it->second;
+  int st = run_string(body);
+  last_status = saved;
+  in_return_trap = false;
+  return st;
+}
+
 void Shell::run_pending_traps() {
   if (in_trap) return;
   for (int s = 1; s < NSIG; s++) {


### PR DESCRIPTION
`trap ... RETURN` was ignored. bash runs it when a function returns, in the
function's scope with `$?` set to the return status, when inherited
(functrace) or installed inside the function.

`Shell::run_return_trap()` fires in the function-invocation path; an
on-entry snapshot distinguishes a self-installed trap from an inherited one.

```
$ gnash -c 'set -T; trap "echo R" RETURN; g(){ :; }; f(){ g; }; f'
R
R
```

trap suite 40 → 36; trap6.sub matches. `ctest` 22/22, `run_diff` all 221 match.

Closes #158.