### PR TITLE
batch68: set readonly integer $UID and $EUID

### DIFF
--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -47,6 +47,13 @@ Shell::Shell() {
   set("OPTIND", "1");  // bash initializes getopts state at startup
   set("PPID", std::to_string(static_cast<long>(getppid())));
   set("$", std::to_string(static_cast<long>(getpid())));
+  // bash exposes the real/effective user id as readonly integer variables.
+  for (const auto &uv : {std::make_pair("UID", getuid()), std::make_pair("EUID", geteuid())}) {
+    set(uv.first, std::to_string(static_cast<long>(uv.second)));
+    Variable &v = vars[uv.first];
+    v.integer = true;
+    v.readonly = true;
+  }
   seconds_base = static_cast<long long>(std::time(nullptr));  // $SECONDS origin
 
   // Establish a valid logical $PWD.  Keep the inherited (possibly symlinked)


### PR DESCRIPTION
gnash didn't define `$UID`/`$EUID`; bash exposes both as readonly integers (`declare -ir UID="501"`). Seeds them from getuid()/geteuid() at startup.

Also removes a spurious `(( == 0 ))` arithmetic error in test.tests (an unset $UID, surfaced once batch67 made the `(( ))` command report errors).

ctest 22/22, run_diff all 221 match, no regressions.

Closes #220