### PR TITLE
Associative-array listings and compound-literal validation

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -950,6 +950,41 @@ std::string declare_quote(const std::string &v) {
   return r + "\"";
 }
 
+// True if KEY contains a shell metacharacter (bash's sh_contains_shell_metas),
+// used to decide whether an associative-array subscript must be quoted.
+static bool sub_has_metas(const std::string &s) {
+  for (size_t i = 0; i < s.size(); i++) {
+    switch (s[i]) {
+      case ' ': case '\t': case '\n':
+      case '\'': case '"': case '\\':
+      case '|': case '&': case ';':
+      case '(': case ')': case '<': case '>':
+      case '!': case '{': case '}':
+      case '*': case '[': case '?': case ']':
+      case '^': case '$': case '`':
+        return true;
+      case '~':
+        if (i == 0 || s[i - 1] == '=' || s[i - 1] == ':') return true;
+        break;
+      case '#':
+        if (i == 0) return true;
+        break;
+    }
+  }
+  return false;
+}
+
+// Quote an associative-array subscript for `declare -p' the way bash does:
+// ANSI-C ($'...') for non-printing bytes, double quotes when it holds a shell
+// metacharacter or is the lone `*'/`@' selector, otherwise bare.
+std::string declare_sub_quote(const std::string &k) {
+  if (q_needs_ansic(k)) return q_ansic(k);
+  if (!sub_has_metas(k) && k != "*" && k != "@") return k;
+  std::string r = "\"";
+  for (char c : k) { if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\'; r += c; }
+  return r + "\"";
+}
+
 // `declare -p NAME': the attribute flags plus the reproducible assignment.
 void declare_print_var(const std::string &name, const Variable &v) {
   // Attribute letters in bash's fixed order (var_attribute_string):
@@ -984,7 +1019,7 @@ void declare_print_var(const std::string &name, const Variable &v) {
     for (const auto &k : Shell::assoc_order(v)) {
       if (!first) decl += ' ';
       first = false;
-      decl += "[" + k + "]=" + declare_quote(v.assoc.at(k));
+      decl += "[" + declare_sub_quote(k) + "]=" + declare_quote(v.assoc.at(k));
     }
     // bash prints a space before the closing paren for a non-empty assoc.
     decl += first ? ")" : " )";
@@ -1010,9 +1045,10 @@ void set_print_var(const std::string &name, const Variable &v) {
     for (const auto &k : Shell::assoc_order(v)) {
       if (!first) s += ' ';
       first = false;
-      s += "[" + k + "]=" + set_elem(v.assoc.at(k));
+      s += "[" + declare_sub_quote(k) + "]=" + set_elem(v.assoc.at(k));
     }
-    std::printf("%s)\n", s.c_str());
+    // bash prints a trailing space before `)' for a non-empty associative array.
+    std::printf("%s%s)\n", s.c_str(), first ? "" : " ");
   } else {
     std::printf("%s=%s\n", name.c_str(), set_quote(v.value).c_str());
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -235,6 +235,10 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
   auto tvit = sh.vars.find(sh.deref(name));
   bool assoc = tvit != sh.vars.end() && tvit->second.kind == VarKind::Assoc;
   long long maxidx = -1;
+  // An associative array whose list already used `[key]=value' form is in
+  // subscript mode: a later bare word is an error.  An all-bare list is a valid
+  // flat key/value list, so only reject a bare word once a subscript was seen.
+  bool saw_sub = false;
   for (const Token &t : tokenize(inner)) {
     if (t.type == Tok::Eof) break;
     if (t.type != Tok::Word) continue;
@@ -282,12 +286,21 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
           }
         }
         out.emplace_back(sub, val);
+        saw_sub = true;
         continue;
       }
     }
+    // An associative array in subscript mode cannot take a bare value: bash
+    // reports the offending word and stops the assignment.
+    if (assoc && saw_sub) {
+      std::fprintf(stderr,
+                   "%s%s: %s: must use subscript when assigning associative array\n",
+                   sh.err_prefix().c_str(), name.c_str(), e.c_str());
+      break;
+    }
     for (const std::string &f : ex.expand_args({Word{e, t.quoted ? W_QUOTED : 0}})) {
       out.emplace_back(std::nullopt, f);
-      if (!assoc) maxidx++;  // a positional element lands at the next index
+      maxidx++;  // a positional element lands at the next index
     }
   }
   return out;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1194,6 +1194,10 @@ void Shell::set_personality(const std::string &name) {
     // empty and only surfaces in `declare'/`set' listings.
     for (const char *nm : {"BASH_ARGC", "BASH_ARGV", "DIRSTACK"})
       if (!vars.count(nm)) array_assign(nm, {}, false, false);
+    // BASH_ALIASES / BASH_CMDS are the associative equivalents (empty stored
+    // arrays; virtual_array serves the live alias/hash tables for reads).
+    for (const char *nm : {"BASH_ALIASES", "BASH_CMDS"})
+      if (!vars.count(nm)) array_assign(nm, {}, false, true);
   }
 
   // Let an interactive REPL re-apply persona-dependent readline hooks when the


### PR DESCRIPTION
Testsuite batch 51 — brings the `assoc` diff from **369 → 254** and `array` from **407 → 371**, with ctest 22/22, run_diff all 221 scripts matching, and no scoreboard regressions.

Closes #186.

1. **List BASH_ALIASES and BASH_CMDS** as empty associative arrays (the assoc counterpart of the BASH_ARGC/BASH_ARGV/DIRSTACK seeding; live tables still served by `virtual_array` for reads).

2. **Quote associative-array subscripts** in `declare -p` and `set`, matching bash's `assoc_to_assign`: ANSI-C (`$'...'`) for non-printing bytes, double quotes for a key containing a shell metacharacter or the lone `*`/`@` selector, otherwise bare — plus the trailing space before `)` in `set` output. (This was the largest single chunk.)

3. **Reject a bare value mixed into a `[key]=value` associative literal** — `NAME: WORD: must use subscript when assigning associative array`, stopping at the first offending word; an all-bare list is still accepted as a flat key/value list.

The remaining `assoc` differences are dominated by one coherent-but-hard cluster: parsing `[key]=value` where the key itself contains brackets or other special characters (the subscript scanner currently stops at the first `]`), plus flat-list quoted-value preservation and `$'...'` key display — a parsing refactor for a future batch.