### PR TITLE
Implement shopt array_expand_once (subscript injection guard)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -111,6 +111,13 @@ class Shell {
   // the whole array.  A negative index on an indexed array counts from the end.
   void array_unset(const std::string &n, const std::string &sub);
   int array_count(const std::string &n) const;
+  // Under `shopt -s array_expand_once', an already-expanded array subscript is
+  // not re-expanded: for an indexed array it is evaluated strictly here, so a
+  // command substitution left in it (an injection attempt) hits the arithmetic
+  // evaluator and errors.  Returns false (bash's `operand expected' diagnostic
+  // printed) when rejected, else rewrites SUB to the resolved numeric index.  A
+  // `@'/`*' selector and an associative key are left untouched.
+  bool array_expand_once_ok(const std::string &base, std::string &sub);
   // True when NAME holds an indexed or associative array (not a scalar); used
   // by the zsh personality, where a bare `$array' expands to all its elements.
   bool is_array(const std::string &n) const;

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -503,7 +503,11 @@ long long eval_string(Shell &sh, const std::string &str, int depth, bool *ok) {
 // recursively -- like bash, where `a=b+1; b=3; echo $((a))' yields 4.
 long long ref_get(const Node *n, Ctx &ctx) {
   std::string v;
-  if (n->has_sub) v = ctx.sh.array_get(n->name, ctx.sh.zsh_subscript(n->name, n->sub));
+  if (n->has_sub) {
+    std::string sub = n->sub;
+    if (!ctx.sh.array_expand_once_ok(n->name, sub)) { ctx.ok = false; return 0; }
+    v = ctx.sh.array_get(n->name, ctx.sh.zsh_subscript(n->name, sub));
+  }
   else { v = ctx.sh.get(n->name); if (v.empty()) { std::string dv; if (ctx.sh.dynamic_var(n->name, dv)) v = dv; } }
   if (v.empty()) return 0;
   if (ctx.depth > 100) return 0;
@@ -512,9 +516,12 @@ long long ref_get(const Node *n, Ctx &ctx) {
   return o ? r : 0;
 }
 void ref_set(const Node *n, long long val, Ctx &ctx) {
-  if (n->has_sub)
-    ctx.sh.array_set(n->name, ctx.sh.zsh_subscript(n->name, n->sub), std::to_string(val));
-  else if (!ctx.sh.set(n->name, std::to_string(val)))
+  if (!ctx.ok) return;  // a read/subscript error already aborted the expression
+  if (n->has_sub) {
+    std::string sub = n->sub;
+    if (!ctx.sh.array_expand_once_ok(n->name, sub)) { ctx.ok = false; return; }
+    ctx.sh.array_set(n->name, ctx.sh.zsh_subscript(n->name, sub), std::to_string(val));
+  } else if (!ctx.sh.set(n->name, std::to_string(val)))
     ctx.ok = false;  // assignment to a readonly variable: the expansion fails
 }
 

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -293,6 +293,19 @@ bool append_formatted(std::string &out, const std::string &spec, T value) {
   return true;
 }
 
+// Apply Shell::array_expand_once_ok to a full `name[sub]' target (e.g. a `read'
+// variable), rewriting the subscript to its resolved index; false (diagnostic
+// printed) on rejection.
+bool array_expand_once_name(Shell &sh, std::string &name) {
+  size_t lb = name.find('[');
+  if (lb == std::string::npos || name.empty() || name.back() != ']') return true;
+  std::string base = name.substr(0, lb);
+  std::string sub = name.substr(lb + 1, name.size() - lb - 2);
+  if (!sh.array_expand_once_ok(base, sub)) return false;
+  name = base + "[" + sub + "]";
+  return true;
+}
+
 int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
   // Options: -v NAME (assign to a variable), -- (end of options).
   size_t ai = 1;
@@ -382,7 +395,10 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
   if (to_var) {
     auto lb = vname.find('[');
     if (lb != std::string::npos && !vname.empty() && vname.back() == ']') {
-      sh.array_set(vname.substr(0, lb), vname.substr(lb + 1, vname.size() - lb - 2), out);
+      std::string base = vname.substr(0, lb);
+      std::string sub = vname.substr(lb + 1, vname.size() - lb - 2);
+      if (!sh.array_expand_once_ok(base, sub)) return 1;
+      sh.array_set(base, sub, out);
     } else {
       sh.set(vname, out);
     }
@@ -917,6 +933,12 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       std::string sub = argv[i].substr(lb + 1, argv[i].size() - lb - 2);
       std::string bd = sh.deref(base);
       auto bit = sh.vars.find(bd);
+      // Unset of an element only evaluates the subscript when the array exists;
+      // `unset a[SUB]' on a missing `a' is a silent no-op (no injection check).
+      if (bit != sh.vars.end() && !sh.array_expand_once_ok(base, sub)) {
+        ret = 1;
+        continue;
+      }
       if (bit != sh.vars.end() && bit->second.readonly) {
         std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",
                      sh.err_prefix().c_str(), bd.c_str());
@@ -1436,8 +1458,11 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     }
   }
   fields.push_back(rest);
-  for (size_t k = 0; k < names.size(); k++)
-    if (!sh.set(names[k], k < fields.size() ? fields[k] : std::string())) return 2;
+  for (size_t k = 0; k < names.size(); k++) {
+    std::string nm = names[k];
+    if (!array_expand_once_name(sh, nm)) return 1;
+    if (!sh.set(nm, k < fields.size() ? fields[k] : std::string())) return 2;
+  }
   return retval;
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -339,7 +339,11 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
     }
     // zsh array subscripts are 1-based; translate to the internal 0-based index
     // (a no-op under other personalities / for associative arrays).
-    std::string sub = sh.zsh_subscript(a.name, ex.expand_no_split(*a.sub));
+    std::string sub = ex.expand_no_split(*a.sub);
+    // `shopt -s array_expand_once': reject an un-evaluatable (e.g. injected)
+    // subscript rather than silently using index 0.
+    if (!sh.array_expand_once_ok(a.name, sub)) { sh.arith_error = true; return; }
+    sub = sh.zsh_subscript(a.name, sub);
     std::string val = ex.expand_assignment(a.value);
     if (integer) {
       bool ok = true;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1236,7 +1236,9 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   std::string val;
   if (have_sub) {
     // zsh subscripts are 1-based; translate before the (0-based) array read.
-    val = sh.array_get(name, sh.zsh_subscript(name, ex.expand_no_split(sub)));
+    std::string esub = ex.expand_no_split(sub);
+    if (!sh.array_expand_once_ok(name, esub)) { sh.arith_error = true; return std::string(); }
+    val = sh.array_get(name, sh.zsh_subscript(name, esub));
     set = sh.is_set(name);
   } else {
     val = ex.param_value(name, set, defaulting_op);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -716,6 +716,19 @@ void Shell::array_unset(const std::string &n_in, const std::string &sub) {
   }
 }
 
+bool Shell::array_expand_once_ok(const std::string &base, std::string &sub) {
+  auto it = shopt_opts.find("array_expand_once");
+  if (it == shopt_opts.end() || !it->second) return true;
+  if (sub == "@" || sub == "*") return true;
+  auto vit = vars.find(deref(base));
+  if (vit != vars.end() && vit->second.kind == VarKind::Assoc) return true;
+  bool ok = true;
+  long long idx = eval_arith_msg(*this, sub, "", &ok);
+  if (!ok) return false;  // eval_arith_msg has already printed the diagnostic
+  sub = std::to_string(idx);
+  return true;
+}
+
 bool Shell::is_array(const std::string &n_in) const {
   std::string n = deref(n_in);
   auto it = vars.find(n);


### PR DESCRIPTION
Closes #204.

With `shopt -s array_expand_once` bash does not re-expand an array subscript that was already expanded once, so a command substitution left in it reaches the arithmetic evaluator and errors with `operand expected` instead of running — an injection guard exercised throughout array32.sub. gnash ignored the option and silently resolved such a subscript to index 0.

New `Shell::array_expand_once_ok(base, sub&)`: when the option is set and the array isn't associative, it evaluates the subscript strictly (`eval_arith_msg`), printing bash's diagnostic and rejecting a non-arithmetic subscript, else normalizing it to the index. Routed through the element-access paths:
- `printf -v a[sub]`, `read a[sub]`, `unset a[sub]` (only when the array exists — a missing array is a silent no-op)
- plain `a[sub]=v` assignment (executor)
- the arithmetic evaluator's `ref_get`/`ref_set` — `(( ))`, `$(())`, `let` (`ref_set` no-ops once `ctx.ok` is cleared, so `a[$sub]++` reports the error once)
- `${a[sub]}` reads

**array 349 → 328** (−21). ctest 22/22, run_diff all 221 match, no scoreboard regressions (assoc 207, quotearray 127, arith 168, etc. unchanged); normal array/arith access unaffected.

Remaining array32.sub cases (`declare -i a[sub]=`, `test -v a[sub]`, `wait -p a[sub]`) resolve subscripts at their own sites and are a follow-up.