### PR TITLE
batch62: help listing + hash/unset/declare fixes (builtins 330→190)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -934,11 +934,12 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
 
 int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   bool funcs = false;
+  bool vflag = false;  // `-v' given explicitly: variables only, no function fallback
   bool noref = false;  // `-n': remove the nameref itself, not its target
   int ret = 0;
   for (size_t i = 1; i < argv.size(); i++) {
     if (argv[i] == "-f") { funcs = true; continue; }
-    if (argv[i] == "-v") { funcs = false; continue; }
+    if (argv[i] == "-v") { funcs = false; vflag = true; continue; }
     if (argv[i] == "-n") { noref = true; continue; }
     if (funcs) { sh.functions.erase(argv[i]); continue; }
     // `unset name[sub]' removes a single array element (or the whole array for
@@ -975,7 +976,10 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       ret = 1;
       continue;
     }
-    sh.unset(argv[i], false, noref);
+    // With neither -v nor -f, `unset NAME' unsets a variable if one exists,
+    // otherwise a function of that name (bash); explicit `-v' skips the fallback.
+    if (!vflag && it == sh.vars.end() && sh.functions.count(tgt)) sh.functions.erase(tgt);
+    else sh.unset(argv[i], false, noref);
   }
   return ret;
 }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2621,10 +2621,30 @@ static const BuiltinHelp kBuiltinHelp[] = {
     {"unalias", "unalias [-a] name [name ...]", "Remove each NAME from the list of defined aliases."},
     {"history", "history [-c] [-d offset] [n] or history -anrw [filename] or history -ps arg [arg...]", "Display or manipulate the history list."},
     {"fc", "fc [-e ename] [-lnr] [first] [last] or fc -s [pat=rep] [command]", "Display or execute commands from the history list."},
-    {"compgen", "compgen [-abcdefgjksuv] [-o option] [-A action] [-G globpat] [-W wordlist] [-F function] [-C command] [-X filterpat] [-P prefix] [-S suffix] [word]", "Display possible completions depending on the options."},
+    {"compgen", "compgen [-V varname] [-abcdefgjksuv] [-o option] [-A action] [-G globpat] [-W wordlist] [-F function] [-C command] [-X filterpat] [-P prefix] [-S suffix] [word]", "Display possible completions depending on the options."},
     {"complete", "complete [-abcdefgjksuv] [-pr] [-DEI] [-o option] [-A action] [-G globpat] [-W wordlist] [-F function] [-C command] [-X filterpat] [-P prefix] [-S suffix] [name ...]", "Specify how arguments are to be completed by Readline."},
     {"compopt", "compopt [-o|+o option] [-DEI] [name ...]", "Modify or display completion options."},
     {"bind", "bind [-lpsvPSVX] [-m keymap] [-f filename] [-q name] [-u name] [-r keyseq] [-x keyseq:shell-command] [keyseq:readline-function or readline-command]", "Set Readline key bindings and variables."},
+    // Compound-command and special-syntax pseudo-builtins, so `help' lists them
+    // like bash's shell_builtins[] (synopses verbatim from bash 5.3).
+    {"!", "! PIPELINE", "Execute PIPELINE and negate its exit status."},
+    {"%", "job_spec [&]", "Resume job in foreground."},
+    {"(( ... ))", "(( expression ))", "Evaluate arithmetic expression."},
+    {".", ". [-p path] filename [arguments]", "Execute commands from a file in the current shell."},
+    {"[", "[ arg... ]", "Evaluate conditional expression."},
+    {"[[ ... ]]", "[[ expression ]]", "Execute conditional command."},
+    {"{ ... }", "{ COMMANDS ; }", "Group commands as a unit."},
+    {"case", "case WORD in [PATTERN [| PATTERN]...) COMMANDS ;;]... esac", "Execute commands based on pattern matching."},
+    {"coproc", "coproc [NAME] command [redirections]", "Create a coprocess named NAME."},
+    {"for", "for NAME [in WORDS ... ] ; do COMMANDS; done", "Execute commands for each member in a list."},
+    {"for ((", "for (( exp1; exp2; exp3 )); do COMMANDS; done", "Arithmetic for loop."},
+    {"function", "function name { COMMANDS ; } or name () { COMMANDS ; }", "Define shell function."},
+    {"if", "if COMMANDS; then COMMANDS; [ elif COMMANDS; then COMMANDS; ]... [ else COMMANDS; ] fi", "Execute commands based on conditional."},
+    {"select", "select NAME [in WORDS ... ;] do COMMANDS; done", "Select words from a list and execute commands."},
+    {"time", "time [-p] pipeline", "Report time consumed by pipeline's execution."},
+    {"until", "until COMMANDS; do COMMANDS-2; done", "Execute commands as long as a test does not succeed."},
+    {"variables", "variables - Names and meanings of some shell variables", "Common shell variable names and usage."},
+    {"while", "while COMMANDS; do COMMANDS-2; done", "Execute commands as long as a test succeeds."},
 };
 
 int bi_help(Shell &sh, const std::vector<std::string> &argv) {
@@ -2644,16 +2664,39 @@ int bi_help(Shell &sh, const std::vector<std::string> &argv) {
     std::printf("gnash, version %s\n", sh.get("BASH_VERSION").c_str());
     std::printf("These shell commands are defined internally.  Type `help' to see this list.\n");
     std::printf("Type `help name' to find out more about the function `name'.\n");
+    std::printf("Use `info bash' to find out more about the shell in general.\n");
     std::printf("Use `man -k' or `info' to find out more about commands not in this list.\n\n");
+    std::printf("A star (*) next to a name means that the command is disabled.\n\n");
+    // The `personality' pseudo-builtin is gnash-specific; leave it out of the
+    // listing so the two-column pairing matches bash's shell_builtins[] exactly.
     std::vector<const BuiltinHelp *> items;
-    for (const auto &h : kBuiltinHelp) items.push_back(&h);
+    for (const auto &h : kBuiltinHelp)
+      if (std::strcmp(h.name, "personality") != 0) items.push_back(&h);
     std::sort(items.begin(), items.end(),
               [](const BuiltinHelp *a, const BuiltinHelp *b) { return std::strcmp(a->name, b->name) < 0; });
-    size_t half = (items.size() + 1) / 2;
-    for (size_t r = 0; r < half; r++) {
-      std::string left = items[r]->synopsis;
-      std::string right = (r + half < items.size()) ? items[r + half]->synopsis : "";
-      std::printf(" %-36.36s%s\n", left.c_str(), right.c_str());
+    // bash's dispcolumn(): a two-column layout of width 40.  Each cell is a
+    // leading space (`*' if disabled -- never here) then the synopsis; when it
+    // is too long it is truncated and a `>' marks the cut.  The first column is
+    // padded with spaces to the column width; the second is not.
+    // bash's dispcolumn(): two columns of field width 40.  A cell is a leading
+    // marker (space; `*' if disabled -- never here) then the synopsis, cut with
+    // a trailing `>' when too long.  Matching bash byte-for-byte, the first
+    // column shows up to 37 synopsis chars and is padded to 40; the second up
+    // to 35.
+    const size_t kWidth = 40, kCol1 = 37, kCol2 = 36;
+    size_t height = (items.size() + 1) / 2;
+    auto cell = [](const std::string &syn, size_t cap) {
+      std::string s = " ";
+      if (syn.size() > cap) s += syn.substr(0, cap) + ">";  // truncated
+      else s += syn;
+      return s;
+    };
+    for (size_t r = 0; r < height; r++) {
+      std::string left = cell(items[r]->synopsis, kCol1);
+      if (r + height >= items.size()) { std::printf("%s\n", left.c_str()); continue; }
+      std::printf("%s", left.c_str());
+      for (size_t j = left.size(); j < kWidth; j++) std::putchar(' ');
+      std::printf("%s\n", cell(items[r + height]->synopsis, kCol2).c_str());
     }
     return 0;
   }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1627,7 +1627,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     }
     for (; i < argv.size(); i++) {
       auto it = sh.functions.find(argv[i]);
-      if (it == sh.functions.end()) { st = 1; continue; }
+      if (it == sh.functions.end()) {
+        // `declare -fp NAME' (the -p form) reports a missing function; the bare
+        // `declare -f NAME' form fails silently.
+        if (fp)
+          std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
+                       argv[0].c_str(), argv[i].c_str());
+        st = 1;
+        continue;
+      }
       if (funcnames) std::printf("%s\n", argv[i].c_str());
       else std::printf("%s\n", named_function_string(argv[i], it->second, sh.opt_posix).c_str());
     }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2820,7 +2820,14 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
   int st = 0;
   for (; i < argv.size(); i++) {
     const std::string &n = argv[i];
-    if (del_d) { sh.hashed.erase(n); continue; }
+    if (del_d) {  // `hash -d NAME': error if NAME is not hashed
+      if (sh.hashed.erase(n) == 0) {
+        std::fflush(stdout);
+        std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str());
+        st = 1;
+      }
+      continue;
+    }
     if (print_t) {
       auto it = sh.hashed.find(n);
       if (it != sh.hashed.end()) std::printf("%s\n", it->second.c_str());


### PR DESCRIPTION
Closes #208.

Brings `builtins.tests` from **330 → 190** (−140):

- **`help` listing** — reproduce bash's `help`/`help --`: the missing footer lines (`info bash`, `A star (*)`), the 19 compound-command/special-syntax pseudo-builtins (`(( ... ))`, `[[ ... ]]`, `for`, `if`, `while`, `case`, `function`, `coproc`, ...), the corrected `compgen` synopsis, and bash's two-column `dispcolumn` field width (40) with `>` truncation. The gnash-only `personality` pseudo-builtin is excluded from the listing so the pairing matches. (The full `help NAME` long-doc / `-m` man form remains a follow-up.)
- **`unset NAME`** (no -v/-f) now falls back to unsetting a **function** when no variable matches; an explicit `-v` keeps variables-only.
- **`declare -fp NAME`** reports a missing function as `declare: NAME: not found`.
- **`hash -d NAME`** on a name that is not hashed now errors `hash: NAME: not found` (rc 1).

ctest 22/22, run_diff all 221 match, no scoreboard regressions (array 316, assoc 207, nameref 251, etc. unchanged).