### PR TITLE
batch64: negative array subscripts + ${a[*]}/$* IFS join

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -844,9 +844,19 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
               if (k) for (char c : j) { out += c; mask += '1'; }
               for (char c : items[k]) { out += c; mask += '1'; }
             }
+          } else if (sel == '*') {
+            // Unquoted/assignment ${a[*]}: join with the first IFS char, left
+            // splittable (mask 0) so an unquoted use still word-splits on it and
+            // an assignment RHS keeps it as the join character.
+            std::string is = sh_.ifs();
+            std::string j = is.empty() ? std::string() : std::string(1, is[0]);
+            for (size_t k = 0; k < items.size(); k++) {
+              if (k) for (char c : j) { out += c; mask += '0'; }
+              for (char c : items[k]) { out += c; mask += '0'; }
+            }
           } else {
-            // Unquoted ${a[@]} / ${a[*]}: an empty element produces no word (it
-            // splits away), so skip it rather than emitting an empty field.
+            // Unquoted ${a[@]}: an empty element produces no word (it splits
+            // away), so skip it rather than emitting an empty field.
             bool first = true;
             for (size_t k = 0; k < items.size(); k++) {
               if (items[k].empty()) continue;
@@ -1015,7 +1025,14 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
         if (k) for (char c : joiner) { out += c; mask += '1'; }
         for (char c : pos[k]) { out += c; mask += '1'; }
       }
-    } else {  // unquoted $@ or $*
+    } else if (n1 == '*') {  // unquoted/assignment $*: join with IFS[0] (splittable)
+      std::string sep = sh_.ifs();
+      std::string joiner = sep.empty() ? std::string() : std::string(1, sep[0]);
+      for (size_t k = 0; k < pos.size(); k++) {
+        if (k) for (char c : joiner) { out += c; mask += '0'; }
+        for (char c : pos[k]) { out += c; mask += '0'; }
+      }
+    } else {  // unquoted $@
       for (size_t k = 0; k < pos.size(); k++) {
         if (k) { out += FIELD_SEP; mask += MMARK; }
         for (char c : pos[k]) { out += c; mask += '0'; }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -621,7 +621,12 @@ std::string Shell::array_get(const std::string &n_in, const std::string &sub) co
   bool ok = true;
   long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
   if (!ok) k = 0;
-  if (v.kind == VarKind::Indexed) return v.idx.count(k) ? v.idx.at(k) : std::string();
+  if (v.kind == VarKind::Indexed) {
+    // A negative index counts back from the highest set index (bash); under zsh
+    // the subscript was already translated (and -1 means "no such element").
+    if (k < 0 && !is_zsh() && !v.idx.empty()) k += v.idx.rbegin()->first + 1;
+    return v.idx.count(k) ? v.idx.at(k) : std::string();
+  }
   return (k == 0) ? v.value : std::string();
 }
 
@@ -676,6 +681,17 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   bool ok = true;
   long long k = eval_arith(*this, sub, &ok);
   if (!ok) k = 0;
+  // A negative index counts back from the highest set index; one that resolves
+  // below zero is a bad subscript (bash errors and leaves the array unchanged).
+  // Under zsh the subscript was already translated by zsh_subscript.
+  if (k < 0 && !is_zsh()) {
+    if (!v.idx.empty()) k += v.idx.rbegin()->first + 1;
+    if (k < 0) {
+      std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", err_prefix().c_str(),
+                   n.c_str(), sub.c_str());
+      return;
+    }
+  }
   v.idx[k] = val;
   if (k == 0) v.value = val;
 }


### PR DESCRIPTION
Closes #212. Two array/expansion fixes:

1. **Negative array subscripts** — `${x[-1]}` (last element) and `x[-2]=v` (assign to it) now count back from the highest set index in `array_get`/`array_set`; an index resolving below zero is a bad subscript. gnash previously treated the negative number as a literal key. (The zsh personality, whose subscripts `zsh_subscript` already translates, is unaffected — this was caught by a run_diff_zsh failure and gated on `!is_zsh()`.)

2. **`${a[*]}` / `$*` IFS join** — the unquoted and assignment-RHS forms now join with the first IFS character (like the quoted form), left splittable, instead of a field separator that became a space. So `IFS=+; A=${a[*]}` gives `aa+bb`.

**Results:** array **288 → 262**, and the join fix also improved **exp 60 → 46** and **posixexp 65 → 60**. ctest 22/22, run_diff all 221 match, no scoreboard regressions.