### PR TITLE
Expose special virtual arrays in variable listings

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -229,6 +229,12 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
                   bool whole_append, const std::string &parenval) {
   std::vector<std::pair<std::optional<std::string>, std::string>> out;
   std::string inner = parenval.substr(1, parenval.size() - 2);
+  // For an indexed array, validate explicit subscripts and resolve negatives
+  // against the highest index seen so far (bash processes the list left to
+  // right); an associative array takes any string as a key.
+  auto tvit = sh.vars.find(sh.deref(name));
+  bool assoc = tvit != sh.vars.end() && tvit->second.kind == VarKind::Assoc;
+  long long maxidx = -1;
   for (const Token &t : tokenize(inner)) {
     if (t.type == Tok::Eof) break;
     if (t.type != Tok::Word) continue;
@@ -242,6 +248,29 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
       if (app || plain) {
         std::string sub = ex.expand_no_split(e.substr(1, rb - 1));
         std::string val = ex.expand_no_split(e.substr(rb + (app ? 3 : 2)));
+        if (!assoc) {
+          // bash stops the whole compound assignment at the first bad subscript
+          // (the array has already been cleared, so the partial result stands).
+          if (sub.empty()) {
+            std::fprintf(stderr, "%s%s: bad array subscript\n",
+                         sh.err_prefix().c_str(), e.c_str());
+            break;
+          }
+          if (sub == "*" || sub == "@") {
+            std::fprintf(stderr, "%s%s: cannot assign to non-numeric index\n",
+                         sh.err_prefix().c_str(), e.c_str());
+            break;
+          }
+          bool ok = true;
+          long long k = eval_arith(sh, sub, &ok);
+          if (ok && k < 0) k += maxidx + 1;  // resolve negative against running max
+          if (ok && k < 0) {
+            std::fprintf(stderr, "%s%s: bad array subscript\n",
+                         sh.err_prefix().c_str(), e.c_str());
+            break;
+          }
+          if (ok) { sub = std::to_string(k); if (k > maxidx) maxidx = k; }
+        }
         if (app) {  // resolve against the current element (fresh assign cleared
                     // it, so the base is 0 unless this is a whole-array append)
           std::string base = whole_append ? sh.array_get(name, sh.zsh_subscript(name, sub)) : "0";
@@ -256,8 +285,10 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
         continue;
       }
     }
-    for (const std::string &f : ex.expand_args({Word{e, t.quoted ? W_QUOTED : 0}}))
+    for (const std::string &f : ex.expand_args({Word{e, t.quoted ? W_QUOTED : 0}})) {
       out.emplace_back(std::nullopt, f);
+      if (!assoc) maxidx++;  // a positional element lands at the next index
+    }
   }
   return out;
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -838,8 +838,17 @@ void Shell::sync_source_arrays() {
     sources.push_back(it->source);
   set_indexed("BASH_SOURCE", sources);
 
-  if (!src_frames.back().is_func) {  // FUNCNAME/BASH_LINENO exist only in functions
-    unset("FUNCNAME"); unset("BASH_LINENO");
+  if (!src_frames.back().is_func) {
+    // At the base (script) frame bash still exposes BASH_LINENO=([0]="0") and an
+    // invisible FUNCNAME (a declared array with no value).
+    set_indexed("BASH_LINENO", {"0"});
+    Variable &fn = vars["FUNCNAME"];
+    fn.kind = VarKind::Indexed;
+    fn.idx.clear();
+    fn.assoc.clear();
+    fn.assoc_seq.clear();
+    fn.value.clear();
+    fn.invisible = true;
     return;
   }
   std::vector<std::string> names, lines;
@@ -1177,6 +1186,11 @@ void Shell::set_personality(const std::string &name) {
       set("BASH_LOADABLES_PATH",
           "/usr/local/lib/bash:/usr/lib/bash:/opt/local/lib/bash:"
           "/usr/pkg/lib/bash:/opt/pkg/lib/bash:.");
+    // bash always lists these as (empty) indexed arrays; their live values are
+    // served dynamically by virtual_array for reads, so the stored array stays
+    // empty and only surfaces in `declare'/`set' listings.
+    for (const char *nm : {"BASH_ARGC", "BASH_ARGV", "DIRSTACK"})
+      if (!vars.count(nm)) array_assign(nm, {}, false, false);
   }
 
   // Let an interactive REPL re-apply persona-dependent readline hooks when the

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -449,9 +449,12 @@ bool Shell::is_set(const std::string &n_in) const {
   }
   std::string n = deref(n_in);
   auto it = vars.find(n);
+  if (it == vars.end()) return false;
   // A nameref with no (or a self) target -- deref stops on it -- is unset.
-  if (it != vars.end() && it->second.nameref) return false;
-  return it != vars.end();
+  if (it->second.nameref) return false;
+  // A declared-but-unset (invisible) variable is not "set" for `-v'.
+  if (it->second.invisible) return false;
+  return true;
 }
 
 static std::string scalar_of(const Variable &v) {


### PR DESCRIPTION
Testsuite batch 50 — brings the `array` diff from **434 → 407** (the headline being the special-arrays block that recurs across the suite), with ctest 22/22, run_diff all 221 scripts matching, and no scoreboard regressions.

Closes #184.

1. **Expose the special virtual arrays in listings.** bash lists BASH_ARGC, BASH_ARGV, BASH_LINENO, DIRSTACK and FUNCNAME among its arrays even at a script's top level; gnash showed only BASH_SOURCE. Seed BASH_ARGC/BASH_ARGV/DIRSTACK as empty indexed arrays (their live values are still served by `virtual_array` for reads, so only the listing sees the empty stored array), and at the base script frame expose `BASH_LINENO=([0]="0")` and an invisible FUNCNAME. Because they are real entries they sort and interleave with user arrays for free.

2. **`[[ -v NAME ]]` honors the invisible flag** — a declared-but-unset variable (e.g. `declare -a b`, or FUNCNAME at the top level) is now correctly reported unset.

3. **Reject bad subscripts in a compound array literal** — `[]=x`, `[*]=x`, or a negative index resolving below zero now stops the assignment at the first bad element with a single diagnostic, matching bash.

The remaining `array` differences are a long tail of distinct cases (POSIX-mode `readonly` listing prefix, per-element pattern-op edge cases, argv quoting, negative-subscript read errors).