### PR TITLE
Compound-assignment parsing and declare -p filtering (batch 42)

### DIFF
--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -23,6 +23,7 @@ struct ParseResult {
   std::string error;    // set when ok == false (may be multiple lines)
   int error_line = 0;   // 1-based source line of the failure
   bool incomplete = false;  // input ended mid-construct (needs more lines)
+  bool assign_error = false;  // a compound-assignment syntax error (`a=(x & y)'): $?=1, not 2
   // A here-document body was delimited by end of input: ok stays true and the
   // command is runnable (bash runs it with a warning), but incomplete is also
   // set so line-at-a-time readers keep accumulating input.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1415,7 +1415,21 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           }
         }
       } else {
-        for (const auto &kv : sh.vars) declare_print_var(kv.first, kv.second);
+        // `declare -p' with attribute flags (`-pa', `-pi', `-pr', ...) lists
+        // only the variables carrying those attributes, not every variable.
+        for (const auto &kv : sh.vars) {
+          const Variable &v = kv.second;
+          if (mk_array && v.kind != VarKind::Indexed) continue;
+          if (mk_assoc && v.kind != VarKind::Assoc) continue;
+          if (nameref && !v.nameref) continue;
+          if (readonly && !v.readonly) continue;
+          if (integer && !v.integer) continue;
+          if (exported && !v.exported) continue;
+          if (lcase && !v.lcase) continue;
+          if (ucase && !v.ucase) continue;
+          if (capcase && !v.capcase) continue;
+          declare_print_var(kv.first, v);
+        }
       }
     } else {
       for (; i < argv.size(); i++) {

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -82,6 +82,27 @@ struct Lexer {
     return std::isalpha(static_cast<unsigned char>(c0)) || c0 == '_';
   }
 
+  // The word so far is a plain name (`a', `foo_1'): a candidate array-assignment
+  // target whose `[subscript]' should be scanned as one word.
+  static bool is_name_word(const std::string &w) {
+    if (w.empty() || !(std::isalpha(static_cast<unsigned char>(w[0])) || w[0] == '_'))
+      return false;
+    for (char c : w)
+      if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) return false;
+    return true;
+  }
+
+  // Offset of the `]' matching the `[' at START (handling nesting), or npos.
+  std::size_t matching_bracket(std::size_t start) const {
+    int depth = 0;
+    for (std::size_t k = start; k < n; k++) {
+      if (in[k] == '[') depth++;
+      else if (in[k] == ']' && --depth == 0) return k;
+      else if (in[k] == '\n') break;  // a subscript does not span input lines here
+    }
+    return std::string::npos;
+  }
+
   explicit Lexer(const std::string &s) : in(s), n(s.size()) {}
 
   char cur() const { return in[pos]; }
@@ -271,6 +292,20 @@ struct Lexer {
         scan_paren(w);  // compound (array) assignment value: name=(...)
         quoted = true;
         continue;
+      }
+      // An array-assignment subscript `name[...]=' / `name[...]+=' is one word,
+      // spaces and all (`a[7 + 8]=v'); a bare `name[...]' (no `=') is not -- so
+      // `set -- a[1 2]' still splits.  Only scan when a `=' follows the `]'.
+      if (c == '[' && is_name_word(w)) {
+        std::size_t close = matching_bracket(pos);
+        std::size_t after = close == std::string::npos ? n : close + 1;
+        bool assign = after < n && (in[after] == '=' ||
+                      (in[after] == '+' && after + 1 < n && in[after + 1] == '='));
+        if (assign) {
+          w.append(in, pos, close - pos + 1);
+          pos = close + 1;
+          continue;
+        }
       }
       // Extended-glob operator: ?(...) *(...) +(...) @(...) !(...)
       if ((c == '?' || c == '*' || c == '+' || c == '@' || c == '!') &&

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -77,6 +77,7 @@ struct Parser {
   std::size_t i = 0;
   bool err = false;
   bool incomplete = false;
+  bool assign_error = false;  // compound-assignment syntax error (`a=(x & y)')
   std::string errmsg;
   int err_line = 0;  // source line of the first failure
   // Stack of open compound commands (opener word/char + its line), so an EOF
@@ -453,9 +454,15 @@ struct Parser {
       }
       if (cur().type == Tok::Word) {
         int wf = cur().quoted ? W_QUOTED : 0;
-        if (still_prefix && is_name_assignment(cur().text))
+        if (still_prefix && is_name_assignment(cur().text)) {
+          std::string bad = array_literal_bad_token(cur().text);
+          if (!bad.empty()) {  // e.g. `a=(x & y)': invalid in a compound assignment
+            fail("near unexpected token `" + bad + "'");
+            assign_error = true;  // bash reports $?=1 for this, not the usual 2
+            return sc;
+          }
           wf |= W_ASSIGNMENT;
-        else
+        } else
           still_prefix = false;
         sc->words.push_back(Word{cur().text, wf});
         advance();
@@ -487,6 +494,30 @@ struct Parser {
     }
     if (i < s.size() && s[i] == '+') i++;
     return i < s.size() && s[i] == '=';
+  }
+
+  // If W is an array-literal assignment `name=(...)' whose contents contain a
+  // token that is invalid there -- a control operator (`&' `|' `;' `&&' `||'),
+  // a redirection, or `(' -- return that token's spelling; else "".  bash
+  // accepts only words, `[sub]=' elements, and newlines inside `(...)'.
+  static std::string array_literal_bad_token(const std::string &w) {
+    std::size_t i = 0;
+    if (i >= w.size() || !(std::isalpha(static_cast<unsigned char>(w[i])) || w[i] == '_'))
+      return "";
+    while (i < w.size() && (std::isalnum(static_cast<unsigned char>(w[i])) || w[i] == '_')) i++;
+    if (i < w.size() && w[i] == '[')
+      for (; i < w.size(); i++) if (w[i] == ']') { i++; break; }
+    if (i < w.size() && w[i] == '+') i++;
+    if (i >= w.size() || w[i] != '=') return "";
+    i++;  // past `='
+    if (i >= w.size() || w[i] != '(' || w.back() != ')') return "";  // not an array literal
+    for (const Token &t : tokenize(w.substr(i + 1, w.size() - i - 2))) {
+      if (t.type == Tok::Eof || t.type == Tok::Word || t.type == Tok::Newline ||
+          t.type == Tok::IoNumber)
+        continue;
+      return tok_to_text(t);
+    }
+    return "";
   }
 
   CommandPtr parse_subshell() {
@@ -964,6 +995,7 @@ struct Parser {
       res.error = errmsg;
       res.error_line = err_line;
       res.incomplete = incomplete;
+      res.assign_error = assign_error;
       res.command.reset();
       return res;
     }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1346,8 +1346,10 @@ int Shell::run_string(const std::string &script) {
         std::fprintf(stderr, "%s`%s'\n", pfx.c_str(), src.c_str());
       }
     }
-    last_status = 2;
-    return 2;
+    // A compound-assignment syntax error (`a=(x & y)') is reported by bash with
+    // status 1, not the usual 2.
+    last_status = r.assign_error ? 1 : 2;
+    return last_status;
   }
   if (r.heredoc_eof)  // run anyway, with bash's warning
     std::fprintf(stderr,


### PR DESCRIPTION
Three fixes targeting the `array` test suite (608 → 521), each a real bug
beyond arrays:

1. **Reject a control operator in a compound array assignment.** `a=(x & y)`
   silently dropped the `&`; bash raises `syntax error near unexpected token
   `&'`, echoes the line, and sets `$?`=1. Validated in `parse_simple`.

2. **Apply attribute filters to `declare -p` with no names.** `declare -pa`
   (and `-pi`, `-pr`, ...) dumped every variable instead of only arrays /
   integers / readonly. (~70 lines of the array diff.)

3. **Keep an array-assignment subscript with spaces as one word.**
   `a[7 + 8]=v` tokenized as three words (`a[7: command not found`); now the
   whole `[...]` is scanned when a `=`/`+=` follows the `]`, while
   `set -- a[1 2]` and `echo a[7 + 8]` still split.

`ctest` 22/22, `run_diff` all 221 match on every commit.