### PR TITLE
Fire a DEBUG trap a function installs for itself (#164)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -312,6 +312,10 @@ class Shell {
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
   bool in_err_trap = false;   // guard: don't fire the ERR trap within itself
   bool in_return_trap = false;// guard: don't fire the RETURN trap within itself
+  // The DEBUG trap body as it stood when each active function was entered.  A
+  // DEBUG trap the function installs for itself (the body differs from entry)
+  // fires without functrace; an inherited one does not.
+  std::vector<std::string> debug_frame;
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV
   // Call-argument stack for $BASH_ARGC/$BASH_ARGV (only maintained under

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -933,6 +933,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       sh_.argframes.emplace_back(argv.begin() + 1, argv.end());
     }
     sh_.push_scope();
+    sh_.debug_frame.push_back(sh_.traps.count("DEBUG") ? sh_.traps["DEBUG"] : std::string());
     sh_.persona_restore.push_back(std::nullopt);  // for `personality -L' / `emulate -L'
     // Run the body under the lineno_base captured at definition time so $LINENO
     // reports absolute source lines regardless of the caller's input block.
@@ -972,6 +973,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       sh_.persona_restore.pop_back();
     }
     sh_.pop_scope();
+    sh_.debug_frame.pop_back();
     if (pushed_argframe && !sh_.argframes.empty()) sh_.argframes.pop_back();
     sh_.pop_src_frame();
     sh_.call_stack.pop_back();

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -246,8 +246,12 @@ void Shell::set_signal_trap(int signo, bool active) {
 int Shell::run_debug_trap(const std::string &cmd_text) {
   auto it = traps.find("DEBUG");
   if (it == traps.end() || in_debug_trap) return 0;
-  // Without functrace, the DEBUG trap fires only outside functions.
-  if (!opt_functrace && in_function()) return 0;
+  // Without functrace a function does not inherit the DEBUG trap: inside one it
+  // fires only if the function installed its own (the body differs from what it
+  // was when the innermost function was entered).
+  if (!opt_functrace && in_function() &&
+      (debug_frame.empty() || it->second == debug_frame.back()))
+    return 0;
   in_debug_trap = true;
   bash_command = cmd_text;
   int saved = last_status;  // $? inside the trap is the previous command's status


### PR DESCRIPTION
Without functrace, gnash suppressed the DEBUG trap for all commands inside
a function — even one the function set for itself. A per-frame snapshot now
distinguishes a self-installed trap (fires) from an inherited one (does not).

```
$ gnash -c 'f() { trap "echo D[$LINENO]" DEBUG; echo a; echo b; }; f; trap - DEBUG'
D[1]
a
D[1]
b
D[1]
```

`ctest` 22/22, `run_diff` all 221 match.

Closes #164.