### PR TITLE
batch69: fix ${ cmd; } funsub — nested braces, local scope, return, valsub

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -408,7 +408,11 @@ class Shell {
   std::string run_and_capture(const std::string &script, int *status);
   // Function substitution ${ cmd; }: like run_and_capture but in the current
   // shell (no subshell), so side effects such as variable changes persist.
-  std::string run_and_capture_inproc(const std::string &script, int *status);
+  // The body runs in a fresh local scope (so `local' works) and is a return
+  // boundary.  With VALSUB (${| cmd; }) stdout is NOT captured -- it goes to
+  // the shell's real stdout -- and the result is the body's $REPLY.
+  std::string run_and_capture_inproc(const std::string &script, int *status,
+                                     bool valsub = false);
 };
 
 // Arithmetic evaluation (arith.cpp): evaluate EXPR in the context of SH.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -660,9 +660,10 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     size_t end = scan_balanced(t, i + 1, '{', '}');
     if (end != std::string::npos) {
       std::string inner = t.substr(i + 2, end - (i + 2));
-      if (!inner.empty() && inner[0] == '|') inner[0] = ' ';  // ${| cmd; } valsub
+      bool valsub = !inner.empty() && inner[0] == '|';  // ${| cmd; } -> $REPLY
+      if (valsub) inner[0] = ' ';
       int st = 0;
-      std::string res = sh_.run_and_capture_inproc(inner, &st);
+      std::string res = sh_.run_and_capture_inproc(inner, &st, valsub);
       sh_.last_status = st;
       sh_.note_cmdsub(st);
       char cm = dq ? '1' : '4';  // command output: zsh-splittable (see $(...) above)

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -173,11 +173,17 @@ struct Lexer {
     // literal character.  This mirrors bash's parse_matched_pair called with
     // P_FIRSTCLOSE for ${...}: it counts `{` only when the previous char was
     // an unquoted `$` (LEX_WASDOL).  `wasdol` tracks that.
+    //
+    // Exception: a funsub `${ cmd; }' (whitespace or `|' right after the brace)
+    // holds a command list, so bare `{' (group commands, function bodies)
+    // balance normally -- otherwise a function body's `}' closes the scan early.
     bool wasdol = false;
+    bool funsub = pos + 1 < n &&
+                  (std::isspace(static_cast<unsigned char>(in[pos + 1])) || in[pos + 1] == '|');
     do {
       char c = in[pos];
       if (c == '{') {
-        if (depth == 0 || wasdol) depth++;  // opening ${ or nested ${
+        if (depth == 0 || wasdol || funsub) depth++;  // opening ${, nested ${, or funsub group
         w += c;
         pos++;
         wasdol = false;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1687,17 +1687,36 @@ int Shell::run_string(const std::string &script) {
   return st;
 }
 
-std::string Shell::run_and_capture_inproc(const std::string &script, int *status) {
+std::string Shell::run_and_capture_inproc(const std::string &script, int *status,
+                                          bool valsub) {
+  // ${| cmd; } valsub captures the body's $REPLY rather than its stdout, which
+  // is left connected to the shell's real stdout.
   std::fflush(stdout);
-  int saved = dup(STDOUT_FILENO);
-  FILE *tf = std::tmpfile();
-  if (!tf) { if (status) *status = 1; return std::string(); }
-  int tfd = fileno(tf);
-  dup2(tfd, STDOUT_FILENO);
+  int saved = -1;
+  FILE *tf = nullptr;
+  if (!valsub) {
+    saved = dup(STDOUT_FILENO);
+    tf = std::tmpfile();
+    if (!tf) { if (status) *status = 1; return std::string(); }
+    dup2(fileno(tf), STDOUT_FILENO);
+  }
   int saved_base = lineno_base;  // run at the enclosing command's line
   lineno_base = cur_lineno - 1;
+  // A funsub runs in a fresh local scope (so a `local' inside it does not leak)
+  // and is a return boundary like a function body: `return' ends the funsub
+  // (its status becomes the funsub's) rather than unwinding the caller.
+  bool saved_returning = returning;
+  returning = false;
+  push_scope();
   int st = run_string(script);
+  pop_scope();
+  if (returning) { st = exit_status; returning = false; }
+  returning = saved_returning;
   lineno_base = saved_base;
+  if (valsub) {
+    if (status) *status = st;
+    return get("REPLY");
+  }
   std::fflush(stdout);
   dup2(saved, STDOUT_FILENO);
   close(saved);


### PR DESCRIPTION
Fixes three defects in the bash 5.3 `${ cmd; }` function substitution.

- **lexer:** balance nested braces so `${ f() { ...; }; }` (function/group bodies inside a funsub) parses.
- **shell:** run the funsub body in a fresh local scope as a return boundary — `return` ends the funsub instead of unwinding the whole script, and `local` no longer leaks.
- **valsub:** `${| cmd; }` now leaves stdout on the real stdout and yields the body's $REPLY.

**Results:** comsub2 191→41. ctest 22/22, run_diff all 221 match, no regressions.

Closes #222