### PR TITLE
Fix nameref temp-env, unset -n, and readonly-target semantics (testsuite batch44)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -61,8 +61,10 @@ class Shell {
   void set_exported(const std::string &n, const std::string &v);
   void export_name(const std::string &n);
   // Remove N.  A readonly variable is left in place unless FORCE is set
-  // (bash's unbind_variable_noref, used by getopts to clear OPTARG).
-  void unset(const std::string &n, bool force = false);
+  // (bash's unbind_variable_noref, used by getopts to clear OPTARG).  When
+  // NOREF is set (`unset -n'), the named nameref variable itself is removed
+  // rather than the variable it points at.
+  void unset(const std::string &n, bool force = false, bool noref = false);
 
   // --- arrays ------------------------------------------------------------
   std::vector<std::string> array_values(const std::string &n) const;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1621,7 +1621,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         sh.set(name, val);
       }
     }
-    Variable &v = sh.vars[name];
+    // Applying an attribute to an existing nameref (without a `-n'/`+n' on this
+    // command) follows the reference and applies it to the target, creating the
+    // target if needed -- e.g. `readonly ref' marks ref's target readonly.  bash
+    // resolves the nameref because -n is not present.
+    std::string aname = name;
+    if (!nameref && !rm_nameref) {
+      auto nit = sh.vars.find(name);
+      if (nit != sh.vars.end() && nit->second.nameref) aname = sh.deref(name);
+    }
+    Variable &v = sh.vars[aname];
     if (readonly) v.readonly = true;
     if (exported) v.exported = true;
     if (integer) v.integer = true;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -875,11 +875,13 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
 
 int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   bool funcs = false;
+  bool noref = false;  // `-n': remove the nameref itself, not its target
   for (size_t i = 1; i < argv.size(); i++) {
     if (argv[i] == "-f") { funcs = true; continue; }
     if (argv[i] == "-v") { funcs = false; continue; }
+    if (argv[i] == "-n") { noref = true; continue; }
     if (funcs) sh.functions.erase(argv[i]);
-    else sh.unset(argv[i]);
+    else sh.unset(argv[i], false, noref);
   }
   return 0;
 }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -913,8 +913,19 @@ int Executor::run_simple(const SimpleCommand *c) {
       auto it = sh_.vars.find(a.first);
       restore.push_back({a.first,
                          it == sh_.vars.end() ? std::nullopt : std::optional<Variable>(it->second)});
-      sh_.set(a.first, a.second);
-      sh_.vars[a.first].exported = true;  // visible to the command's children
+      if (it != sh_.vars.end() && it->second.nameref) {
+        // A temporary assignment to a nameref shadows it with a plain binding
+        // for the duration of the command; it does not write through to the
+        // target variable (bash discards the temp binding afterward, leaving
+        // the nameref and its target unchanged).
+        Variable v;
+        v.value = a.second;
+        v.exported = true;
+        sh_.vars[a.first] = v;
+      } else {
+        sh_.set(a.first, a.second);
+        sh_.vars[a.first].exported = true;  // visible to the command's children
+      }
     }
   };
   auto undo_temp = [&]() {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -841,13 +841,13 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
 
 void Shell::export_name(const std::string &n) { vars[n].exported = true; }
 
-void Shell::unset(const std::string &n_in, bool force) {
+void Shell::unset(const std::string &n_in, bool force, bool noref) {
   if (n_in == "HISTSIZE" && history_loaded) unstifle_history();
-  // `unset name' on a nameref removes the target; only `unset -n' (not modeled
-  // here) removes the nameref itself.  Following the ref matches common usage.
-  // FORCE mirrors bash's unbind_variable_noref: remove the named variable
-  // itself (no nameref following) even when it is readonly.
-  std::string n = force ? n_in : deref(n_in);
+  // `unset name' on a nameref removes the target; `unset -n name' (NOREF)
+  // removes the nameref variable itself.  Following the ref matches common
+  // usage.  FORCE mirrors bash's unbind_variable_noref: remove the named
+  // variable itself (no nameref following) even when it is readonly.
+  std::string n = (force || noref) ? n_in : deref(n_in);
   if (n == "POSIXLY_CORRECT") opt_posix = false;  // unsetting leaves POSIX mode
   auto it = vars.find(n);
   if (it != vars.end() && (force || !it->second.readonly)) vars.erase(it);


### PR DESCRIPTION
Three nameref correctness fixes that bring the `nameref.tests` byte-diff from **599 → 536** against bash 5.3, with no regressions (`ctest` 22/22, `run_diff` all 221 match).

## 1. Scope a temporary assignment to a nameref to the command
`ref=x cmd` where `ref` is a nameref was following the reference and mutating the pointed-at variable **permanently**. bash keeps the assignment scoped: it shadows the nameref with a plain binding for the command and discards it afterward, leaving the target unchanged. `apply_temp()` now shadows rather than writes through.

## 2. Implement `unset -n`
`bi_unset` ignored `-n` entirely, so `unset -n ref` followed the reference and unset the *target*, leaving the nameref itself in place (which then corrupted later `readonly`/assignment through the surviving reference). `-n` is now parsed and `Shell::unset` takes a `noref` flag that removes the named nameref without dereferencing.

## 3. Apply an attribute to a nameref's target
`readonly ref` (and other attribute changes without `-n`) on an existing nameref must follow the reference and mark the *target* — creating it if needed — as bash does. gnash was marking the nameref variable itself, leaving the target writable. The attribute-application block now resolves the target first.

Each fix is a separate commit.