### PR TITLE
Do not count a literal { as nesting inside ${...}

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -43,27 +43,36 @@ bool pat_match(const std::string &pattern, const std::string &text) {
 }
 
 // Scan a balanced span from `open`/`close` starting with text[i] at the opener;
-// returns the index of the matching closer (or npos).  Honors quotes.
-size_t scan_balanced(const std::string &t, size_t i, char open, char close) {
+// returns the index of the matching closer (or npos).  Honors quotes.  With
+// `firstclose` (used for ${param...}), a bare `{` does not open a nested level
+// -- only a `${` does -- matching bash's parse_matched_pair P_FIRSTCLOSE rule,
+// so `${IFS+a{b}` closes at the `}` after `b`.
+size_t scan_balanced(const std::string &t, size_t i, char open, char close,
+                     bool firstclose = false) {
   int depth = 0;
+  bool wasdol = false;  // previous char was an unquoted `$` (LEX_WASDOL)
   for (; i < t.size(); i++) {
     char c = t[i];
-    if (c == '\\') { i++; continue; }
+    if (c == '\\') { i++; wasdol = false; continue; }
     if (c == '$' && i + 1 < t.size() && t[i + 1] == '\'') {
       // $'...': ANSI-C quoting, where a backslash escapes the next character
       // (so \' is not a terminator).
       i += 2;
       while (i < t.size() && t[i] != '\'') { if (t[i] == '\\' && i + 1 < t.size()) i++; i++; }
+      wasdol = false;
       continue;
     }
-    if (c == '\'') { while (++i < t.size() && t[i] != '\'') {} continue; }
+    if (c == '\'') { while (++i < t.size() && t[i] != '\'') {} wasdol = false; continue; }
     if (c == '"') {
       while (++i < t.size() && t[i] != '"')
         if (t[i] == '\\') i++;
+      wasdol = false;
       continue;
     }
-    if (c == open) depth++;
-    else if (c == close) { if (--depth == 0) return i; }
+    if (c == open) {
+      if (!firstclose || open != '{' || depth == 0 || wasdol) depth++;
+    } else if (c == close) { if (--depth == 0) return i; }
+    wasdol = (c == '$');
   }
   return std::string::npos;
 }
@@ -661,7 +670,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   }
   // ${...}
   if (n1 == '{') {
-    size_t end = scan_balanced(t, i + 1, '{', '}');
+    size_t end = scan_balanced(t, i + 1, '{', '}', /*firstclose=*/true);
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
 

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -172,29 +172,42 @@ struct Lexer {
   }
   void scan_brace(std::string &w) {  // pos at '{'
     int depth = 0;
+    // Inside ${...} only a nested `${` opens another level; a bare `{` is a
+    // literal character.  This mirrors bash's parse_matched_pair called with
+    // P_FIRSTCLOSE for ${...}: it counts `{` only when the previous char was
+    // an unquoted `$` (LEX_WASDOL).  `wasdol` tracks that.
+    bool wasdol = false;
     do {
       char c = in[pos];
       if (c == '{') {
-        depth++;
+        if (depth == 0 || wasdol) depth++;  // opening ${ or nested ${
         w += c;
         pos++;
+        wasdol = false;
       } else if (c == '}') {
         depth--;
         w += c;
         pos++;
+        wasdol = false;
       } else if (c == '$' && pos + 1 < n && in[pos + 1] == '\'') {
         scan_dollar_single(w);  // $'...' inside ${...}: backslash-aware
+        wasdol = false;
       } else if (c == '\'') {
         scan_single(w);
+        wasdol = false;
       } else if (c == '"') {
         scan_double(w);
+        wasdol = false;
       } else if (c == '`') {
         scan_backtick(w);
+        wasdol = false;
       } else if (c == '\\') {
         w += c;
         pos++;
         if (pos < n) w += in[pos++];
+        wasdol = false;
       } else {
+        wasdol = (c == '$');
         w += c;
         pos++;
       }


### PR DESCRIPTION
## Summary

Inside a `${...}` parameter expansion, gnash's brace scanners counted a **literal** `{` as opening a nesting level, so in `"${IFS+a{b}"` the `}` after `b` was consumed by the literal `{` and the parser ran off to EOF looking for the closing quote — aborting the rest of any script containing the construct.

```console
$ gnash -c 'echo "${IFS+a{b}"'
gnash: -c: line 2: unexpected EOF while looking for matching `"'
$ bash  -c 'echo "${IFS+a{b}"'
a{b
```

## Root cause

bash calls `parse_matched_pair` for `${...}` with `P_FIRSTCLOSE|P_DOLBRACE` (parse.y:4183, 5513). Under `P_FIRSTCLOSE` a bare `{` does **not** open a nested level — only a `${` (a `{` preceded by an unquoted `$`, `LEX_WASDOL`) does; `}` always closes. gnash's `scan_brace` (lexer) and `scan_balanced` (expander) instead counted every `{`.

## Fix

Mirror bash's rule in both scanners. `scan_balanced` gets a `firstclose` flag applied only to the real `${param...}` call site — not the `${ cmd; }` funsub or `$(...)`, which keep normal nesting.

## Testing

- `posixexp` byte-diff: **295 → 67** (the parse-abort cascade is gone).
- `ctest --test-dir build`: 22/22.
- `tests/harness/run_diff.sh`: all 221 scripts match bash.
- Full scoreboard rescan (builtins/array/assoc/nameref/complete/dbg-support/intl/varenv/quotearray): no regressions.

The remaining 67 `posixexp` diffs are a separate cluster of DOLBRACE quote-state cases (`\}` delimiter dequoting, single quotes inside `${...}` within double quotes) left for a follow-up.

Closes #194