### PR TITLE
batch67: report arithmetic errors from the (( )) command and arith-for

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -327,7 +327,10 @@ struct Parser {
     auto n = mk(k);
     if (read_ref(*n)) return n;
     // `++'/`--' before a non-lvalue (e.g. ++7): bash evaluates the operand and
-    // applies no increment, without error.
+    // applies no increment, without error.  A wholly dangling `++'/`--' (no
+    // operand at all) is an "operand expected" error whose token bash reports
+    // as the second sign, since it rereads the pair as two unary operators.
+    last_tok = save - 1;
     pos = save;
     return unary();
   }

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -171,8 +171,12 @@ void CondCommand::print(std::string &out) const {
 
 void ArithCommand::print(std::string &out) const {
   invert_prefix(this, out);
+  // `expression' keeps a trailing blank (so an arithmetic error reproduces
+  // bash's raw text); the reconstructed single-line form trims it back off.
+  std::string e = expression;
+  while (!e.empty() && std::isspace(static_cast<unsigned char>(e.back()))) e.pop_back();
   out += "(( ";
-  out += expression;
+  out += e;
   out += " ))";
   print_redirects(redirects, out);
 }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1377,7 +1377,9 @@ int Executor::run_for(const ForCommand *c) {
         if (tst != 0 && ed != sh_.shopt_opts.end() && ed->second) return 0LL;
       }
       if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", e.c_str());
-      return static_cast<long long>(eval_arith(sh_, aex.expand_no_split(e), &ok));
+      // Report an arithmetic error with bash's `((: EXPR: ...' diagnostic (the
+      // loop-abort above then stops the loop), rather than failing silently.
+      return static_cast<long long>(eval_arith_msg(sh_, aex.expand_no_split(e), "((", &ok));
     };
     // An arithmetic error (bad lvalue, division by zero, ...) in any of the
     // three sections aborts the loop with failure status, as bash does; without
@@ -1522,7 +1524,9 @@ int Executor::run_arith(const ArithCommand *c) {
   if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", c->expression.c_str());
   bool ok = true;
   Expander ex(sh_);  // expand ${#arr[@]} etc. before arithmetic evaluation
-  long long v = eval_arith(sh_, ex.expand_no_split(c->expression), &ok);
+  // The `(( ))' command reports an arithmetic error (bad token, division by
+  // zero) with bash's `((: EXPR: ...' diagnostic, unlike bare $(( )).
+  long long v = eval_arith_msg(sh_, ex.expand_no_split(c->expression), "((", &ok);
   if (!ok) return 1;
   return v != 0 ? 0 : 1;
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -643,6 +643,9 @@ struct Parser {
     while (!is(Tok::Eof) && !err) {
       if (is(Tok::Rparen) && depth == 0) {
         if (peek(1).type == Tok::Rparen) {
+          // Keep a blank before `))' so the reconstructed step and any error
+          // diagnostic match bash's raw text (`for ((...; i++ ))').
+          if (!parts.back().empty() && cur().preceded_by_blank) parts.back() += ' ';
           advance();
           advance();
           break;
@@ -694,9 +697,11 @@ struct Parser {
            "\n`" + raw + "'");
       return;
     }
-    n.a_init = trim(parts[0]);
-    n.a_cond = trim(parts[1]);
-    n.a_update = trim(parts[2]);
+    // Keep any trailing blank on the step (from the blank before `))') so its
+    // display and error text match bash; no section ever gets a leading blank.
+    n.a_init = parts[0];
+    n.a_cond = parts[1];
+    n.a_update = parts[2];
   }
 
   CommandPtr parse_arith_command() {
@@ -719,6 +724,10 @@ struct Parser {
       }
       if (is(Tok::Rparen) && depth == 0) {
         if (peek(1).type == Tok::Rparen) {
+          // Keep a blank before `))' so an arithmetic error diagnostic
+          // reproduces bash's raw expression (`((: 7++ : ...', token `"+ "');
+          // the single-line printer trims it back off for display.
+          if (!expr.empty() && cur().preceded_by_blank) expr += ' ';
           advance();
           advance();
           break;
@@ -752,7 +761,9 @@ struct Parser {
       return parse_subshell();
     }
     auto n = std::make_unique<ArithCommand>();
-    n->expression = trim(expr);
+    // Keep the trailing blank (the reconstruction never yields a leading one)
+    // so an error diagnostic matches bash's raw expression text.
+    n->expression = expr;
     n->line = arith_line;
     parse_redirect_list(n->redirects);
     return n;


### PR DESCRIPTION
The `(( ))` command and the arith-for sections evaluated silently; bash reports arithmetic errors with `((: EXPR: MESSAGE (error token is "...")`.

- **Executor:** `(( ))` and each arith-for section now report via `eval_arith_msg` with the `((` command name.
- **Parser/ast:** preserve the raw trailing blank before `))` so the diagnostic reproduces bash's expression text (`((: 7++ : ...`, token `"+ "`); the single-line printer trims it back for display.
- **arith:** a dangling `++`/`--` now reports the second sign as the error token (`+ `), matching bash.

**Results:** arith 168→164, arith-for 12→5, set-x 46→34 (arith xtrace bonus). ctest 22/22, run_diff all 221 match, no regressions.

Closes #218