### PR TITLE
Validate nameref targets (testsuite batch46)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -58,6 +58,9 @@ class Shell {
   // (`declare -n ref=arr[2]'), split it into BASE and SUB (raw subscript text,
   // evaluated by array_get/array_set) and return true; otherwise false.
   bool nameref_elt(const std::string &n, std::string &base, std::string &sub) const;
+  // A valid nameref target: an identifier, optionally with an array subscript
+  // (`foo' or `foo[2]').  bash rejects anything else (`/', `a b', `9x').
+  static bool valid_nameref_target(const std::string &s);
   std::string get(const std::string &n) const;  // "" if unset
   bool get_if_set(const std::string &n, std::string &out) const;
   // Assign N=V; false if N is readonly (an error is printed).

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1604,13 +1604,39 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // the reference itself rather than writing through to its old target.
         Expander ex(sh);
         val = ex.expand_assignment(val);
+        bool preexist = sh.vars.count(name) != 0;
+        auto pv = sh.vars.find(name);
+        std::string tgt =
+            (append && pv != sh.vars.end()) ? pv->second.value + val : val;
+        // A nameref may not point at itself (`declare -n r=r').  At function
+        // scope a same-name target instead refers to the enclosing variable
+        // (bash warns of a circular reference rather than erroring), so only
+        // reject a self reference outside a function.
+        if (tgt == name && !sh.in_function()) {
+          std::fprintf(stderr,
+                       "%s%s: %s: nameref variable self references not allowed\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+          ret = 1;
+          if (!preexist) sh.vars.erase(name);
+          continue;
+        }
+        // The target must be a valid nameref target (`foo' or `foo[2]').  bash
+        // rejects anything else and does not create the variable.
+        if (!tgt.empty() && !Shell::valid_nameref_target(tgt)) {
+          std::fprintf(stderr,
+                       "%s%s: `%s': invalid variable name for name reference\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+          ret = 1;
+          if (!preexist) sh.vars.erase(name);  // no half-created variable
+          continue;
+        }
         Variable &rv = sh.vars[name];
         if (rv.readonly) {
           std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
                        name.c_str());
           return 1;
         }
-        rv.value = append ? rv.value + val : val;
+        rv.value = tgt;
       } else {
         val = pre_val;  // expanded above, in the enclosing scope, before localizing
         // Honor a pre-existing integer attribute too (e.g. `readonly x+=7' on a
@@ -1635,6 +1661,18 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             cfirst = false;
           }
         }
+        // Retargeting an existing empty nameref via `declare r=val' validates
+        // the value like a plain assignment, but the diagnostic carries the
+        // builtin name (Shell::set would print it bare).
+        auto nrit = sh.vars.find(name);
+        if (nrit != sh.vars.end() && nrit->second.nameref &&
+            nrit->second.value.empty() && !val.empty() &&
+            !Shell::valid_nameref_target(val)) {
+          std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
+          ret = 1;
+          continue;
+        }
         sh.set(name, val);
       }
     }
@@ -1655,8 +1693,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (lcase) v.lcase = true;
     if (capcase) v.capcase = true;
     // Mark the nameref last, so the assignment above stored the *target name*
-    // as this variable's value rather than being redirected through it.
-    if (nameref) v.nameref = true;
+    // as this variable's value rather than being redirected through it.  Adding
+    // `-n' to a variable whose existing value is not a valid nameref target
+    // (`r=/; declare -n r') -- or which names itself -- is rejected; bash leaves
+    // the variable unchanged without the attribute.  (The `=val' form validated
+    // its value above.)
+    if (nameref && v.value == name && !sh.in_function()) {
+      std::fprintf(stderr,
+                   "%s%s: %s: nameref variable self references not allowed\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+      ret = 1;
+    } else if (nameref && !v.value.empty() && v.value != name &&
+               !Shell::valid_nameref_target(v.value)) {
+      std::fprintf(stderr,
+                   "%s%s: `%s': invalid variable name for name reference\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), v.value.c_str());
+      ret = 1;
+    } else if (nameref) {
+      v.nameref = true;
+    }
     // `+X' removes attributes.  Applied after the assignment so `typeset +n
     // foo=other' writes through the still-active nameref to its target before
     // the reference is torn down, matching bash.

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -357,6 +357,23 @@ std::string Shell::deref(const std::string &n) const {
   return cur;
 }
 
+bool Shell::valid_nameref_target(const std::string &s) {
+  if (s.empty()) return false;
+  if (!(std::isalpha(static_cast<unsigned char>(s[0])) || s[0] == '_')) return false;
+  size_t i = 1;
+  for (; i < s.size(); i++) {
+    char c = s[i];
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_') continue;
+    if (c == '[') break;  // an array subscript may follow the identifier
+    return false;
+  }
+  // A subscript, if present, must be non-empty and close the string
+  // (`foo[x]': `[' at i, `]' last, at least one char between).
+  if (i < s.size() && s[i] == '[')
+    return s.back() == ']' && s.size() - i > 2;
+  return true;
+}
+
 bool Shell::nameref_elt(const std::string &n_in, std::string &base,
                         std::string &sub) const {
   // Only a nameref may introduce a subscript.  A name that already contains a
@@ -833,6 +850,18 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     }
   }
   std::string n = deref(n_in);
+  // Assigning to a nameref that has no target yet sets its target (`declare -n
+  // r; r=x' points r at x); the value must be a valid identifier.  deref stops
+  // on such a nameref, so n still names it.  bash rejects a non-identifier here.
+  {
+    auto it = vars.find(n);
+    if (it != vars.end() && it->second.nameref && it->second.value.empty() &&
+        !v.empty() && !valid_nameref_target(v)) {
+      std::fprintf(stderr, "%s`%s': not a valid identifier\n", err_prefix().c_str(),
+                   v.c_str());
+      return false;
+    }
+  }
   // Assigning BASH_ARGV0 resets $0 (and the name used in error messages), as
   // bash does; still stored so `$BASH_ARGV0' reads back the value.
   if (n == "BASH_ARGV0") { arg0 = v; shell_name = v; }


### PR DESCRIPTION
Reject invalid nameref targets, bringing `nameref.tests` from **362 → 338** against bash 5.3. No regressions: `ctest` 22/22, `run_diff` all 221 scripts match; `array`/`assoc`/`builtins`/`varenv` scoreboards unchanged.

A nameref's target must be a valid identifier, optionally with an array subscript (`foo` or `foo[2]`), and may not name the nameref itself. gnash accepted any string, so `declare -n r=/`, `r=/; declare -n r`, and assigning a non-identifier to an unset nameref all silently succeeded.

Adds `Shell::valid_nameref_target` and enforces it:
- **`declare -n r=VALUE`** (and adding `-n` to a variable with an existing value) with an invalid target → `invalid variable name for name reference`, and the variable is not created.
- **Self-reference** (`declare -n r=r`) → `nameref variable self references not allowed`. Gated to non-function scope: inside a function a same-name target refers to the enclosing variable (bash warns of a circular reference rather than erroring), so the hard error only fires at global scope.
- **Assigning a non-identifier to an unset nameref** → `not a valid identifier` — bare from a plain assignment (`Shell::set`), or carrying the builtin name from `declare r=VALUE`.
- Append (`ref+=[@]`) is validated against the concatenated target, not the fragment.

The remaining nameref diffs are dominated by the in-function **circular-reference warning** system (`warning: X: circular name reference`, `maximum nameref depth (8) exceeded`) — intricate and scope/resolution-dependent, deferred to a later batch.