### PR TITLE
batch66: arith-for empty sections + error handling

### DIFF
--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -135,12 +135,14 @@ void LoopCommand::print(std::string &out) const {
 void ForCommand::print(std::string &out) const {
   invert_prefix(this, out);
   if (is_arith) {
+    // bash stores an empty arith-for section as the constant `1', so its
+    // reconstructed form (declare -f, xtrace) shows `for ((1; 1; 1))'.
     out += "for ((";
-    out += a_init;
+    out += a_init.empty() ? "1" : a_init;
     out += "; ";
-    out += a_cond;
+    out += a_cond.empty() ? "1" : a_cond;
     out += "; ";
-    out += a_update;
+    out += a_update.empty() ? "1" : a_update;
     out += "))";
   } else {
     out += is_select ? "select " : "for ";
@@ -408,12 +410,13 @@ struct MPrinter {
     }
     if (const auto *fc = dynamic_cast<const ForCommand *>(c)) {
       if (fc->is_arith) {
+        // An empty section is stored/printed as `1' (bash make_arith_for_expr).
         out += "for ((";
-        out += fc->a_init;
+        out += fc->a_init.empty() ? "1" : fc->a_init;
         out += "; ";
-        out += fc->a_cond;
+        out += fc->a_cond.empty() ? "1" : fc->a_cond;
         out += "; ";
-        out += fc->a_update;
+        out += fc->a_update.empty() ? "1" : fc->a_update;
         out += "))";
       } else {
         out += fc->is_select ? "select " : "for ";

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1379,9 +1379,17 @@ int Executor::run_for(const ForCommand *c) {
       if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", e.c_str());
       return static_cast<long long>(eval_arith(sh_, aex.expand_no_split(e), &ok));
     };
+    // An arithmetic error (bad lvalue, division by zero, ...) in any of the
+    // three sections aborts the loop with failure status, as bash does; without
+    // this a broken step expression like `7++' would spin forever.
     aeval(c->a_init);
+    if (!ok) return 1;
     for (;;) {
-      if (!c->a_cond.empty() && aeval(c->a_cond) == 0) break;
+      if (!c->a_cond.empty()) {
+        long long cv = aeval(c->a_cond);
+        if (!ok) { st = 1; break; }
+        if (cv == 0) break;
+      }
       st = run(c->body.get());
       if (sh_.break_count) { sh_.break_count--; break; }
       // `continue N' with N>1 propagates to the enclosing loop; N==1 runs the
@@ -1389,6 +1397,7 @@ int Executor::run_for(const ForCommand *c) {
       if (sh_.continue_count) { if (--sh_.continue_count) break; }
       if (unwinding()) break;
       aeval(c->a_update);
+      if (!ok) { st = 1; break; }
     }
     return st;
   }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -667,6 +667,15 @@ struct Parser {
         advance();
         continue;
       }
+      // `;;' lexes as a single token, but between the arith-for parentheses
+      // two adjacent semicolons just delimit an empty middle section
+      // (`for (( ;; ))', `for (( i=0;;i++ ))'), so split into two parts.
+      if (is(Tok::SemiSemi) && depth == 0) {
+        parts.emplace_back();
+        parts.emplace_back();
+        advance();
+        continue;
+      }
       if (!parts.back().empty() && cur().preceded_by_blank) parts.back() += ' ';
       parts.back() += tok_to_text(cur());
       advance();


### PR DESCRIPTION
Fixes arithmetic `for'' loops with empty expression sections.

- **Parser:** `for (( ;; ))` / `for (( i=0;;i++ ))` now parse — a `;;` (`SemiSemi`) token between the parens is treated as two section separators (empty middle).
- **Executor:** an arithmetic error in any section (bad step `7++`, division by zero) now aborts the loop with failure status instead of spinning forever.
- **Display:** `declare -f` / xtrace print an empty section as `1` (`for ((1; 1; 1))`), matching bash's `make_arith_for_expr`.

**Results:** arith-for 113→12 (and eliminates an infinite loop). ctest 22/22, run_diff all 221 match, no regressions. Remaining 12 diffs are deferred follow-ups: raw trailing-space preservation in display, the `((:`-prefixed arith-error format, and command-substitution-in-arith-section edge cases.

Closes #216