### PR TITLE
Conform shopt/set option handling and #!-less script exec to bash

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -256,6 +256,9 @@ class Shell {
 
   // --- diagnostics -------------------------------------------------------
   std::string shell_name = "gnash";  // program name shown in error messages
+  // Absolute path to this shell's own executable, captured at startup.  Used
+  // to re-exec a script that has no #! line (see the ENOEXEC path in exec).
+  std::string self_exe;
   // Extra context component for parse errors ("eval", "command substitution"),
   // as bash prints `NAME: eval: line N: ...'.
   std::string error_context;

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -323,6 +323,12 @@ class Shell {
 
   bool opt_posix = false;       // -o posix
   bool opt_restricted = false;  // -r / -o restricted / rbash: restricted shell
+  // State-only options: recorded for `set -o'/`shopt -o' reporting even when
+  // non-interactive (no functional effect there, matching bash).
+  bool opt_emacs = false;       // -o emacs: emacs command-line editing mode
+  bool opt_vi = false;          // -o vi: vi command-line editing mode
+  bool opt_monitor = false;     // -m / -o monitor: job control
+  bool opt_privileged = false;  // -p / -o privileged
   // Set when a top-level $((...)) / $[...] arithmetic expansion failed (bad
   // expression or an assignment to a readonly variable); run_simple aborts the
   // current command (bash aborts but the shell continues).

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1100,9 +1100,18 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
     else return false;  // cannot clear restricted; caller reports the error
   }
   // `set -o vi'/`set -o emacs' switch the readline editing mode (they are
-  // mutually exclusive); `+o' flips to the other.
-  else if (o == "vi") { if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0); }
-  else if (o == "emacs") { if (on) rl_emacs_editing_mode(0, 0); else rl_vi_editing_mode(0, 0); }
+  // mutually exclusive); `+o' flips to the other.  The stored flags let the
+  // state be reported even in a non-interactive shell, as bash does.
+  else if (o == "vi") {
+    if (on) rl_vi_editing_mode(0, 0); else rl_emacs_editing_mode(0, 0);
+    sh.opt_vi = on; sh.opt_emacs = !on;
+  }
+  else if (o == "emacs") {
+    if (on) rl_emacs_editing_mode(0, 0); else rl_vi_editing_mode(0, 0);
+    sh.opt_emacs = on; sh.opt_vi = !on;
+  }
+  else if (o == "monitor") sh.opt_monitor = on;
+  else if (o == "privileged") sh.opt_privileged = on;
   else return false;
   return true;
 }
@@ -1116,18 +1125,20 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
   bool i = sh.interactive;
   return {
       {"allexport", false},   {"braceexpand", true},
-      {"emacs", i && rl_editing_mode == 1}, {"errexit", sh.opt_errexit},
+      {"emacs", i ? (rl_editing_mode == 1) : sh.opt_emacs},
+      {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
       {"hashall", true},      {"histexpand", sh.opt_histexpand},
       {"history", sh.opt_history}, {"ignoreeof", false},
       {"interactive-comments", true}, {"keyword", sh.opt_keyword},
-      {"monitor", i},         {"noclobber", false},
+      {"monitor", sh.job_control || sh.opt_monitor}, {"noclobber", false},
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
       {"nounset", sh.opt_nounset}, {"onecmd", false},
       {"physical", sh.opt_physical}, {"pipefail", sh.opt_pipefail},
-      {"posix", sh.opt_posix}, {"privileged", false},
-      {"verbose", sh.opt_verbose}, {"vi", i && rl_editing_mode == 0},
+      {"posix", sh.opt_posix}, {"privileged", sh.opt_privileged},
+      {"verbose", sh.opt_verbose},
+      {"vi", i ? (rl_editing_mode == 0) : sh.opt_vi},
       {"xtrace", sh.opt_xtrace}};
 }
 
@@ -1166,6 +1177,8 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'T': sh.opt_functrace = on; break;  // DEBUG/RETURN trap inheritance
           case 'E': sh.opt_functrace = on; break;  // errtrace: ERR trap inheritance
           case 'H': sh.opt_histexpand = on; break;  // `!' history expansion
+          case 'm': sh.opt_monitor = on; break;     // monitor: job control
+          case 'p': sh.opt_privileged = on; break;  // privileged mode
           case 'r':  // restricted: can be turned on, never off
             if (on) sh.opt_restricted = true;
             else {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2769,17 +2769,28 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
         case 'q': quiet_q = true; break;
         case 'p': print_p = true; break;
         case 'o': o_names = true; break;
-        default: break;
+        default:
+          std::fprintf(stderr, "%sshopt: -%c: invalid option\n",
+                       sh.err_prefix().c_str(), a[k]);
+          std::fprintf(stderr, "shopt: usage: shopt [-pqsu] [-o] [optname ...]\n");
+          return 2;
       }
     }
   }
 
   if (o_names) {
+    // `-p' reproduces as `set -o'/`set +o' commands; otherwise a NAME<TAB>state
+    // two-column listing (bash's list_minus_o_opts, field width 15).
+    auto show_o = [&](const std::string &n, bool on) {
+      if (quiet_q) return;
+      if (print_p) std::printf("set %co %s\n", on ? '-' : '+', n.c_str());
+      else std::printf("%-15s\t%s\n", n.c_str(), on ? "on" : "off");
+    };
     if (i >= argv.size()) {  // list set -o options
       for (const auto &o : set_option_states(sh)) {
         if (set_s && !o.second) continue;
         if (unset_u && o.second) continue;
-        if (!quiet_q) std::printf("set %co %s\n", o.second ? '-' : '+', o.first.c_str());
+        show_o(o.first, o.second);
       }
       return 0;
     }
@@ -2791,14 +2802,14 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
         if (o.first == n) { found = true; cur = o.second; }
       if (!found) {
         if (!quiet_q)
-          std::fprintf(stderr, "%sshopt: %s: invalid shell option name\n",
+          std::fprintf(stderr, "%sshopt: %s: invalid option name\n",
                        sh.err_prefix().c_str(), n.c_str());
         st = 1;
         continue;
       }
       if (set_s || unset_u) set_o_option(sh, n, set_s);
       else if (quiet_q) { if (!cur) st = 1; }
-      else std::printf("set %co %s\n", cur ? '-' : '+', n.c_str());
+      else show_o(n, cur);
     }
     return st;
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <termios.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/times.h>
 #include <sys/wait.h>
@@ -1113,7 +1114,47 @@ int Executor::run_simple(const SimpleCommand *c) {
     // directly; a hashed name execs its remembered value, and reports that
     // value's name on failure (bash's behavior for `hash'/BASH_CMDS entries).
     auto do_exec = [&](std::vector<char *> &cargv) {
-      execvp(exec_file.c_str(), cargv.data());
+      // Resolve a bare name on $PATH ourselves and execve the full path, rather
+      // than execvp -- execvp silently re-runs a #!-less script through /bin/sh,
+      // whereas bash (and we) re-exec it with the current shell.
+      std::string full = exec_file;
+      if (!exec_file.empty() && exec_file.find('/') == std::string::npos) {
+        std::string p = sh_.get("PATH");
+        bool found = false;
+        std::string noexec_path;  // a regular-file match that is not executable
+        for (size_t i = 0; i <= p.size();) {
+          size_t j = p.find(':', i);
+          std::string dir = p.substr(i, j == std::string::npos ? std::string::npos : j - i);
+          if (dir.empty()) dir = ".";
+          std::string cand = dir + "/" + exec_file;
+          struct stat stbuf;
+          if (stat(cand.c_str(), &stbuf) == 0 && S_ISREG(stbuf.st_mode)) {
+            if (access(cand.c_str(), X_OK) == 0) { full = cand; found = true; break; }
+            if (noexec_path.empty()) noexec_path = cand;
+          }
+          if (j == std::string::npos) break;
+          i = j + 1;
+        }
+        if (!found) {
+          // A file that exists on $PATH but is not executable is reported by
+          // its full path as "Permission denied" (126); otherwise the bare
+          // name is "command not found" (127), as bash does.
+          if (!noexec_path.empty()) { exec_file = noexec_path; errno = EACCES; }
+          else errno = ENOENT;
+          return;
+        }
+      }
+      execve(full.c_str(), cargv.data(), environ);
+      // A file that is neither a binary nor has a #! line: run it as a shell
+      // script with this shell, as bash does (not the libc /bin/sh fallback).
+      if (errno == ENOEXEC && !sh_.self_exe.empty()) {
+        std::vector<char *> nargv;
+        nargv.push_back(const_cast<char *>(sh_.self_exe.c_str()));
+        nargv.push_back(const_cast<char *>(full.c_str()));
+        for (size_t k = 1; cargv[k] != nullptr; k++) nargv.push_back(cargv[k]);
+        nargv.push_back(nullptr);
+        execve(sh_.self_exe.c_str(), nargv.data(), environ);
+      }
     };
     // external command.  If we are a disposable subshell child whose sole
     // command this is, exec it in place -- become the command with no second

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -281,6 +281,7 @@ int main(int argc, char **argv) {
 
   // $SHELL is the execution path of the current shell (persona-independent).
   std::string exec_path = resolve_exec_path(prog);
+  sh.self_exe = exec_path;  // for re-execing #!-less scripts (ENOEXEC)
   sh.set_exported("SHELL", exec_path);
 
   std::vector<std::string> args(argv + 1, argv + argc);


### PR DESCRIPTION
Closes #192.

Brings `shopt.tests` to **byte-perfect (318 → 0)** and, as a side effect of the exec fix, `trap.tests` **27 → 22**. No other test regressed; total suite byte-diff drops 5918 → 5595.

### Commits
1. **Report an error for shopt with an invalid option or -o name** — `shopt -z` now prints `shopt: -z: invalid option` + usage and returns 2 instead of listing everything; `shopt -o` honors `-p` (column `NAME<TAB>state` listing without it, reusable `set -o` commands with it); an unknown `set -o` name reports `invalid option name`.
2. **Record emacs/monitor/privileged as set -o option state** — new `opt_emacs`/`opt_vi`/`opt_monitor`/`opt_privileged` flags, driven by `set -o NAME` and the `-m`/`-p` short options, reported from `set_option_states` so `set -o`/`shopt -o` reflect them even non-interactively (monitor also honors an interactive shell's job control).
3. **Re-exec a script with no #! line using the current shell** — resolve a bare command on $PATH ourselves and `execve` the full path so a `#!`-less text file surfaces as ENOEXEC (which `execvp` would instead hand to `/bin/sh`); on ENOEXEC, re-exec the file with this shell's own executable, matching bash. Preserves bash's `command not found` (127) vs `Permission denied` (126) distinction and directory/empty-name handling.

### Verification
- `shopt` scoreboard 318 → 0; `trap` 27 → 22; full 83-file rescan shows no regressions.
- ctest 22/22.
- Spot-checked exec: shebang scripts, \#!-less scripts (now run under gnash), non-executable files on $PATH (126 + full path), missing commands (127), and empty command names all match bash.