### PR TITLE
Deliver the SIGCHLD trap when a child is reaped (#150)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -146,6 +146,8 @@ class Shell {
   bool in_trap = false;                       // guard against trap recursion
   void set_signal_trap(int signo, bool active);  // (de)install the shared handler
   void run_pending_traps();                   // run traps for signals received
+  void note_child_reaped();                   // count a reaped child for the SIGCHLD trap
+  int pending_sigchld = 0;                     // children reaped, awaiting the CHLD trap
   // Run the DEBUG trap (if set) before a command, with $BASH_COMMAND set to
   // CMD_TEXT.  Only fires inside functions when functrace (-T) is enabled.
   // Run the DEBUG trap; returns its exit status (extdebug: non-zero skips

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -518,6 +518,8 @@ int Executor::run_connection(const Connection *c) {
         signal(SIGTSTP, SIG_DFL);
         sh_.job_control = false;  // background: descendants must not touch the tty
         sh_.subshell_level++;
+        sh_.traps.erase("CHLD");  // the parent fires CHLD when it reaps this job
+        sh_.pending_sigchld = 0;
         Executor ex(sh_);
         int s = ex.run(c->first.get());
         std::fflush(nullptr);
@@ -594,6 +596,8 @@ int Executor::run_pipeline(const Connection *c) {
       // it never inherits the parent's EXIT trap -- only one it sets itself runs.
       if (!sh_.opt_functrace) sh_.traps.erase("ERR");
       sh_.traps.erase("EXIT");
+      sh_.traps.erase("CHLD");  // the parent fires CHLD for the stage as a whole
+      sh_.pending_sigchld = 0;
       // A simple command as a pipeline stage does not raise $BASH_SUBSHELL; a
       // compound one does.  An explicit ( ) subshell counts itself in
       // run_subshell, so don't double-count it here.
@@ -631,6 +635,7 @@ int Executor::run_pipeline(const Connection *c) {
     int wst = 0;
     waitpid(pids[i], &wst, WUNTRACED);
     if (WIFSTOPPED(wst)) { any_stopped = true; pstat.push_back(128 + WSTOPSIG(wst)); continue; }
+    sh_.note_child_reaped();  // a pipeline stage that terminated
     int s = WIFEXITED(wst) ? WEXITSTATUS(wst) : (128 + WTERMSIG(wst));
     pstat.push_back(s);
     if (i == pids.size() - 1) last_st = s;
@@ -1091,6 +1096,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       if (sh_.interactive)
         std::fprintf(stderr, "\n[%d]+  Stopped                 %s\n", j->id, cmd.c_str());
     } else {
+      sh_.note_child_reaped();  // a foreground subshell that terminated
       status = WIFEXITED(wst) ? WEXITSTATUS(wst) : (128 + WTERMSIG(wst));
     }
   }
@@ -1123,6 +1129,8 @@ int Executor::run_subshell(const Subshell *c) {
     // A subshell does not inherit the parent's EXIT trap; only one it sets for
     // itself runs when it exits.
     sh_.traps.erase("EXIT");
+    sh_.traps.erase("CHLD");  // the parent fires CHLD for the subshell as a whole
+    sh_.pending_sigchld = 0;
     // (external): a lone simple command can exec in place, no second fork.
     if (dynamic_cast<const SimpleCommand *>(c->body.get())) sh_.can_exec_replace = true;
     Executor ex(sh_);
@@ -1144,6 +1152,7 @@ int Executor::run_subshell(const Subshell *c) {
   }
   int wst = 0;
   waitpid(pid, &wst, 0);
+  sh_.note_child_reaped();  // a foreground external command that terminated
   return WIFEXITED(wst) ? WEXITSTATUS(wst) : 128;
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -158,6 +158,7 @@ void Shell::background_job(Job &j, bool cont) {
 int Shell::wait_for_pid(long pid) {
   int st = 0;
   if (waitpid(static_cast<pid_t>(pid), &st, 0) < 0) return 127;
+  note_child_reaped();
   int rc = WIFEXITED(st) ? WEXITSTATUS(st)
                          : (WIFSIGNALED(st) ? 128 + WTERMSIG(st) : 128);
   for (auto &j : jobs)
@@ -169,10 +170,10 @@ int Shell::wait_for_pid(long pid) {
 int Shell::wait_all() {
   int st = 0;
   for (auto &j : jobs) {
-    if (!j.done) st = wait_job(j);
+    if (!j.done) { st = wait_job(j); if (j.done) for (size_t k = 0; k < j.pids.size(); k++) note_child_reaped(); }
   }
   int wst;
-  while (waitpid(-1, &wst, 0) > 0) {}  // reap any stragglers
+  while (waitpid(-1, &wst, 0) > 0) note_child_reaped();  // reap any stragglers
   return st;
 }
 
@@ -193,6 +194,7 @@ bool Shell::check_job_events() {
         }
       }
     }
+    if (!WIFSTOPPED(wst)) note_child_reaped();  // a background child terminated
   }
   for (const Job &j : jobs)
     if ((j.done || j.stopped) && !j.notified) return true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -235,6 +235,10 @@ const char *signum_to_trapname(int sig) {
 
 void Shell::set_signal_trap(int signo, bool active) {
   if (signo <= 0 || signo >= NSIG) return;
+  // SIGCHLD is reaped synchronously and its trap is delivered from the reap
+  // counter (note_child_reaped), so leave its disposition at the default rather
+  // than installing the async handler -- otherwise the trap would fire twice.
+  if (signo == SIGCHLD) return;
   struct sigaction sa;
   std::memset(&sa, 0, sizeof sa);
   sigemptyset(&sa.sa_mask);
@@ -293,8 +297,26 @@ int Shell::run_return_trap(int status) {
   return st;
 }
 
+void Shell::note_child_reaped() {
+  // bash runs the SIGCHLD trap once for each terminated child; only count while
+  // such a trap is installed.
+  if (traps.count("CHLD")) pending_sigchld++;
+}
+
 void Shell::run_pending_traps() {
   if (in_trap) return;
+  // The SIGCHLD trap fires once per child reaped since the last check.
+  while (pending_sigchld > 0) {
+    auto it = traps.find("CHLD");
+    if (it == traps.end() || it->second.empty()) { pending_sigchld = 0; break; }
+    pending_sigchld--;
+    in_trap = true;
+    int saved = last_status;
+    std::string cmd = it->second;
+    run_string(cmd);
+    last_status = saved;
+    in_trap = false;
+  }
   for (int s = 1; s < NSIG; s++) {
     if (!g_trap_pending[s]) continue;
     g_trap_pending[s] = 0;
@@ -1384,6 +1406,8 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     close(fds[1]);
     job_control = false;  // command substitution: no nested tty control
     subshell_level++;  // $BASH_SUBSHELL
+    traps.erase("CHLD");  // the parent fires CHLD for the substitution as a whole
+    pending_sigchld = 0;
     subshell_leaf = true;  // a lone external here can exec in place (no 2nd fork)
     // Command substitution unsets errexit in the subshell unless the caller has
     // enabled `shopt -s inherit_errexit'; so `$(false; echo ok)' still runs the
@@ -1402,6 +1426,7 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
   close(fds[0]);
   int wst = 0;
   waitpid(pid, &wst, 0);
+  note_child_reaped();  // a command-substitution child terminated
   if (status) *status = WIFEXITED(wst) ? WEXITSTATUS(wst) : 128;
   // Strip trailing newlines, as command substitution does.
   while (!out.empty() && out.back() == '\n') out.pop_back();


### PR DESCRIPTION
`trap ... CHLD` never ran. bash runs it once per reaped child (foreground
externals, subshells, command subs, pipeline stages, background jobs),
between commands, no coalescing.

A `pending_sigchld` counter (incremented at each reap site, drained in
`run_pending_traps`) delivers it; forked children clear it and the inherited
trap; `set_signal_trap` is a no-op for SIGCHLD to avoid double-firing.

```
$ gnash -c 'trap "echo caught" CHLD; ( exit 3 ) & wait'
caught
```

Covers foreground externals, subshells, command subs, pipelines, and a
single background job + wait (trap8.sub now matches). trap suite 31 → 28.
`ctest` 22/22, `run_diff` all 221 match.

A known gap remains for several simultaneous background jobs awaited
together (`wait_all` sees one of them); filed as a follow-up. Refs #150.