### PR TITLE
batch70: nested $() inside ${} + quoted-heredoc backslash-newline

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -61,6 +61,7 @@ struct Token {
   bool heredoc_eof = false;
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
+  bool heredoc_eof_quoted = false;  // the open here-doc's delimiter was quoted
   // For a here-document delimiter word, the collected body and whether the
   // delimiter was quoted (which disables expansion of the body).
   std::string heredoc_body;

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -30,6 +30,7 @@ struct ParseResult {
   bool heredoc_eof = false;
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
+  bool heredoc_eof_quoted = false;
 };
 
 // Parse a complete program.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -70,6 +70,16 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
       wasdol = false;
       continue;
     }
+    // A nested `$( ... )' / `$(( ... ))' is skipped by paren balancing so its
+    // inner `{'/`}' (e.g. brace expansion `$(echo a{b,c})') do not disturb this
+    // scan's `{' depth -- unless we are ourselves scanning a `(...)' group.
+    if (c == '$' && open != '(' && i + 1 < t.size() && t[i + 1] == '(') {
+      size_t inner = scan_balanced(t, i + 1, '(', ')');
+      if (inner == std::string::npos) return std::string::npos;
+      i = inner;  // now at the matching `)'
+      wasdol = false;
+      continue;
+    }
     if (c == open) {
       if (!firstclose || open != '{' || depth == 0 || wasdol) depth++;
     } else if (c == close) { if (--depth == 0) return i; }

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -195,6 +195,14 @@ struct Lexer {
       } else if (c == '$' && pos + 1 < n && in[pos + 1] == '\'') {
         scan_dollar_single(w);  // $'...' inside ${...}: backslash-aware
         wasdol = false;
+      } else if (c == '$' && pos + 1 < n && in[pos + 1] == '(') {
+        // A nested command/arith substitution `$( ... )' / `$(( ... ))' is
+        // scanned by paren balancing so any `{'/`}' inside it are consumed as
+        // its content rather than counted against this ${...}'s brace depth.
+        w += c;
+        pos++;  // the `$'
+        scan_paren(w);
+        wasdol = false;
       } else if (c == '\'') {
         scan_single(w);
         wasdol = false;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -64,6 +64,7 @@ struct Lexer {
   bool heredoc_eof = false;        // here-doc body delimited by end of input
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
+  bool heredoc_eof_quoted = false;  // that here-doc's delimiter was quoted
   std::size_t line_scanned = 0;  // bytes already counted for line numbering
   int cur_line = 1;              // 1-based line at line_scanned
 
@@ -509,6 +510,7 @@ struct Lexer {
         heredoc_eof = true;
         heredoc_eof_delim = pd.delim;
         heredoc_eof_line = out[pd.index].line;
+        heredoc_eof_quoted = pd.quoted;
       }
       out[pd.index].heredoc_body = body;
       out[pd.index].has_heredoc = true;
@@ -581,6 +583,7 @@ struct Lexer {
     eof.heredoc_eof = heredoc_eof;
     eof.heredoc_eof_delim = heredoc_eof_delim;
     eof.heredoc_eof_line = heredoc_eof_line;
+    eof.heredoc_eof_quoted = heredoc_eof_quoted;
     out.push_back(eof);
   }
 };

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1035,6 +1035,7 @@ struct Parser {
       res.heredoc_eof = true;
       res.heredoc_eof_delim = toks.back().heredoc_eof_delim;
       res.heredoc_eof_line = toks.back().heredoc_eof_line;
+      res.heredoc_eof_quoted = toks.back().heredoc_eof_quoted;
     }
     return res;
   }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1503,6 +1503,7 @@ int Shell::run_script_lines(const std::string &text) {
   bool cont_bslash = false;  // previous line ended in a line continuation
   bool first_line_saved = false;  // this command's first line is in the history
   bool in_heredoc = false;   // the pending command has an open here-document
+  bool in_heredoc_quoted = false;  // ...and its delimiter was quoted
   int st = last_status;
 
   auto flush = [&]() {
@@ -1591,7 +1592,12 @@ int Shell::run_script_lines(const std::string &text) {
     // line (handled below by the incomplete-parse path).
     size_t nbs = 0;
     while (nbs < pending.size() && pending[pending.size() - 1 - nbs] == '\\') nbs++;
-    if (nbs % 2 == 1 && !squote_backslash_literal(pending)) {
+    // A trailing backslash inside a QUOTED here-document is a literal body
+    // character, not a line continuation.  In an unquoted here-document bash
+    // still splices `\<newline>' (before even checking for the delimiter), so
+    // only suppress the continuation for a quoted delimiter.
+    if (nbs % 2 == 1 && !squote_backslash_literal(pending) &&
+        !(in_heredoc && in_heredoc_quoted)) {
       pending.pop_back();
       cont_bslash = true;
       continue;
@@ -1602,6 +1608,7 @@ int Shell::run_script_lines(const std::string &text) {
       ParseResult chk = parse(pending);
       bool was_heredoc = in_heredoc;
       in_heredoc = chk.heredoc_eof;
+      in_heredoc_quoted = chk.heredoc_eof_quoted;
       if (was_heredoc && !in_heredoc && first_line_saved)
         append_history_line("", true);  // the closing delimiter's newline
       if (chk.incomplete) continue;


### PR DESCRIPTION
Two parsing fixes.

- **Nested `$( )` in `${ }`:** `${foo:-$(echo a{b,c})}` mis-scanned because the inner `{`/`}` were counted against the ${...} brace depth. The lexer and the expansion scanner now skip a nested `$( )` by paren balancing.
- **Quoted here-doc:** a backslash-newline in `<<'EOF'` is now literal (was spliced as a continuation); unquoted here-docs still splice it before the delimiter check.

**Results:** comsub 115→113, heredoc 109→106. ctest 22/22, run_diff all 221 match, no regressions.

Closes #224