### PR TITLE
Fix array-declaration edge cases (batch43)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -40,6 +40,8 @@ struct Variable {
   bool ucase = false;    // `declare -u': uppercase the value on every assignment
   bool lcase = false;    // `declare -l': lowercase the value on every assignment
   bool capcase = false;  // `declare -c': capitalize the value on every assignment
+  bool invisible = false;  // declared with no value (`declare -a b'): unset, so
+                           // `declare -p' prints it without a `=' / `=()' value
 };
 
 class Shell {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -935,7 +935,10 @@ void declare_print_var(const std::string &name, const Variable &v) {
   if (v.ucase) f += 'u';
   std::string decl = "declare -" + (f.empty() ? std::string("-") : f);
   decl += ' ' + name;
-  if (v.kind == VarKind::Indexed) {
+  if (v.invisible) {
+    // Declared with no value (`declare -a b'): bash prints just the attributes
+    // and name, no `=' / `=()'.
+  } else if (v.kind == VarKind::Indexed) {
     decl += "=(";
     bool first = true;
     for (const auto &kv : v.idx) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -842,6 +842,16 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       continue;
     }
     size_t eq = a.find('=');
+    // `export' cannot target a single array element (`export a[5]'); bash reports
+    // it as an invalid identifier.  (zsh's rules differ, so leave it alone.)
+    size_t br = a.find('[');
+    if (br != std::string::npos && (eq == std::string::npos || br < eq) && !sh.is_zsh()) {
+      std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
+      std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), tgt.c_str());
+      st = 1;
+      continue;
+    }
     if (eq != std::string::npos) {
       // `export name+=value' appends to the current value.
       bool append = eq > 0 && a[eq - 1] == '+';
@@ -1504,6 +1514,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     bool arraylit0 = eq != std::string::npos && a.size() > eq + 2 &&
                      a[eq + 1] == '(' && a.back() == ')';
     bool subscript0 = nend != std::string::npos && a[nend] == '[';
+    // `readonly'/`export' cannot target a single array element (`readonly a[5]')
+    // -- bash reports it as an invalid identifier; declare/typeset/local can.
+    // (zsh's array/readonly rules differ, so leave that personality alone.)
+    if (subscript0 && !sh.is_zsh() && (argv[0] == "readonly" || argv[0] == "export")) {
+      std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
+      std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
+                   argv[0].c_str(), tgt.c_str());
+      ret = 1;
+      continue;
+    }
     bool scalar_pre = eq != std::string::npos && !arraylit0 && !subscript0 && !nameref;
     std::string pre_val;
     if (scalar_pre) { Expander ex(sh); pre_val = ex.expand_assignment(a.substr(eq + 1)); }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -268,6 +268,15 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   auto vit = sh.vars.find(a.name);
   bool integer = vit != sh.vars.end() && vit->second.integer;
   if (a.sub) {
+    // A compound value `(...)' cannot be assigned to a single element in bash
+    // (`a[0]=(x y)').  zsh has its own array semantics, so only enforce this
+    // outside the zsh personality.
+    if (a.is_array && !sh.is_zsh()) {
+      std::fprintf(stderr, "%s%s[%s]: cannot assign list to array member\n",
+                   sh.err_prefix().c_str(), a.name.c_str(), a.sub->c_str());
+      sh.last_status = 1;
+      return;
+    }
     // zsh array subscripts are 1-based; translate to the internal 0-based index
     // (a no-op under other personalities / for associative arrays).
     std::string sub = sh.zsh_subscript(a.name, ex.expand_no_split(*a.sub));

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -540,6 +540,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   }
   Variable &v = vars[n];
   if (v.readonly) return;
+  v.invisible = false;  // an assignment makes a declared-but-unset array visible
   if (v.kind == VarKind::Assoc) {
     assoc_put(v, sub, val);
     return;
@@ -593,7 +594,9 @@ int Shell::array_count(const std::string &n_in) const {
 
 void Shell::make_array(const std::string &n_in, bool assoc) {
   std::string n = deref(n_in);
+  bool fresh = !vars.count(n);
   Variable &v = vars[n];
+  if (fresh) v.invisible = true;  // `declare -a b' with no value: declared, unset
   if (v.kind == VarKind::Scalar) {
     // Converting an existing scalar to an indexed array keeps its value as
     // element 0 (`a=abcde; declare -a a' leaves ${a[0]} == abcde), matching
@@ -614,6 +617,7 @@ void Shell::array_assign(
   std::string n = deref(n_in);
   Variable &v = vars[n];
   if (v.readonly) return;
+  v.invisible = false;  // even `b=()' makes a declared-but-unset array visible
   if (!append) {
     v.idx.clear();
     v.assoc.clear();


### PR DESCRIPTION
Continues bash test-suite conformance for the `array` suite.

- **Reject assigning a list to a single array element.** `a[0]=(x y)` is an
  error in bash (`cannot assign list to array member`); gnash silently
  accepted it.
- **Reject a subscripted target for `readonly`/`export`.** `readonly a[0]`
  and `export a[0]` report `not a valid identifier` in bash.
- **Print a declared-but-unset array without a value.** `declare -a b`
  (or `declare -ar c`) declares an invisible array; `declare -p` prints just
  `declare -a b`, not `declare -a b=()`. Added a `Variable::invisible` flag,
  set on fresh `make_array`, cleared by any assignment, honored by the
  declare printer.

All bash-specific behavior is gated on `!is_zsh()` so the zsh personality is
preserved. Gates: ctest 22/22, run_diff all 221 scripts match.