### PR TITLE
Refactor: shared quote-aware array-subscript scanner

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_library(gnash_core STATIC
   src/ast.cpp
   src/lexer.cpp
+  src/subscript.cpp
   src/parser.cpp
   src/shell.cpp
   src/arith.cpp

--- a/core/include/gnash/core/subscript.hpp
+++ b/core/include/gnash/core/subscript.hpp
@@ -1,0 +1,32 @@
+#ifndef GNASH_CORE_SUBSCRIPT_HPP
+#define GNASH_CORE_SUBSCRIPT_HPP
+
+#include <cstddef>
+#include <string>
+
+namespace gnash::core {
+
+// Given s[open] == '[', return the index of the matching, unquoted ']' that
+// closes the array subscript, or std::string::npos if none is found.
+//
+// This mirrors bash's skipsubscript()/skip_matched_pair(): a ']' does not close
+// the subscript when it is backslash-escaped, inside single or double quotes,
+// inside a `...` / $(...) / ${...} substitution, or nested in a further '['.
+// So the key of `a[x\]y]`, `a["p]q"]`, `a[$(cmd])]` and `a[b[c]]` all scan
+// correctly.  It is the single boundary primitive shared by the lexer (deciding
+// an assignment word), the compound-literal element parser, the read/write of
+// `name[sub]', and `unset name[sub]'.
+std::size_t skip_subscript(const std::string &s, std::size_t open);
+
+// Split a possibly-subscripted assignment target.  If `word' begins with a
+// valid name optionally followed by `[subscript]', sets `name' and (when a
+// subscript is present) `sub` to the text between the brackets, and returns the
+// index of the first character after the closing ']' (or after the name when
+// there is no subscript).  Returns std::string::npos if `word' does not start
+// with a valid name.  `has_sub' reports whether a subscript was present.
+std::size_t split_subscript(const std::string &word, std::string &name,
+                            std::string &sub, bool &has_sub);
+
+}  // namespace gnash::core
+
+#endif  // GNASH_CORE_SUBSCRIPT_HPP

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -4,6 +4,7 @@
 // executor.cpp -- execute the command AST.
 
 #include "gnash/core/executor.hpp"
+#include "gnash/core/subscript.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -202,21 +203,11 @@ struct Assign {
 };
 
 bool parse_assign(const std::string &w, Assign &a) {
-  size_t i = 0;
-  while (i < w.size() && (std::isalnum(static_cast<unsigned char>(w[i])) || w[i] == '_')) i++;
-  a.name = w.substr(0, i);
-  if (a.name.empty()) return false;
-  if (i < w.size() && w[i] == '[') {
-    size_t s = ++i;
-    int d = 1;
-    while (i < w.size() && d) {
-      if (w[i] == '[') d++;
-      else if (w[i] == ']') d--;
-      if (d) i++;
-    }
-    a.sub = w.substr(s, i - s);
-    if (i < w.size() && w[i] == ']') i++;
-  }
+  std::string sub;
+  bool has_sub = false;
+  size_t i = split_subscript(w, a.name, sub, has_sub);
+  if (i == std::string::npos) return false;  // not a name-headed word
+  if (has_sub) a.sub = sub;
   if (i < w.size() && w[i] == '+') { a.append = true; i++; }
   if (i >= w.size() || w[i] != '=') return false;
   i++;
@@ -245,7 +236,7 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
     if (t.type != Tok::Word) continue;
     const std::string &e = t.text;
     if (!e.empty() && e[0] == '[') {
-      size_t rb = e.find(']');
+      size_t rb = skip_subscript(e, 0);  // the ']' closing the [subscript]
       // [sub]=value or [sub]+=value (append to that element).
       bool app = rb != std::string::npos && rb + 2 < e.size() && e[rb + 1] == '+' &&
                  e[rb + 2] == '=';
@@ -391,9 +382,9 @@ bool is_assignment_word_text(const std::string &w) {
     return false;
   while (i < w.size() && (std::isalnum(static_cast<unsigned char>(w[i])) || w[i] == '_')) i++;
   if (i < w.size() && w[i] == '[') {
-    int d = 1;
-    i++;
-    while (i < w.size() && d) { if (w[i] == '[') d++; else if (w[i] == ']') d--; i++; }
+    size_t close = skip_subscript(w, i);
+    if (close == std::string::npos) return false;
+    i = close + 1;
   }
   if (i < w.size() && w[i] == '+') i++;
   return i < w.size() && w[i] == '=';

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -8,6 +8,7 @@
 // are follow-ons.
 
 #include "gnash/core/expand.hpp"
+#include "gnash/core/subscript.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -1202,17 +1203,15 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   bool have_sub = false;
   std::string sub;
   if (p < b.size() && b[p] == '[') {
-    size_t s = p + 1;
-    int d = 1;
-    p++;
-    while (p < b.size() && d) {
-      if (b[p] == '[') d++;
-      else if (b[p] == ']') d--;
-      if (d) p++;
+    size_t close = skip_subscript(b, p);
+    if (close != std::string::npos) {
+      sub = b.substr(p + 1, close - p - 1);
+      p = close + 1;
+    } else {  // unterminated: treat the rest as the subscript
+      sub = b.substr(p + 1);
+      p = b.size();
     }
-    sub = b.substr(s, p - s);
     have_sub = true;
-    if (p < b.size() && b[p] == ']') p++;
   }
 
   // zsh: `${#a}' on an array is the element count (bash gives the length of

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -4,6 +4,7 @@
 // lexer.cpp -- shell tokenizer (see lexer.hpp).
 
 #include "gnash/core/lexer.hpp"
+#include "gnash/core/subscript.hpp"
 
 #include <cctype>
 
@@ -92,15 +93,11 @@ struct Lexer {
     return true;
   }
 
-  // Offset of the `]' matching the `[' at START (handling nesting), or npos.
+  // Offset of the `]' closing the array subscript opened by the `[' at START,
+  // or npos.  Delegates to the shared quote-aware scanner so an escaped/quoted
+  // `]' or one inside a substitution does not close the subscript.
   std::size_t matching_bracket(std::size_t start) const {
-    int depth = 0;
-    for (std::size_t k = start; k < n; k++) {
-      if (in[k] == '[') depth++;
-      else if (in[k] == ']' && --depth == 0) return k;
-      else if (in[k] == '\n') break;  // a subscript does not span input lines here
-    }
-    return std::string::npos;
+    return skip_subscript(in, start);
   }
 
   explicit Lexer(const std::string &s) : in(s), n(s.size()) {}

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -4,6 +4,7 @@
 // parser.cpp -- recursive-descent parser (see parser.hpp).
 
 #include "gnash/core/parser.hpp"
+#include "gnash/core/subscript.hpp"
 
 #include <cctype>
 #include <cstdlib>
@@ -484,13 +485,10 @@ struct Parser {
     if (i >= s.size() || !(std::isalpha(static_cast<unsigned char>(s[i])) || s[i] == '_'))
       return false;
     while (i < s.size() && (std::isalnum(static_cast<unsigned char>(s[i])) || s[i] == '_')) i++;
-    if (i < s.size() && s[i] == '[') {  // subscript
-      int depth = 0;
-      for (; i < s.size(); i++) {
-        if (s[i] == '[') depth++;
-        else if (s[i] == ']') { i++; break; }
-      }
-      (void)depth;
+    if (i < s.size() && s[i] == '[') {  // subscript (quote/escape aware)
+      std::size_t close = skip_subscript(s, i);
+      if (close == std::string::npos) return false;
+      i = close + 1;
     }
     if (i < s.size() && s[i] == '+') i++;
     return i < s.size() && s[i] == '=';
@@ -505,8 +503,11 @@ struct Parser {
     if (i >= w.size() || !(std::isalpha(static_cast<unsigned char>(w[i])) || w[i] == '_'))
       return "";
     while (i < w.size() && (std::isalnum(static_cast<unsigned char>(w[i])) || w[i] == '_')) i++;
-    if (i < w.size() && w[i] == '[')
-      for (; i < w.size(); i++) if (w[i] == ']') { i++; break; }
+    if (i < w.size() && w[i] == '[') {
+      std::size_t close = skip_subscript(w, i);
+      if (close == std::string::npos) return "";
+      i = close + 1;
+    }
     if (i < w.size() && w[i] == '+') i++;
     if (i >= w.size() || w[i] != '=') return "";
     i++;  // past `='

--- a/core/src/subscript.cpp
+++ b/core/src/subscript.cpp
@@ -1,0 +1,111 @@
+#include "gnash/core/subscript.hpp"
+
+#include <cctype>
+
+namespace gnash::core {
+
+namespace {
+
+// Advance past a single-quoted run; `i' points just after the opening quote.
+// Single quotes protect everything up to the next quote (no escapes).
+std::size_t skip_sq(const std::string &s, std::size_t i) {
+  while (i < s.size() && s[i] != '\'') i++;
+  return i < s.size() ? i + 1 : i;
+}
+
+// Advance past a `...` run; `i' points just after the opening backtick.  Like
+// bash's skip_matched_pair, a backtick body is scanned only for its terminator.
+std::size_t skip_bq(const std::string &s, std::size_t i) {
+  while (i < s.size() && s[i] != '`') i++;
+  return i < s.size() ? i + 1 : i;
+}
+
+std::size_t skip_dq(const std::string &s, std::size_t i);
+
+// Advance past a $(...) or ${...} substitution; `i' points at the `$'.  Nested
+// substitutions, quotes and escapes inside are skipped so a `)' / `}' / `]'
+// buried in the substitution does not end the enclosing construct.
+std::size_t skip_dollar(const std::string &s, std::size_t i) {
+  char open = s[i + 1];
+  char close = open == '(' ? ')' : '}';
+  i += 2;
+  int depth = 1;
+  while (i < s.size() && depth) {
+    char c = s[i];
+    if (c == '\\') { i += (i + 1 < s.size()) ? 2 : 1; continue; }
+    if (c == '\'') { i = skip_sq(s, i + 1); continue; }
+    if (c == '"') { i = skip_dq(s, i + 1); continue; }
+    if (c == '`') { i = skip_bq(s, i + 1); continue; }
+    if (c == '$' && i + 1 < s.size() && (s[i + 1] == '(' || s[i + 1] == '{')) {
+      i = skip_dollar(s, i);
+      continue;
+    }
+    if (c == open) depth++;
+    else if (c == close && --depth == 0) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+// Advance past a double-quoted run; `i' points just after the opening quote.
+// Inside, `\' escapes the next byte and `...` / $(...) / ${...} nest.
+std::size_t skip_dq(const std::string &s, std::size_t i) {
+  while (i < s.size() && s[i] != '"') {
+    char c = s[i];
+    if (c == '\\') { i += (i + 1 < s.size()) ? 2 : 1; continue; }
+    if (c == '`') { i = skip_bq(s, i + 1); continue; }
+    if (c == '$' && i + 1 < s.size() && (s[i + 1] == '(' || s[i + 1] == '{')) {
+      i = skip_dollar(s, i);
+      continue;
+    }
+    i++;
+  }
+  return i < s.size() ? i + 1 : i;
+}
+
+}  // namespace
+
+std::size_t skip_subscript(const std::string &s, std::size_t open) {
+  std::size_t i = open + 1;
+  int count = 1;  // the opening '[' already seen
+  while (i < s.size()) {
+    char c = s[i];
+    if (c == '\\') { i += (i + 1 < s.size()) ? 2 : 1; continue; }
+    if (c == '`') { i = skip_bq(s, i + 1); continue; }
+    if (c == '\'') { i = skip_sq(s, i + 1); continue; }
+    if (c == '"') { i = skip_dq(s, i + 1); continue; }
+    if (c == '$' && i + 1 < s.size() && (s[i + 1] == '(' || s[i + 1] == '{')) {
+      i = skip_dollar(s, i);
+      continue;
+    }
+    if (c == '\n') return std::string::npos;  // a bare newline ends the word
+    if (c == '[') { count++; i++; continue; }
+    if (c == ']') { if (--count == 0) return i; i++; continue; }
+    i++;
+  }
+  return std::string::npos;
+}
+
+std::size_t split_subscript(const std::string &word, std::string &name,
+                            std::string &sub, bool &has_sub) {
+  has_sub = false;
+  std::size_t i = 0;
+  if (i >= word.size() ||
+      (!std::isalpha(static_cast<unsigned char>(word[i])) && word[i] != '_'))
+    return std::string::npos;
+  while (i < word.size() &&
+         (std::isalnum(static_cast<unsigned char>(word[i])) || word[i] == '_'))
+    i++;
+  name = word.substr(0, i);
+  if (i < word.size() && word[i] == '[') {
+    std::size_t close = skip_subscript(word, i);
+    if (close != std::string::npos) {
+      sub = word.substr(i + 1, close - i - 1);
+      has_sub = true;
+      return close + 1;
+    }
+  }
+  return i;
+}
+
+}  // namespace gnash::core


### PR DESCRIPTION
Closes #202.

Replaces the seven independent, quote-blind subscript scanners with a single shared primitive, so `name[KEY]` is parsed consistently everywhere.

**New module** `core/subscript.{hpp,cpp}`:
- `skip_subscript(s, open)` — returns the matching **unquoted** `]`, mirroring bash's `skip_matched_pair`: a `]` inside `'...'`, `"..."`, after `\`, inside `` `...` ``/`$(...)`/`${...}`, or nested in a further `[` does not close the subscript.
- `split_subscript(word, name, sub, has_sub)` — the common `name[sub]` split.

**Sites routed through it:** the lexer's assignment-word detection, the parser's `is_name_assignment` and `array_literal_bad_token`, the executor's `parse_assign`, `is_assignment_word_text` and compound-literal element parser, and the expander's `${name[sub]}` reader.

**Fixes** (all previously `command not found` / mis-split):
```
a[x\]y]=1        →  key x]y
a["p]q"]=1       →  key p]q
a[$(echo k]v)]=9 →  key k]v
declare -A a=([x\]y]=1 ["m]n"]=2)   and   ${a["p]q"]}  reads
```

**Results:** assoc **254→207**, quotearray **130→127**, array **371→349** (−72). ctest 22/22, run_diff all 221 match; non-subscript `[`/`]` uses (globs `a[bc]`, `[[ ]]`, `[ ]`, `case` patterns) unaffected.

The remaining quotearray/assoc diffs are the *arithmetic-context* subscript (`(( assoc[$key]++ ))`) — an evaluation-semantics problem in the arith evaluator, not a scanner boundary one — left for a follow-up.