### PR TITLE
testsuite batch58: FUNCNEST, integer-assignment errors, function-name validation

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -80,7 +80,8 @@ std::string to_string(const Command *c);
 
 // bash's multi-line function rendering (print_cmd.c named_function_string),
 // used by `type', `declare -f', and `set' -- byte-identical to bash.
-std::string named_function_string(const std::string &name, const Command *body);  // full canonical rendering
+std::string named_function_string(const std::string &name, const Command *body,
+                                  bool posix = false);  // full canonical rendering
 
 struct SimpleCommand : Command {
   std::vector<Word> words;  // assignment prefix + argv, in order

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -556,9 +556,34 @@ std::string canonical_word(const std::string &w) {
 
 }  // namespace
 
-std::string named_function_string(const std::string &name, const Command *body) {
+// bash's assignment(): NAME[sub]=... where NAME is a valid identifier.
+static bool func_name_is_assignment(const std::string &s) {
+  size_t i = 0;
+  if (s.empty() || (!std::isalpha((unsigned char)s[0]) && s[0] != '_')) return false;
+  while (i < s.size() && (std::isalnum((unsigned char)s[i]) || s[i] == '_')) i++;
+  if (i < s.size() && s[i] == '[') {
+    size_t j = s.find(']', i);
+    if (j == std::string::npos) return false;
+    i = j + 1;
+  }
+  return i < s.size() && s[i] == '=';
+}
+
+std::string named_function_string(const std::string &name, const Command *body,
+                                  bool posix) {
   MPrinter p;
-  p.out = name + " () ";
+  // bash prefixes `function ' to a name that is not a valid function name: in
+  // the default mode that means an assignment-shaped name (`a=2'); under posix
+  // it also covers all-digit names and non-identifiers.
+  bool prefix = func_name_is_assignment(name);
+  if (posix && !prefix) {
+    bool all_digits = !name.empty();
+    for (char c : name) if (!std::isdigit((unsigned char)c)) { all_digits = false; break; }
+    bool ident = !name.empty() && (std::isalpha((unsigned char)name[0]) || name[0] == '_');
+    for (char c : name) if (!std::isalnum((unsigned char)c) && c != '_') { ident = false; break; }
+    if (all_digits || !ident) prefix = true;
+  }
+  p.out = (prefix ? "function " : "") + name + " () ";
   p.out += '\n';
   p.print_func_body(body, 0);
   return p.out;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1575,7 +1575,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (i >= argv.size()) {  // all functions
       for (const auto &kv : sh.functions) {
         if (funcnames) std::printf("declare -f %s\n", kv.first.c_str());
-        else std::printf("%s\n", named_function_string(kv.first, kv.second).c_str());
+        else std::printf("%s\n", named_function_string(kv.first, kv.second, sh.opt_posix).c_str());
       }
       return 0;
     }
@@ -1583,7 +1583,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       auto it = sh.functions.find(argv[i]);
       if (it == sh.functions.end()) { st = 1; continue; }
       if (funcnames) std::printf("%s\n", argv[i].c_str());
-      else std::printf("%s\n", named_function_string(argv[i], it->second).c_str());
+      else std::printf("%s\n", named_function_string(argv[i], it->second, sh.opt_posix).c_str());
     }
     return st;
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -836,9 +836,13 @@ int Executor::run_simple(const SimpleCommand *c) {
           else sh_.vars.erase(it->first);
         }
         if (integer) {
+          // An integer-attributed assignment evaluates the RHS as arithmetic;
+          // a malformed value (`i=0#4') prints bash's diagnostic and aborts the
+          // assignment with status 1 rather than silently storing 0.
           bool ok = true;
-          long long rv = eval_arith(sh_, v, &ok);
-          if (a.append) rv = eval_arith(sh_, cur, &ok) + rv;
+          long long rv = eval_arith_msg(sh_, v, "", &ok);
+          if (ok && a.append) rv = eval_arith_msg(sh_, cur, "", &ok) + rv;
+          if (!ok) { sh_.arith_error = true; break; }
           v = std::to_string(rv);
         } else if (a.append) {
           v = cur + v;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1483,6 +1483,13 @@ static int first_body_line(const Command *c) {
 }
 
 int Executor::run_funcdef(const FunctionDef *c) {
+  // bash rejects a function name that contained an unquoted `$' expansion
+  // (W_HASDOLLAR) -- e.g. `function sys$read' -- as not a valid identifier.
+  if (c->name.find('$') != std::string::npos) {
+    std::fprintf(stderr, "%s`%s': not a valid identifier\n",
+                 sh_.err_prefix().c_str(), c->name.c_str());
+    return (sh_.last_status = 1);
+  }
   sh_.functions[c->name] = c->body.get();
   sh_.func_src[c->name] = sh_.current_source();  // file it was defined in, for BASH_SOURCE
   sh_.func_lineno_base[c->name] = sh_.lineno_base;  // for $LINENO inside the body

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1011,6 +1011,17 @@ int Executor::run_simple(const SimpleCommand *c) {
 
   int status = 0;
   if (is_func) {
+    // FUNCNEST caps function-call nesting: bash aborts with an error once the
+    // depth would reach it (a value <= 0 or an unset/invalid FUNCNEST = no cap).
+    if (sh_.is_set("FUNCNEST")) {
+      long fn_max = std::strtol(sh_.get("FUNCNEST").c_str(), nullptr, 10);
+      if (fn_max > 0 && static_cast<long>(sh_.local_stack.size()) >= fn_max) {
+        std::fprintf(stderr, "%s%s: maximum function nesting level exceeded (%ld)\n",
+                     sh_.err_prefix().c_str(), argv[0].c_str(), fn_max);
+        sh_.last_status = 1;
+        return 1;
+      }
+    }
     apply_temp();
     std::vector<std::string> saved_pos = sh_.positional;
     sh_.positional.assign(argv.begin() + 1, argv.end());

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -953,6 +953,9 @@ struct Parser {
     expect(Tok::Rparen, ")");
     newline_list();
     n->body = parse_command({});
+    // bash validates the function name at the end of the definition, so an
+    // invalid-name error reports the line the definition closes on.
+    n->line = i > 0 ? toks[i - 1].line : cur().line;
     return n;
   }
 
@@ -971,6 +974,7 @@ struct Parser {
     }
     newline_list();
     n->body = parse_command({});
+    n->line = i > 0 ? toks[i - 1].line : cur().line;  // the definition's end line
     return n;
   }
 


### PR DESCRIPTION
Closes #200.

Four independent conformance fixes from func.tests and arith.tests:

1. **FUNCNEST** — recursion is now capped at `FUNCNEST`, aborting with `NAME: maximum function nesting level exceeded (N)` and status 1 (func4.sub now byte-matches).
2. **Malformed integer assignment** — `declare -i i; i=0#4` prints bash's `invalid number` diagnostic and fails, instead of silently storing 0.
3. **Function-name validation** — `function sys$read` (a name with an unquoted `$`) is rejected as ``sys$read': not a valid identifier`, and the error reports the definition's closing line (FunctionDef now records its end line).
4. **`declare -f` display** — a non-identifier function name is prefixed with `function ` (`function a=2 ()`), matching bash's `named_function_string` (assignment-shaped in default mode; also all-digit/non-identifier under posix).

Results: **func 137 → 111**, **arith 170 → 168**. Verification: ctest 22/22, run_diff all 221 match, broad scoreboard rescan shows no regressions (array 371, builtins 340, assoc 254, nameref 251, varenv 181, complete 3, dbg-support 51 unchanged).