### PR TITLE
Fix declare/typeset nameref-vs-array interactions

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1546,6 +1546,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       ret = 1;
       continue;
     }
+    // A nameref cannot itself be an array element (`declare -n a[128]'): bash
+    // rejects the subscripted name outright.  (A subscript in the *value*,
+    // `declare -n r=a[2]', has `=' before `[' so subscript0 is false.)
+    if (subscript0 && nameref) {
+      std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
+      std::fprintf(stderr, "%s%s: %s: reference variable cannot be an array\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+      ret = 1;
+      continue;
+    }
     bool scalar_pre = eq != std::string::npos && !arraylit0 && !subscript0 && !nameref;
     std::string pre_val;
     if (scalar_pre) { Expander ex(sh); pre_val = ex.expand_assignment(a.substr(eq + 1)); }
@@ -1741,7 +1751,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // (`r=/; declare -n r') -- or which names itself -- is rejected; bash leaves
     // the variable unchanged without the attribute.  (The `=val' form validated
     // its value above.)
-    if (nameref && v.value == name && !sh.in_function()) {
+    if (nameref && (v.kind == VarKind::Indexed || v.kind == VarKind::Assoc)) {
+      // An existing array/associative variable cannot be turned into a nameref;
+      // bash rejects the `-n' and leaves the array (and any assignment made by
+      // this same command) intact.
+      std::fprintf(stderr,
+                   "%s%s: %s: reference variable cannot be an array\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+      ret = 1;
+    } else if (nameref && v.value == name && !sh.in_function()) {
       std::fprintf(stderr,
                    "%s%s: %s: nameref variable self references not allowed\n",
                    sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1724,6 +1724,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
                          sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
           ret = 1;
+          // At global scope the still-invisible nameref is discarded (a later
+          // `declare -p' reports it as not found); a function-local one made by
+          // this scope persists.
+          if (!sh.in_function()) sh.vars.erase(name);
           continue;
         }
         sh.set(name, val);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -711,6 +711,12 @@ void Shell::make_array(const std::string &n_in, bool assoc) {
   bool fresh = !vars.count(n);
   Variable &v = vars[n];
   if (fresh) v.invisible = true;  // `declare -a b' with no value: declared, unset
+  // `declare -a' on an unset nameref (deref lands on the nameref itself)
+  // converts it into a genuine, still-unset array, dropping the reference.
+  if (v.nameref) {
+    v.nameref = false;
+    v.invisible = true;
+  }
   if (v.kind == VarKind::Scalar) {
     // Converting an existing scalar to an indexed array keeps its value as
     // element 0 (`a=abcde; declare -a a' leaves ${a[0]} == abcde), matching


### PR DESCRIPTION
Testsuite batch 48 — brings the `nameref` diff from **289 → 255** byte-differences (ctest 22/22, run_diff all 221 scripts match, no scoreboard regressions). Follows #179.

Three conceptual fixes to how `declare`/`typeset`/`local` handle namerefs that collide with arrays (closes #180):

1. **Reject making an array a nameref.** `declare -n arr` on an existing indexed/associative variable, or a subscripted name `declare -n arr[128]`, now fails with `reference variable cannot be an array` and leaves the array intact, instead of producing a `declare -an` hybrid. A subscript in the *value* (`declare -n r=a[2]`) is unaffected. Fixes nameref6 and nameref22.

2. **Convert an unset nameref to an array under `declare -a`.** `declare -a foo` on an unset nameref turns it into a genuine, still-unset array (dropping `-n`), printed `declare -a foo` rather than `declare -an foo=()`.

3. **Discard an invisible nameref after a rejected target assignment.** At global scope `declare -n x; declare x=42` discards the still-invisible `x` (a later `declare -p x` reports "not found"); a function-local one persists.