### PR TITLE
Nameref array-element targets, for-loop retargeting, indirect expansion (testsuite batch45)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -54,6 +54,10 @@ class Shell {
   // Follow a `declare -n' nameref chain to the ultimate target name (with a
   // cycle guard); returns n unchanged when it is not a nameref.
   std::string deref(const std::string &n) const;
+  // If following N's nameref chain lands on a subscripted target `base[sub]'
+  // (`declare -n ref=arr[2]'), split it into BASE and SUB (raw subscript text,
+  // evaluated by array_get/array_set) and return true; otherwise false.
+  bool nameref_elt(const std::string &n, std::string &base, std::string &sub) const;
   std::string get(const std::string &n) const;  // "" if unset
   bool get_if_set(const std::string &n, std::string &out) const;
   // Assign N=V; false if N is readonly (an error is printed).

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -876,14 +876,25 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
 int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   bool funcs = false;
   bool noref = false;  // `-n': remove the nameref itself, not its target
+  int ret = 0;
   for (size_t i = 1; i < argv.size(); i++) {
     if (argv[i] == "-f") { funcs = true; continue; }
     if (argv[i] == "-v") { funcs = false; continue; }
     if (argv[i] == "-n") { noref = true; continue; }
-    if (funcs) sh.functions.erase(argv[i]);
-    else sh.unset(argv[i], false, noref);
+    if (funcs) { sh.functions.erase(argv[i]); continue; }
+    // A readonly variable cannot be unset.  Resolve through a nameref (unless
+    // -n) so the target that is actually readonly is the one reported.
+    std::string tgt = noref ? argv[i] : sh.deref(argv[i]);
+    auto it = sh.vars.find(tgt);
+    if (it != sh.vars.end() && it->second.readonly) {
+      std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",
+                   sh.err_prefix().c_str(), tgt.c_str());
+      ret = 1;
+      continue;
+    }
+    sh.unset(argv[i], false, noref);
   }
-  return 0;
+  return ret;
 }
 
 // Quote a scalar value for `set' output: bare if it is "simple", else single

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1433,6 +1433,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // `declare -p' with attribute flags (`-pa', `-pi', `-pr', ...) lists
         // only the variables carrying those attributes, not every variable.
         for (const auto &kv : sh.vars) {
+          const std::string &nm = kv.first;
+          if (nm.empty() || !(std::isalpha(static_cast<unsigned char>(nm[0])) || nm[0] == '_'))
+            continue;  // skip special parameters like $, ?, # (not real variables)
           const Variable &v = kv.second;
           if (mk_array && v.kind != VarKind::Indexed) continue;
           if (mk_assoc && v.kind != VarKind::Assoc) continue;
@@ -1488,6 +1491,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       (nameref || readonly || integer || exported || mk_array || mk_assoc ||
        lcase || ucase || capcase)) {
     for (const auto &kv : sh.vars) {
+      const std::string &nm = kv.first;
+      if (nm.empty() || !(std::isalpha(static_cast<unsigned char>(nm[0])) || nm[0] == '_'))
+        continue;  // skip special parameters like $, ?, # (not real variables)
       const Variable &v = kv.second;
       if (nameref && !v.nameref) continue;
       if (readonly && !v.readonly) continue;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1251,7 +1251,20 @@ int Executor::run_for(const ForCommand *c) {
     std::fprintf(stderr, "%s\n", line.c_str());
   }
   for (const std::string &item : items) {
-    sh_.set(c->var, item);
+    // A nameref loop variable is special: each iteration *retargets* the
+    // reference to name ITEM rather than writing ITEM through to its current
+    // target (bash treats `for ref in a b c' like successive `declare -n
+    // ref=a/b/c').  A readonly nameref cannot be retargeted.
+    auto vit = sh_.vars.find(c->var);
+    if (vit != sh_.vars.end() && vit->second.nameref) {
+      if (vit->second.readonly)
+        std::fprintf(stderr, "%s%s: readonly variable\n", sh_.err_prefix().c_str(),
+                     c->var.c_str());
+      else
+        vit->second.value = item;
+    } else {
+      sh_.set(c->var, item);
+    }
     st = run(c->body.get());
     if (sh_.break_count) { sh_.break_count--; break; }
     if (sh_.continue_count) { sh_.continue_count--; continue; }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1125,6 +1125,14 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
         }
         return names;
       }
+      // ${!ref} where ref is a nameref expands to the NAME of the referenced
+      // variable, not a second level of indirection (bash special-cases a
+      // nameref here).
+      auto nit = sh.vars.find(iname);
+      if (q == b.size() && nit != sh.vars.end() && nit->second.nameref) {
+        std::string tname = sh.deref(iname);
+        return length ? std::to_string(tname.size()) : tname;
+      }
       // The value of INAME is the parameter to expand; any operator that
       // follows applies to the indirected parameter.
       std::string target = sh.get(iname);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -357,16 +357,47 @@ std::string Shell::deref(const std::string &n) const {
   return cur;
 }
 
+bool Shell::nameref_elt(const std::string &n_in, std::string &base,
+                        std::string &sub) const {
+  // Only a nameref may introduce a subscript.  A name that already contains a
+  // `[' is a direct element reference (`a[0]', handled by array_get/array_set),
+  // not a nameref-to-element, and must not be rerouted here.
+  if (n_in.find('[') != std::string::npos) return false;
+  std::string d = deref(n_in);
+  // A `[' in the dereferenced name can only appear because a nameref in the
+  // chain pointed at a subscripted target (`declare -n r=a[2]').
+  size_t lb = d.find('[');
+  if (lb == 0 || lb == std::string::npos || d.back() != ']') return false;
+  base = d.substr(0, lb);
+  sub = d.substr(lb + 1, d.size() - lb - 2);
+  return true;
+}
+
 bool Shell::is_set(const std::string &n_in) const {
   // BASH_ALIASES/BASH_CMDS always exist; BASH_ARGC/BASH_ARGV exist while their
   // (extdebug-only) view is non-empty.
   if (n_in == "BASH_ALIASES" || n_in == "BASH_CMDS") return true;
   if (n_in == "BASH_ARGC" || n_in == "BASH_ARGV") return !argframes.empty();
+  std::string base, sub;
+  if (nameref_elt(n_in, base, sub)) {
+    // A nameref to an array element is "set" iff that element exists.
+    auto it = vars.find(base);
+    if (it == vars.end()) return false;
+    const Variable &v = it->second;
+    if (v.kind == VarKind::Assoc) return v.assoc.count(sub) != 0;
+    bool ok = true;
+    long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
+    if (!ok) k = 0;
+    if (v.kind == VarKind::Indexed) return v.idx.count(k) != 0;
+    return k == 0;  // a scalar's element [0] is the scalar itself
+  }
   std::string n = deref(n_in);
   return vars.count(n) != 0;
 }
 
 std::string Shell::get(const std::string &n_in) const {
+  std::string base, sub;
+  if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
   std::string n = deref(n_in);
   auto it = vars.find(n);
   if (it == vars.end()) return std::string();
@@ -755,6 +786,12 @@ void Shell::make_local(const std::string &n) {
 }
 
 bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
+  std::string base, sub;
+  if (nameref_elt(n_in, base, sub)) {
+    if (!is_set(n_in)) return false;
+    out = array_get(base, sub);
+    return true;
+  }
   std::string n = deref(n_in);
   auto it = vars.find(n);
   if (it == vars.end()) return false;
@@ -775,6 +812,21 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
 }
 
 bool Shell::set(const std::string &n_in, const std::string &v) {
+  // A nameref whose target is an array element (`declare -n r=a[2]'): write
+  // through to that element.  array_set enforces the target's readonly flag.
+  {
+    std::string base, sub;
+    if (nameref_elt(n_in, base, sub)) {
+      auto it = vars.find(base);
+      if (it != vars.end() && it->second.readonly) {
+        std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
+                     base.c_str());
+        return false;
+      }
+      array_set(base, sub, v);
+      return true;
+    }
+  }
   std::string n = deref(n_in);
   // Assigning BASH_ARGV0 resets $0 (and the name used in error messages), as
   // bash does; still stored so `$BASH_ARGV0' reads back the value.

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -392,7 +392,10 @@ bool Shell::is_set(const std::string &n_in) const {
     return k == 0;  // a scalar's element [0] is the scalar itself
   }
   std::string n = deref(n_in);
-  return vars.count(n) != 0;
+  auto it = vars.find(n);
+  // A nameref with no (or a self) target -- deref stops on it -- is unset.
+  if (it != vars.end() && it->second.nameref) return false;
+  return it != vars.end();
 }
 
 std::string Shell::get(const std::string &n_in) const {
@@ -795,6 +798,8 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   std::string n = deref(n_in);
   auto it = vars.find(n);
   if (it == vars.end()) return false;
+  // A nameref with no (or a self) target -- deref stops on it -- is unset.
+  if (it->second.nameref) return false;
   const Variable &v = it->second;
   // An array in scalar context is its element 0 (indexed) / "0" (assoc).
   if (v.kind == VarKind::Indexed) {


### PR DESCRIPTION
Six nameref/variable correctness fixes, bringing `nameref.tests` from **536 → 362** against bash 5.3 (with `nameref5.sub` now byte-perfect), plus small wins in `assoc` (391→390) and `varenv` (201→197). No regressions: `ctest` 22/22, `run_diff` all 221 scripts match.

## 1. Omit special parameters from declare -p listings
A full `declare -p` iterated the whole variable table, including the internal `$` binding gnash keeps to expand `$$`. bash never stores special parameters there. The two `declare -p` listing loops now skip non-identifier names, matching the guard `set` already applies.

## 2. Support a nameref that targets an array element
`declare -n ref=arr[2]` must read/write that element: `${ref}` → `${arr[2]}`, `ref=x` → `arr[2]=x`. gnash treated the literal string `arr[2]` as a variable name. Adds `Shell::nameref_elt` (which fires only when a nameref *introduces* the subscript — a name that already contains `[` is a direct element reference and is left alone) and routes `get`/`get_if_set`/`is_set`/`set` through `array_get`/`array_set`.

## 3. Treat a nameref with no target as unset
`declare -n ref` with no target is unset: `${ref-word}` yields `word`, `[[ -v ref ]]` is false. `is_set`/`get_if_set` now report unset when the deref chain ends on an unresolved nameref.

## 4. Retarget a nameref used as a for-loop variable
`for ref in a b c` retargets the nameref to each word (like successive `declare -n ref=a`) instead of writing through to its target.

## 5. Expand `${!ref}` to the referenced name
When `ref` is a nameref, `${!ref}` expands to the *name* it references (bash special-cases a nameref in the `${!name}` form), not a second indirection level.

## 6. Report an error when unsetting a readonly variable
`unset` on a readonly variable now fails with `cannot unset: readonly variable` and non-zero status (through a nameref, the readonly target is reported).

Each fix is a separate commit.