### PR TITLE
Background each command of a longer list before '&' separately (#171)

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -277,15 +277,15 @@ struct Parser {
   }
 
   // `&' backgrounds only the command immediately before it.  Because the list
-  // is built left-associatively, that command is LEFT->second when LEFT is a
-  // list-level sequence (`;', newline, or an earlier `&') -- so `A; B &' becomes
-  // `A; (B &)' and `A & B &' becomes `A & (B &)', two separate jobs, rather than
-  // backgrounding the whole preceding list in one child.
+  // is built left-associatively, that command is the rightmost leaf reached by
+  // descending LEFT->second through list-level connectors (`;', newline, or an
+  // earlier `&').  Recursing to that leaf makes `X; A & B & wait' background A
+  // and B as two separate jobs -- not `A & B' together in one child.
   static CommandPtr background_tail(CommandPtr left, CommandPtr right) {
     if (auto *cn = dynamic_cast<Connection *>(left.get());
         cn && (cn->conn == Connector::Semi || cn->conn == Connector::Newline ||
                cn->conn == Connector::Amp)) {
-      cn->second = connect(Connector::Amp, std::move(cn->second), std::move(right));
+      cn->second = background_tail(std::move(cn->second), std::move(right));
       return left;
     }
     return connect(Connector::Amp, std::move(left), std::move(right));


### PR DESCRIPTION
`X; A & B & wait` grouped `A & B` into one background child (background_tail
recursed only one level), so `wait` saw a single job and the SIGCHLD trap
fired once instead of once per job.

Make `background_tail` recurse to the rightmost leaf, so each `&` yields its
own job at any list depth.

```
$ gnash -c 'trap "echo C" CHLD; sleep 0.05 & sleep 0.08 & wait'
C
C
```

trap suite 28 → 27; the trap.tests "caught a child death" diffs are gone.
`ctest` 22/22, `run_diff` all 221 match.

Closes #171.