### PR TITLE
Handle circular namerefs and refine target-validation diagnostics

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -54,6 +54,19 @@ class Shell {
   // Follow a `declare -n' nameref chain to the ultimate target name (with a
   // cycle guard); returns n unchanged when it is not a nameref.
   std::string deref(const std::string &n) const;
+  // Like deref, but sets CIRCULAR when the chain forms a cycle (a self
+  // reference `v->v' or a longer loop).  On a cycle it returns the last name
+  // walked before the loop closed; the warning-issuing caller uses the
+  // original NAME for the diagnostic, matching bash's find_variable_nameref.
+  std::string deref_ex(const std::string &n, bool &circular) const;
+  // The global (pre-function) binding of NAME: when a local scope has shadowed
+  // NAME, the saved outer Variable; otherwise the entry in `vars'.  bash
+  // resolves a circular nameref to global scope, so a write through one lands
+  // here.  Creates the saved slot if the global did not exist.
+  Variable &global_var_ref(const std::string &name);
+  // Read-only counterpart of global_var_ref: the global binding of NAME, or
+  // nullptr if there is none (nothing was shadowed and `vars' has no entry).
+  const Variable *global_var_ptr(const std::string &name) const;
   // If following N's nameref chain lands on a subscripted target `base[sub]'
   // (`declare -n ref=arr[2]'), split it into BASE and SUB (raw subscript text,
   // evaluated by array_get/array_set) and return true; otherwise false.
@@ -62,6 +75,10 @@ class Shell {
   // (`foo' or `foo[2]').  bash rejects anything else (`/', `a b', `9x').
   static bool valid_nameref_target(const std::string &s);
   std::string get(const std::string &n) const;  // "" if unset
+  // Like get, but does not warn when N resolves through a circular nameref.
+  // Used for the internal old-value read of an append/arithmetic assignment,
+  // which bash performs silently (only the write itself warns).
+  std::string get_quiet(const std::string &n) const;
   bool get_if_set(const std::string &n, std::string &out) const;
   // Assign N=V; false if N is readonly (an error is printed).
   bool set(const std::string &n, const std::string &v);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1644,6 +1644,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           std::fprintf(stderr, "%swarning: %s: circular name reference\n",
                        sh.err_prefix().c_str(), name.c_str());
         }
+        // An explicit empty target (`declare -n r=') is rejected as an invalid
+        // identifier and does not create the nameref (bash reports the empty
+        // name); at global scope no variable survives, in a function the local
+        // that was just made stays as a plain variable.
+        if (tgt.empty()) {
+          std::fprintf(stderr, "%s%s: `': not a valid identifier\n",
+                       sh.err_prefix().c_str(), argv[0].c_str());
+          ret = 1;
+          if (!preexist) sh.vars.erase(name);
+          continue;
+        }
         // The target must be a valid nameref target (`foo' or `foo[2]').  bash
         // rejects anything else and does not create the variable.
         if (!tgt.empty() && !Shell::valid_nameref_target(tgt)) {
@@ -1692,8 +1703,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         if (nrit != sh.vars.end() && nrit->second.nameref &&
             nrit->second.value.empty() && !val.empty() &&
             !Shell::valid_nameref_target(val)) {
-          std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                       sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
+          // At function scope bash validates the value as a nameref target
+          // ("invalid variable name for name reference"); at global scope it
+          // reports it as a plain invalid identifier.
+          if (sh.in_function())
+            std::fprintf(stderr,
+                         "%s%s: `%s': invalid variable name for name reference\n",
+                         sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
+          else
+            std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
+                         sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
           ret = 1;
           continue;
         }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1608,17 +1608,41 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         auto pv = sh.vars.find(name);
         std::string tgt =
             (append && pv != sh.vars.end()) ? pv->second.value + val : val;
-        // A nameref may not point at itself (`declare -n r=r').  At function
-        // scope a same-name target instead refers to the enclosing variable
-        // (bash warns of a circular reference rather than erroring), so only
-        // reject a self reference outside a function.
-        if (tgt == name && !sh.in_function()) {
-          std::fprintf(stderr,
-                       "%s%s: %s: nameref variable self references not allowed\n",
-                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+        // A nameref may not point at itself (`declare -n r=r'), either directly
+        // or via one of its own elements (`r=r[0]').  At function scope a
+        // same-name target instead refers to the enclosing variable, so bash
+        // warns of a circular reference rather than erroring.
+        bool selfref = (tgt == name);
+        if (!selfref && !tgt.empty()) {
+          size_t lb = tgt.find('[');
+          if (lb != std::string::npos && tgt.back() == ']' &&
+              tgt.substr(0, lb) == name)
+            selfref = true;
+        }
+        if (selfref && !sh.in_function()) {
+          // A direct `=' self reference is rejected by the declare builtin, so
+          // the message carries the builtin name.  One that only becomes a self
+          // reference after `+=' concatenation slips past that check and is
+          // caught later while binding the value, which prints it bare.
+          if (append)
+            std::fprintf(stderr,
+                         "%s%s: nameref variable self references not allowed\n",
+                         sh.err_prefix().c_str(), name.c_str());
+          else
+            std::fprintf(stderr,
+                         "%s%s: %s: nameref variable self references not allowed\n",
+                         sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
           ret = 1;
           if (!preexist) sh.vars.erase(name);
           continue;
+        }
+        if (selfref) {
+          // Warn once with the builtin prefix and once without, matching bash's
+          // declare.def (builtin_warning) plus bind_variable_value.
+          std::fprintf(stderr, "%s%s: warning: %s: circular name reference\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+          std::fprintf(stderr, "%swarning: %s: circular name reference\n",
+                       sh.err_prefix().c_str(), name.c_str());
         }
         // The target must be a valid nameref target (`foo' or `foo[2]').  bash
         // rejects anything else and does not create the variable.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -757,7 +757,11 @@ int Executor::run_simple(const SimpleCommand *c) {
           sh_.set(pa.first, pa.second);
         }
         std::string v = ex.expand_assignment(a.value);
-        std::string cur = is_arr ? sh_.array_get(a.name, "0") : sh_.get(a.name);
+        // Only the old value is needed for `+=' / integer arithmetic; reading it
+        // for a plain assignment would spuriously resolve a circular nameref.
+        std::string cur = (integer || a.append)
+                              ? (is_arr ? sh_.array_get(a.name, "0") : sh_.get_quiet(a.name))
+                              : std::string();
         for (auto it = prior.rbegin(); it != prior.rend(); ++it) {
           if (it->second) sh_.vars[it->first] = *it->second;
           else sh_.vars.erase(it->first);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -6,6 +6,7 @@
 #include "gnash/core/shell.hpp"
 
 #include <algorithm>
+#include <set>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -357,6 +358,44 @@ std::string Shell::deref(const std::string &n) const {
   return cur;
 }
 
+std::string Shell::deref_ex(const std::string &n, bool &circular) const {
+  circular = false;
+  std::string cur = n;
+  std::set<std::string> seen;
+  for (;;) {
+    auto it = vars.find(cur);
+    if (it == vars.end() || !it->second.nameref) return cur;
+    const std::string &tgt = it->second.value;
+    if (tgt.empty()) return cur;  // untargeted nameref: not circular
+    if (tgt == cur || seen.count(tgt)) {  // self reference or a longer loop
+      circular = true;
+      return cur;
+    }
+    seen.insert(cur);
+    cur = tgt;
+  }
+}
+
+Variable &Shell::global_var_ref(const std::string &name) {
+  for (auto &scope : local_stack) {  // front = outermost (nearest to global)
+    for (auto &e : scope)
+      if (e.first == name) {
+        if (!e.second) e.second = Variable{};  // global didn't exist; create it
+        return *e.second;
+      }
+  }
+  return vars[name];
+}
+
+const Variable *Shell::global_var_ptr(const std::string &name) const {
+  for (const auto &scope : local_stack) {  // front = outermost
+    for (const auto &e : scope)
+      if (e.first == name) return e.second ? &*e.second : nullptr;
+  }
+  auto it = vars.find(name);
+  return it == vars.end() ? nullptr : &it->second;
+}
+
 bool Shell::valid_nameref_target(const std::string &s) {
   if (s.empty()) return false;
   if (!(std::isalpha(static_cast<unsigned char>(s[0])) || s[0] == '_')) return false;
@@ -415,16 +454,40 @@ bool Shell::is_set(const std::string &n_in) const {
   return it != vars.end();
 }
 
-std::string Shell::get(const std::string &n_in) const {
-  std::string base, sub;
-  if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
-  std::string n = deref(n_in);
-  auto it = vars.find(n);
-  if (it == vars.end()) return std::string();
-  const Variable &v = it->second;
+static std::string scalar_of(const Variable &v) {
   if (v.kind == VarKind::Indexed) return v.idx.count(0) ? v.idx.at(0) : std::string();
   if (v.kind == VarKind::Assoc) return v.assoc.count("0") ? v.assoc.at("0") : std::string();
   return v.value;
+}
+
+std::string Shell::get(const std::string &n_in) const {
+  std::string base, sub;
+  if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
+  bool circular = false;
+  std::string n = deref_ex(n_in, circular);
+  if (circular) {
+    // bash warns and, at function scope, resolves the reference at global
+    // scope (find_variable_nameref); at global scope it resolves to nothing.
+    std::fprintf(stderr, "%swarning: %s: circular name reference\n",
+                 err_prefix().c_str(), n_in.c_str());
+    const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
+    return g ? scalar_of(*g) : std::string();
+  }
+  auto it = vars.find(n);
+  return it == vars.end() ? std::string() : scalar_of(it->second);
+}
+
+std::string Shell::get_quiet(const std::string &n_in) const {
+  std::string base, sub;
+  if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
+  bool circular = false;
+  std::string n = deref_ex(n_in, circular);
+  if (circular) {
+    const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
+    return g ? scalar_of(*g) : std::string();
+  }
+  auto it = vars.find(n);
+  return it == vars.end() ? std::string() : scalar_of(it->second);
 }
 
 // ---- arrays ---------------------------------------------------------------
@@ -812,7 +875,28 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
     out = array_get(base, sub);
     return true;
   }
-  std::string n = deref(n_in);
+  bool circular = false;
+  std::string n = deref_ex(n_in, circular);
+  if (circular) {
+    // Same resolution as get(): warn, and at function scope fall through to the
+    // global binding; a global-scope cycle resolves to nothing (unset).
+    std::fprintf(stderr, "%swarning: %s: circular name reference\n",
+                 err_prefix().c_str(), n_in.c_str());
+    const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
+    if (!g) return false;
+    if (g->kind == VarKind::Indexed) {
+      if (!g->idx.count(0)) return false;
+      out = g->idx.at(0);
+      return true;
+    }
+    if (g->kind == VarKind::Assoc) {
+      if (!g->assoc.count("0")) return false;
+      out = g->assoc.at("0");
+      return true;
+    }
+    out = g->value;
+    return true;
+  }
   auto it = vars.find(n);
   if (it == vars.end()) return false;
   // A nameref with no (or a self) target -- deref stops on it -- is unset.
@@ -849,7 +933,36 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
       return true;
     }
   }
-  std::string n = deref(n_in);
+  bool circular = false;
+  std::string n = deref_ex(n_in, circular);
+  // A circular nameref (self reference `v->v' or a longer loop).  At function
+  // scope bash reports the loop as exceeding the max nameref depth and binds
+  // the value at global scope; at global scope it warns and the assignment has
+  // no persistent effect.
+  if (circular) {
+    if (!in_function()) {
+      std::fprintf(stderr, "%swarning: %s: circular name reference\n",
+                   err_prefix().c_str(), n_in.c_str());
+      return true;
+    }
+    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (8) exceeded\n",
+                 err_prefix().c_str(), n_in.c_str());
+    Variable &g = global_var_ref(n_in);
+    if (g.readonly) {
+      std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
+                   n_in.c_str());
+      return false;
+    }
+    if (g.kind == VarKind::Indexed) {
+      g.idx[0] = v;
+    } else if (g.kind == VarKind::Assoc) {
+      if (!g.assoc.count("0")) g.assoc_seq.push_back("0");
+      g.assoc["0"] = v;
+    } else {
+      g.value = v;
+    }
+    return true;
+  }
   // Assigning to a nameref that has no target yet sets its target (`declare -n
   // r; r=x' points r at x); the value must be a valid identifier.  deref stops
   // on such a nameref, so n still names it.  bash rejects a non-identifier here.


### PR DESCRIPTION
Testsuite batch 47 — brings the bash test suite's `nameref` diff from **338 → 289** byte-differences (ctest 22/22, run_diff all 221 scripts match, no scoreboard regressions).

## Circular nameref references at function scope (closes #178)

A nameref whose target resolves back to itself is a *circular* reference. bash treats it by scope:

- **Function scope**: declaring one warns twice (once with the builtin prefix, once without) and still creates the nameref; reading it warns `circular name reference` and resolves at global scope; writing it warns `maximum nameref depth (8) exceeded` and binds at global scope.
- **Global scope**: a direct self reference stays the error `nameref variable self references not allowed`, but a longer loop (`v→w→x→v`) warns `circular name reference` on read/write.

Implemented with `deref_ex` (a cycle-detecting nameref walk) and `global_var_ref` / `global_var_ptr` (the pre-function binding of a name). The append/arithmetic old-value read now uses `get_quiet` so it does not spuriously warn, and a plain assignment skips the old-value read entirely. A self reference that only arises after `+=` concatenation is reported bare, matching bash's bind-time detection.

Fixes nameref8 (byte-perfect) and most of nameref15.

## Nameref target-validation diagnostics

- Assigning a non-identifier through an existing unset nameref reports `not a valid identifier` at global scope but `invalid variable name for name reference` inside a function.
- An explicit empty target (`declare -n r=`) is rejected as `` `': not a valid identifier`` and the nameref is not created.

Fixes nameref13 and nameref24 (both byte-perfect).