### PR TITLE
Array conformance: element unset, quoted compound literals, sparse slicing

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -107,6 +107,9 @@ class Shell {
   bool virtual_array(const std::string &name,
                      std::vector<std::pair<std::string, std::string>> &pairs) const;
   void array_set(const std::string &n, const std::string &sub, const std::string &v);
+  // Remove one element of an array (`unset a[2]'); a `@'/`*' subscript unsets
+  // the whole array.  A negative index on an indexed array counts from the end.
+  void array_unset(const std::string &n, const std::string &sub);
   int array_count(const std::string &n) const;
   // True when NAME holds an indexed or associative array (not a scalar); used
   // by the zsh personality, where a bare `$array' expands to all its elements.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1624,7 +1624,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       std::string val = a.substr(eq + 1);
       bool arraylit = val.size() >= 2 && val.front() == '(' && val.back() == ')';
       bool subscript = nend != std::string::npos && a[nend] == '[';
-      if (arraylit || subscript) {
+      // A quoted compound value (`declare -a d='(...)'`) is an array literal
+      // when the target is an array: unwrap one layer of matched outer quotes so
+      // the parentheses are recognized and the elements expanded.  Any subscript
+      // is dropped -- the compound replaces the whole array, as in bash.
+      auto cur = sh.vars.find(name);
+      bool arrayvar = cur != sh.vars.end() &&
+          (cur->second.kind == VarKind::Indexed || cur->second.kind == VarKind::Assoc);
+      if (!arraylit && arrayvar && val.size() >= 4 &&
+          (val.front() == '\'' || val.front() == '"') && val.back() == val.front() &&
+          val[1] == '(' && val[val.size() - 2] == ')') {
+        apply_assignment_word(sh, name + (append ? "+=" : "=") +
+                                      val.substr(1, val.size() - 2));
+      } else if (arraylit || subscript) {
         apply_assignment_word(sh, a);  // NAME=(...) or NAME[i]=...
       } else if (nameref) {
         // `declare -n ref=target': store the target NAME as ref's own value.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -882,6 +882,24 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     if (argv[i] == "-v") { funcs = false; continue; }
     if (argv[i] == "-n") { noref = true; continue; }
     if (funcs) { sh.functions.erase(argv[i]); continue; }
+    // `unset name[sub]' removes a single array element (or the whole array for
+    // a `@'/`*' subscript), not a variable literally named "name[sub]".
+    size_t lb = argv[i].find('[');
+    if (!noref && lb != std::string::npos && !argv[i].empty() &&
+        argv[i].back() == ']') {
+      std::string base = argv[i].substr(0, lb);
+      std::string sub = argv[i].substr(lb + 1, argv[i].size() - lb - 2);
+      std::string bd = sh.deref(base);
+      auto bit = sh.vars.find(bd);
+      if (bit != sh.vars.end() && bit->second.readonly) {
+        std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",
+                     sh.err_prefix().c_str(), bd.c_str());
+        ret = 1;
+        continue;
+      }
+      sh.array_unset(base, sub);
+      continue;
+    }
     // A readonly variable cannot be unset.  Resolve through a nameref (unless
     // -n) so the target that is actually readonly is the one reported.
     std::string tgt = noref ? argv[i] : sh.deref(argv[i]);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1620,6 +1620,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     }
     if (mk_assoc) sh.make_array(name, true);
     else if (mk_array) sh.make_array(name, false);
+    // A subscripted name implies an indexed array even without `-a'
+    // (`declare -r c[100]' creates an empty readonly array c).
+    else if (subscript0) sh.make_array(name, false);
     if (eq != std::string::npos) {
       std::string val = a.substr(eq + 1);
       bool arraylit = val.size() >= 2 && val.front() == '(' && val.back() == ')';

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -263,6 +263,30 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
 }
 
 void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
+  // Assigning to any part of a readonly array is an error (bash names the array,
+  // not the element).
+  {
+    auto rit = sh.vars.find(sh.deref(a.name));
+    if (rit != sh.vars.end() && rit->second.readonly) {
+      std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
+                   a.name.c_str());
+      sh.last_status = 1;
+      return;
+    }
+  }
+  // An empty subscript (`b[]=x') is always a bad array subscript.  The special
+  // `*'/`@' selectors are bad for an indexed array but are ordinary literal keys
+  // for an associative one (`a[@]=x' stores under the key "@").
+  if (a.sub) {
+    auto sit = sh.vars.find(sh.deref(a.name));
+    bool assoc = sit != sh.vars.end() && sit->second.kind == VarKind::Assoc;
+    if (a.sub->empty() || (!assoc && (*a.sub == "*" || *a.sub == "@"))) {
+      std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
+                   a.name.c_str(), a.sub->c_str());
+      sh.last_status = 1;
+      return;
+    }
+  }
   // An integer-attributed array (`declare -i') evaluates each element value as
   // an arithmetic expression, and `+=' adds rather than string-appends.
   auto vit = sh.vars.find(a.name);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -906,29 +906,55 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       // ${a[@]:off:len} / ${@:off:len}: array/positional slice.
       std::string slname, soffx, slenx; char ssel; bool shaslen = false;
       if (slice_ref(body, slname, ssel, soffx, slenx, shaslen)) {
-        std::vector<std::string> list;
-        if (slname.empty()) {  // positionals: index 0 is $0
-          list.push_back(sh_.arg0);
-          for (const auto &pp : sh_.positional) list.push_back(pp);
-        } else {
-          list = sh_.array_values(slname);
-        }
-        long long n = static_cast<long long>(list.size());
         bool ok = true;
         long long off = eval_arith(sh_, expand_no_split(soffx, false, false), &ok);
         if (!ok) off = 0;
-        if (off < 0) { off += n; if (off < 0) off = 0; }
-        long long count;
-        if (shaslen) {
-          long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
-          if (!ok) len = 0;
-          count = (len < 0) ? (n + len - off) : len;  // negative len = offset from end
-        } else {
-          count = n - off;
-        }
         std::vector<std::string> slice;
-        for (long long k = off; k < n && static_cast<long long>(slice.size()) < count; k++)
-          if (k >= 0) slice.push_back(list[static_cast<size_t>(k)]);
+        // For an indexed array, `offset' is an array-index threshold: bash takes
+        // up to `length' set elements whose index is >= offset (a negative
+        // offset counts back from the highest index).  Positional parameters and
+        // associative arrays slice by position in their value list instead.
+        auto vit = slname.empty() ? sh_.vars.end() : sh_.vars.find(sh_.deref(slname));
+        bool indexed = vit != sh_.vars.end() && vit->second.kind == VarKind::Indexed;
+        if (indexed) {
+          std::vector<std::string> keys = sh_.array_keys(slname);
+          std::vector<std::string> vals = sh_.array_values(slname);
+          long long maxidx = keys.empty() ? -1 : std::strtoll(keys.back().c_str(), nullptr, 10);
+          if (off < 0) { off += maxidx + 1; }
+          long long count;
+          if (shaslen) {
+            long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
+            if (!ok) len = 0;
+            count = (len < 0) ? (maxidx + 1 + len - off) : len;
+          } else {
+            count = static_cast<long long>(keys.size());
+          }
+          for (size_t k = 0; k < keys.size() &&
+                             static_cast<long long>(slice.size()) < count; k++) {
+            long long ix = std::strtoll(keys[k].c_str(), nullptr, 10);
+            if (ix >= off) slice.push_back(vals[k]);
+          }
+        } else {
+          std::vector<std::string> list;
+          if (slname.empty()) {  // positionals: index 0 is $0
+            list.push_back(sh_.arg0);
+            for (const auto &pp : sh_.positional) list.push_back(pp);
+          } else {
+            list = sh_.array_values(slname);
+          }
+          long long n = static_cast<long long>(list.size());
+          if (off < 0) { off += n; if (off < 0) off = 0; }
+          long long count;
+          if (shaslen) {
+            long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
+            if (!ok) len = 0;
+            count = (len < 0) ? (n + len - off) : len;  // negative len = offset from end
+          } else {
+            count = n - off;
+          }
+          for (long long k = off; k < n && static_cast<long long>(slice.size()) < count; k++)
+            if (k >= 0) slice.push_back(list[static_cast<size_t>(k)]);
+        }
         if (ssel == '*' && dq) {
           std::string is = sh_.ifs();
           std::string j = is.empty() ? std::string() : std::string(1, is[0]);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -835,8 +835,13 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
               for (char c : items[k]) { out += c; mask += '1'; }
             }
           } else {
+            // Unquoted ${a[@]} / ${a[*]}: an empty element produces no word (it
+            // splits away), so skip it rather than emitting an empty field.
+            bool first = true;
             for (size_t k = 0; k < items.size(); k++) {
-              if (k) { out += FIELD_SEP; mask += MMARK; }
+              if (items[k].empty()) continue;
+              if (!first) { out += FIELD_SEP; mask += MMARK; }
+              first = false;
               for (char c : items[k]) { out += c; mask += '0'; }
             }
           }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -671,6 +671,42 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   if (k == 0) v.value = val;
 }
 
+void Shell::array_unset(const std::string &n_in, const std::string &sub) {
+  std::string n = deref(n_in);
+  auto it = vars.find(n);
+  if (it == vars.end()) return;  // unsetting an element of a missing array: no-op
+  Variable &v = it->second;
+  if (v.readonly) return;
+  // `unset a[@]' / `unset a[*]' clears every element but leaves the (now empty)
+  // array in place -- bash still reports `declare -a a=()' afterward.
+  if (sub == "@" || sub == "*") {
+    v.idx.clear();
+    v.assoc.clear();
+    v.assoc_seq.clear();
+    v.value.clear();
+    return;
+  }
+  if (v.kind == VarKind::Assoc) {
+    v.assoc.erase(sub);
+    v.assoc_seq.erase(std::remove(v.assoc_seq.begin(), v.assoc_seq.end(), sub),
+                      v.assoc_seq.end());
+    return;
+  }
+  bool ok = true;
+  long long k = eval_arith(*this, sub, &ok);
+  if (!ok) return;
+  // A negative index counts back from the highest assigned index (`a[-1]').
+  if (k < 0 && v.kind == VarKind::Indexed && !v.idx.empty())
+    k += v.idx.rbegin()->first + 1;
+  if (k < 0) return;  // still out of range: bash reports a bad subscript
+  if (v.kind == VarKind::Indexed) {
+    v.idx.erase(k);
+    if (k == 0) v.value.clear();  // element 0 is mirrored in the scalar field
+  } else if (v.kind == VarKind::Scalar && k == 0) {
+    vars.erase(it);  // a scalar's only element is itself
+  }
+}
+
 bool Shell::is_array(const std::string &n_in) const {
   std::string n = deref(n_in);
   auto it = vars.find(n);


### PR DESCRIPTION
Testsuite batch 49 — brings the `array` diff from **519 → 434** byte-differences (and `assoc` 390 → 369, `nameref` 255 → 251), with ctest 22/22, run_diff all 221 scripts matching, and no scoreboard regressions.

Six fixes to array handling:

1. **Unset individual array elements** (closes #182). `unset a[2]` had no effect — gnash looked for a variable literally named `a[2]`. It now removes the element (negative index counts from the end, string key for associative, `[@]`/`[*]` clears the whole array). This was the single biggest cascade, corrupting every later listing and expansion; it also improved `assoc` and `nameref`.

2. **Diagnose bad and readonly array-element assignments.** Assigning to a readonly array reports `NAME: readonly variable`; an empty subscript (`b[]=x`) or `*`/`@` as an indexed-array assignment target is a bad subscript (they stay literal keys for associative arrays).

3. **Parse a quoted compound array value** (`declare -a d='(...)'`), unwrapping one layer of outer quotes and expanding the elements.

4. **Create an indexed array from a subscripted declare name** (`declare -r c[100]`).

5. **Drop empty elements from an unquoted array expansion** — `echo ${a[@]}` collapsed empty elements to a single separator, matching bash; quoted `"${a[@]}"` still preserves them.

6. **Slice an indexed array by index, not dense position** — `${a[@]:offset:length}` treats offset as an array-index threshold, fixing sparse arrays.