### PR TITLE
batch61: wire remaining array_expand_once sites + implement test -v

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -441,6 +441,7 @@ bool int_cmp(const std::string &op, long a, long b) {
 // Evaluate a `test' argument vector [a..b) (exclusive of trailing ] already
 // removed).  Handles !, -a/-o, unary, binary; a small recursive evaluator.
 struct TestEval {
+  Shell &sh;
   const std::vector<std::string> &a;
   size_t i;
   size_t end;
@@ -448,6 +449,21 @@ struct TestEval {
 
   bool at_end() { return i >= end; }
   const std::string &cur() { return a[i]; }
+
+  // `test -v NAME' / `-v NAME[sub]': true if the variable (or array element) is
+  // set.  Under `shopt -s array_expand_once' an un-evaluatable subscript errors.
+  bool var_is_set(const std::string &arg) {
+    size_t br = arg.find('[');
+    if (br != std::string::npos && !arg.empty() && arg.back() == ']') {
+      std::string nm = arg.substr(0, br);
+      std::string sub = arg.substr(br + 1, arg.size() - br - 2);
+      if (!sh.array_expand_once_ok(nm, sub)) { ok = false; return false; }
+      if (sub == "@" || sub == "*") return sh.array_count(nm) > 0;
+      for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
+      return false;
+    }
+    return sh.is_set(arg);
+  }
 
   bool expr() { return or_expr(); }
   bool or_expr() {
@@ -476,6 +492,7 @@ struct TestEval {
       if (std::strchr("efdrwxsLhpbc", o)) { std::string p = a[i + 1]; i += 2; return file_test(o, p); }
       if (o == 'z') { std::string s = a[i + 1]; i += 2; return s.empty(); }
       if (o == 'n') { std::string s = a[i + 1]; i += 2; return !s.empty(); }
+      if (o == 'v') { std::string arg = a[i + 1]; i += 2; return var_is_set(arg); }
     }
     // binary: a OP b
     if (i + 2 < end + 1 && i + 2 <= end) {
@@ -499,14 +516,14 @@ struct TestEval {
   }
 };
 
-int bi_test(Shell &, const std::vector<std::string> &argv, bool bracket) {
+int bi_test(Shell &sh, const std::vector<std::string> &argv, bool bracket) {
   std::vector<std::string> a(argv.begin() + 1, argv.end());
   if (bracket) {
     if (a.empty() || a.back() != "]") return 2;  // missing ]
     a.pop_back();
   }
   if (a.empty()) return 1;
-  TestEval te{a, 0, a.size(), true};
+  TestEval te{sh, a, 0, a.size(), true};
   bool v = te.expr();
   return v ? 0 : 1;
 }
@@ -4566,6 +4583,7 @@ struct CondEval {
         if (br != std::string::npos && !arg.empty() && arg.back() == ']') {
           std::string nm = arg.substr(0, br);
           std::string sub = arg.substr(br + 1, arg.size() - br - 2);
+          if (!sh.array_expand_once_ok(nm, sub)) return false;  // diagnostic printed
           if (sub == "@" || sub == "*") return sh.array_count(nm) > 0;
           for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
           return false;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -257,6 +257,9 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
                          sh.err_prefix().c_str(), e.c_str());
             break;
           }
+          // `shopt -s array_expand_once': a compound assignment must not perform
+          // a second expansion of the subscript (an injection attempt errors).
+          if (!sh.array_expand_once_ok(name, sub)) break;  // diagnostic printed
           bool ok = true;
           long long k = eval_arith(sh, sub, &ok);
           if (ok && k < 0) k += maxidx + 1;  // resolve negative against running max

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -692,6 +692,7 @@ struct Parser {
 
   CommandPtr parse_arith_command() {
     std::size_t save = i;
+    int arith_line = cur().line;  // $LINENO / error line of the `((' command
     advance();  // (
     advance();  // (
     int depth = 0;
@@ -743,6 +744,7 @@ struct Parser {
     }
     auto n = std::make_unique<ArithCommand>();
     n->expression = trim(expr);
+    n->line = arith_line;
     parse_redirect_list(n->redirects);
     return n;
   }


### PR DESCRIPTION
Closes #206. Follow-up to #204/#205.

Wires the remaining array32.sub subscript sites through `Shell::array_expand_once_ok` and fixes two adjacent gaps:

1. **`test -v`** — the `test`/`[` builtin didn't implement `-v` at all (`test -v X` was always true). Implemented it (true when the scalar / array element / `@`/`*` selector is set) by giving `TestEval` a `Shell` reference, and applied the array_expand_once guard so `test -v a[$sub]` / `[ -v a[$sub] ]` reject an injected subscript. The `[[ -v ]]` conditional gained the same check.
2. **Compound array literal** — `a=([$sub]=hi)` now routes its element subscript through the guard.
3. **Arithmetic command line** — `ArithCommand` now records the `((` line, so its `((: ...` errors report the right line number.

**Results:** array 328→316, **builtins 340→330** (the `test -v` implementation fixed a pre-existing gap used elsewhere), **quotearray 127→119**. ctest 22/22, run_diff all 221 match, no scoreboard regressions.

Remaining array32.sub cases (`wait -n -p a[sub]`, and a `declare -ai` attribute-ordering edge) need `wait` option parsing / declare attribute-vs-assignment ordering and are a separate follow-up.