### PR TITLE
testsuite batch56: dbg-support DEBUG/RETURN trap & $LINENO conformance

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -165,6 +165,9 @@ class Shell {
   // inside the body reports absolute source lines even when the function is
   // called from a different input block (which has its own lineno_base).
   std::map<std::string, int> func_lineno_base;
+  // Function name -> the absolute source line of its definition (the `name ()'
+  // line), reported by the whole-body DEBUG trap fired on entry under functrace.
+  std::map<std::string, int> func_def_line;
   std::string current_source() const {          // file of the innermost frame
     return src_frames.empty() ? std::string() : src_frames.back().source;
   }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3941,7 +3941,12 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // so ${BASH_SOURCE[0]} lets a script locate itself.  The call line is
         // where `source' appears in the current file.
         sh.push_src_frame("source", path, sh.cur_lineno, false);
+        // A sourced file has its own line numbering starting at 1 ($LINENO, the
+        // DEBUG trap, and functions it defines all use the file's own lines).
+        int saved_src_base = sh.lineno_base;
+        sh.lineno_base = 0;
         st = sh.run_string(ss.str());
+        sh.lineno_base = saved_src_base;
         // `return' inside a sourced file ends the file (and sets its status),
         // like reaching EOF -- it must not unwind past `source' or exit the
         // shell (bash semantics; e.g. /etc/bashrc does `[ -z "$PS1" ] && return').

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3008,23 +3008,58 @@ int bi_enable(Shell &sh, const std::vector<std::string> &argv) {
 
 // ---- caller --------------------------------------------------------------
 int bi_caller(Shell &sh, const std::vector<std::string> &argv) {
-  if (sh.call_stack.empty()) return 1;
-  size_t top = sh.call_stack.size() - 1;
-  // call_stack[k].line is where call_stack[k].func was invoked.  For frame N,
-  // bash reports that call line, but the *calling* function's name/source (the
-  // frame just below), FUNCNAME[N+1]/BASH_SOURCE[N+1].
-  if (argv.size() > 1) {  // caller N: "line function source"
-    long n = std::atol(argv[1].c_str());
-    // Valid only while FUNCNAME[N+1] is a real function (not the main script).
-    if (n < 0 || static_cast<size_t>(n) + 1 >= sh.call_stack.size()) return 1;
-    const auto &fr = sh.call_stack[top - static_cast<size_t>(n)];
-    const auto &caller = sh.call_stack[top - static_cast<size_t>(n) - 1];
-    std::printf("%d %s %s\n", fr.line, caller.func.c_str(), caller.source.c_str());
+  // Mirror bash's caller.def: read the BASH_LINENO / BASH_SOURCE / FUNCNAME
+  // call-context arrays so top-level ("line source", with NULL for a missing
+  // frame) and the error diagnostics match byte-for-byte.
+  static const char *kUsage = "caller: usage: caller [expr]\n";
+  size_t ai = 1;
+  // no_options: a leading `-X' (anything but a bare `--') is an invalid option.
+  if (ai < argv.size() && argv[ai].size() >= 1 && argv[ai][0] == '-' &&
+      argv[ai] != "--") {
+    std::fprintf(stderr, "%scaller: %s: invalid option\n",
+                 sh.err_prefix().c_str(), argv[ai].c_str());
+    std::fprintf(stderr, "%s", kUsage);
+    return 2;
+  }
+  if (ai < argv.size() && argv[ai] == "--") ai++;
+
+  std::vector<std::string> lineno = sh.array_values("BASH_LINENO");
+  std::vector<std::string> source = sh.array_values("BASH_SOURCE");
+  std::vector<std::string> funcs = sh.array_values("FUNCNAME");
+  auto at = [](const std::vector<std::string> &v, size_t i) -> const char * {
+    return i < v.size() ? v[i].c_str() : "NULL";
+  };
+  if (lineno.empty() || source.empty()) return 1;
+
+  if (ai >= argv.size()) {  // caller (no arg): "line source"
+    std::printf("%s %s\n", at(lineno, 0), at(source, 1));
     return 0;
   }
-  const auto &fr = sh.call_stack[top];  // caller (no arg): "line source"
-  std::string source = (top >= 1) ? sh.call_stack[top - 1].source : fr.source;
-  std::printf("%d %s\n", fr.line, source.c_str());
+  // valid_number: optional surrounding blanks, an optional sign, then digits.
+  const std::string &w = argv[ai];
+  size_t p = 0, e = w.size();
+  while (p < e && std::isspace(static_cast<unsigned char>(w[p]))) p++;
+  while (e > p && std::isspace(static_cast<unsigned char>(w[e - 1]))) e--;
+  size_t d = p;
+  if (d < e && (w[d] == '+' || w[d] == '-')) d++;
+  bool valid = d < e;
+  for (size_t k = d; k < e; k++)
+    if (!std::isdigit(static_cast<unsigned char>(w[k]))) { valid = false; break; }
+  if (!valid) {
+    std::fprintf(stderr, "%scaller: %s: invalid number\n",
+                 sh.err_prefix().c_str(), w.c_str());
+    std::fprintf(stderr, "%s", kUsage);
+    return 2;
+  }
+  // A valid EXPR requires an active function frame and an in-range index.
+  if (funcs.empty()) return 1;
+  long num = std::atol(w.substr(p, e - p).c_str());
+  size_t un = static_cast<size_t>(num);
+  if (num < 0 || un >= lineno.size() || un + 1 >= source.size() ||
+      un + 1 >= funcs.size())
+    return 1;
+  std::printf("%s %s %s\n", lineno[un].c_str(), funcs[un + 1].c_str(),
+              source[un + 1].c_str());
   return 0;
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1050,12 +1050,14 @@ int Executor::run_simple(const SimpleCommand *c) {
     status = unwinding() ? sh_.last_status : run(fit->second);
     // The RETURN trap fires when the function returns, in its own scope, with $?
     // set to the return status.  It runs when inherited (functrace) or installed
-    // inside the function.
+    // inside the function.  A function invoked while the DEBUG trap is running
+    // (e.g. the DEBUG-trap handler itself) does not inherit the RETURN trap --
+    // bash restores its default at entry when signal_in_progress(DEBUG_TRAP).
     {
       auto rt = sh_.traps.find("RETURN");
       bool set_now = rt != sh_.traps.end() && !rt->second.empty();
       bool set_inside = set_now && (!had_return || rt->second != return_before);
-      if (set_now && (sh_.opt_functrace || set_inside)) {
+      if (set_now && (sh_.opt_functrace || set_inside) && !sh_.in_debug_trap) {
         int ret_status = sh_.returning ? sh_.exit_status : status;
         bool save_ret = sh_.returning;
         int save_es = sh_.exit_status;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1040,8 +1040,13 @@ int Executor::run_simple(const SimpleCommand *c) {
     if (lbit != sh_.func_lineno_base.end()) sh_.lineno_base = lbit->second;
     // Under functrace, bash fires the DEBUG trap once for the function body as a
     // whole on entry, before the per-command traps inside it.
-    if (sh_.opt_functrace && sh_.traps.count("DEBUG") && !sh_.in_debug_trap)
+    if (sh_.opt_functrace && sh_.traps.count("DEBUG") && !sh_.in_debug_trap) {
+      // The whole-body DEBUG trap reports the function's definition line.
+      auto dlit = sh_.func_def_line.find(argv[0]);
+      sh_.cur_lineno = dlit != sh_.func_def_line.end() ? dlit->second
+                                                       : sh_.lineno_base + 1;
       sh_.run_debug_trap(to_string(fit->second));
+    }
     // Snapshot the RETURN trap so we can tell one the function installs for
     // itself from an inherited one (only inherited under functrace).
     auto rtit = sh_.traps.find("RETURN");
@@ -1439,10 +1444,27 @@ int Executor::run_case(const CaseCommand *c) {
   return st;
 }
 
+// The relative source line of the first executable command in a body, found by
+// descending through wrapping groups/connections; 0 if none carries a line.
+static int first_body_line(const Command *c) {
+  if (!c) return 0;
+  if (auto *g = dynamic_cast<const Group *>(c)) return first_body_line(g->body.get());
+  if (auto *s = dynamic_cast<const Subshell *>(c)) return first_body_line(s->body.get());
+  if (auto *cn = dynamic_cast<const Connection *>(c)) {
+    int f = first_body_line(cn->first.get());
+    return f > 0 ? f : first_body_line(cn->second.get());
+  }
+  return c->line;
+}
+
 int Executor::run_funcdef(const FunctionDef *c) {
   sh_.functions[c->name] = c->body.get();
   sh_.func_src[c->name] = sh_.current_source();  // file it was defined in, for BASH_SOURCE
   sh_.func_lineno_base[c->name] = sh_.lineno_base;  // for $LINENO inside the body
+  // The `name ()' line = one above the body's first command (both the entry
+  // DEBUG trap and `caller' report it); computed absolutely under the body base.
+  int fbl = first_body_line(c->body.get());
+  sh_.func_def_line[c->name] = fbl > 0 ? sh_.lineno_base + fbl - 1 : sh_.cur_lineno;
   return 0;
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1348,11 +1348,21 @@ int Executor::run_for(const ForCommand *c) {
   }
   if (c->is_arith) {
     bool ok = true;
+    int for_line = sh_.cur_lineno;  // the loop's own line (set by run() on entry)
     // The three arithmetic sections undergo parameter/command expansion before
     // evaluation (as bash does), so forms like ${#arr[@]} work inside them.
     Expander aex(sh_);
-    auto aeval = [&](const std::string &e) {
+    auto aeval = [&](const std::string &e) -> long long {
       if (e.empty()) return 0LL;
+      // bash fires the DEBUG trap for each arith-for expression (init, and the
+      // test/step on every iteration), reporting the loop's own line, before
+      // evaluating it; extdebug lets a non-zero trap skip that evaluation.
+      if (sh_.traps.count("DEBUG") && !sh_.in_debug_trap) {
+        sh_.cur_lineno = for_line;
+        int tst = sh_.run_debug_trap("(( " + e + " ))");
+        auto ed = sh_.shopt_opts.find("extdebug");
+        if (tst != 0 && ed != sh_.shopt_opts.end() && ed->second) return 0LL;
+      }
       if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", e.c_str());
       return static_cast<long long>(eval_arith(sh_, aex.expand_no_split(e), &ok));
     };

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -584,10 +584,12 @@ struct Parser {
 
   CommandPtr parse_for() {
     bool select = reserved("select");
+    int for_line = cur().line;  // $LINENO of the `for'/`select' keyword
     push_open(select ? "select" : "for");
     advance();  // for / select
     auto n = std::make_unique<ForCommand>();
     n->is_select = select;
+    n->line = for_line;
 
     if (!select && is(Tok::Lparen) && cur().glued && peek(1).type == Tok::Lparen) {
       parse_arith_for_header(*n);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -860,13 +860,20 @@ void Shell::sync_source_arrays() {
     fn.invisible = true;
     return;
   }
+  // A script run from a file (or sourced) has a base "main" frame at index 0
+  // that FUNCNAME/BASH_LINENO trail with `main'/`0'; `sh -c' has no such frame,
+  // so its FUNCNAME/BASH_LINENO list only the active function frames.
+  bool has_base = !src_frames.front().is_func;
+  size_t stop = has_base ? 1 : 0;
   std::vector<std::string> names, lines;
-  for (size_t i = src_frames.size(); i-- > 1;) {  // top down to frame 1 (above base)
+  for (size_t i = src_frames.size(); i-- > stop;) {  // top down to the first frame
     names.push_back(src_frames[i].name);
     lines.push_back(std::to_string(src_frames[i].line));
   }
-  names.push_back("main");
-  lines.push_back("0");
+  if (has_base) {
+    names.push_back("main");
+    lines.push_back("0");
+  }
   set_indexed("FUNCNAME", names);
   set_indexed("BASH_LINENO", lines);
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1651,7 +1651,10 @@ std::string Shell::run_and_capture_inproc(const std::string &script, int *status
   if (!tf) { if (status) *status = 1; return std::string(); }
   int tfd = fileno(tf);
   dup2(tfd, STDOUT_FILENO);
+  int saved_base = lineno_base;  // run at the enclosing command's line
+  lineno_base = cur_lineno - 1;
   int st = run_string(script);
+  lineno_base = saved_base;
   std::fflush(stdout);
   dup2(saved, STDOUT_FILENO);
   close(saved);
@@ -1688,6 +1691,10 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     // `echo' under `set -e'.  POSIX mode inherits errexit into the subshell, so
     // there `z=$(false; echo foo)' exits silently before the `echo'.
     if (opt_errexit && !opt_posix && !shopt_opts["inherit_errexit"]) opt_errexit = false;
+    // The substitution's commands run at the enclosing command's line: bash does
+    // not reset the line counter for a command substitution, so $LINENO (and a
+    // DEBUG trap firing inside it) reports the line where the `$(...)' appears.
+    lineno_base = cur_lineno - 1;
     int st = run_string(script);
     std::fflush(stdout);
     _exit(st & 0xff);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -261,10 +261,16 @@ int Shell::run_debug_trap(const std::string &cmd_text) {
   bash_command = cmd_text;
   int saved = last_status;  // $? inside the trap is the previous command's status
   int saved_line = cur_lineno;  // the trap must not leak its own line numbers
+  // bash runs a DEBUG/RETURN/ERR trap body without resetting the line counter
+  // (no SEVAL_RESETLINE), so $LINENO in the body's first line reports the
+  // command that triggered the trap; later body lines count up from there.
+  int saved_base = lineno_base;
+  lineno_base = cur_lineno - 1;
   std::string body = it->second;
   int st = run_string(body);
   last_status = saved;  // the trap does not alter $? for the upcoming command
   cur_lineno = saved_line;
+  lineno_base = saved_base;
   in_debug_trap = false;
   return st;
 }


### PR DESCRIPTION
Closes #196.

Brings `dbg-support.tests` from **514 → 51** byte-normalized diffs against bash 5.3, with bonus improvements to `trap` (27 → 20) and `exp` (68 → 60). Eight focused fixes:

1. **$LINENO inside a trap body** now reports the triggering command's line, not the trap body's own line (bash runs DEBUG/RETURN/ERR traps without `SEVAL_RESETLINE`).
2. **RETURN trap** no longer fires for a function invoked while the DEBUG trap is running (bash restores its default when `signal_in_progress(DEBUG_TRAP)`). This alone removed ~120 spurious lines.
3. **Function entry DEBUG trap** reports the function's definition line (recorded at definition time), fixing functions defined in sourced files.
4. **Command substitutions** run at the enclosing command's line for $LINENO / DEBUG.
5. **Sourced files** get their own line numbering starting at 1.
6. **Arithmetic `for (( ; ; ))`** fires the DEBUG trap for its init/test/step expressions at the loop's line; the parser now records the for/select line.
7. **`caller` builtin** reworked to match `builtins/caller.def`: top-level `0 NULL`, option/invalid-number diagnostics, NULL for missing frames.
8. **FUNCNAME/BASH_LINENO under `sh -c`** no longer append a spurious `main` frame (there is no base frame under `-c`).

Verification: `ctest` 22/22, `run_diff` all 221 scripts match, and a broad scoreboard rescan shows no regressions (array 371, builtins 340, assoc 254, nameref 251, varenv 181, arith 170, func 137, quote 71, posixexp 67 all unchanged).