### PR TITLE
Batch 72: break/continue/return context checks, kill validation, in-scope traps (errors 170→128, trap 20→17)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -390,6 +390,14 @@ class Shell {
   // --- control-flow signals (set by builtins, honored by the executor) ---
   int break_count = 0;
   int continue_count = 0;
+  // Current loop nesting depth (bash's loop_level).  The executor bumps this
+  // around each for/while/until body; `break'/`continue' consult it to reject a
+  // use outside any loop.  Reset to 0 across function-call and subshell
+  // boundaries so a `break' in a function doesn't break the caller's loop.
+  int loop_depth = 0;
+  // Depth of active `source'/`.' invocations.  `return' is legal in a function
+  // OR a sourced script; outside both it is an error (bash).
+  int source_depth = 0;
   bool returning = false;
   bool exiting = false;
   int exit_status = 0;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4204,15 +4204,59 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
     st = sh.exit_status;
   } else if (cmd == "return") {
-    sh.returning = true;
-    sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
-    st = sh.exit_status;
-  } else if (cmd == "break") {
-    sh.break_count = argv.size() > 1 ? std::atoi(argv[1].c_str()) : 1;
-    st = 0;
-  } else if (cmd == "continue") {
-    sh.continue_count = argv.size() > 1 ? std::atoi(argv[1].c_str()) : 1;
-    st = 0;
+    // `return' is only meaningful in a function or a sourced script; elsewhere
+    // it is an error and must not unwind the current input (bash).
+    if (!sh.in_function() && sh.source_depth == 0) {
+      std::fprintf(stderr, "%sreturn: can only `return' from a function or sourced script\n",
+                   sh.err_prefix().c_str());
+      st = 1;
+    } else {
+      sh.returning = true;
+      sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
+      st = sh.exit_status;
+    }
+  } else if (cmd == "break" || cmd == "continue") {
+    // Outside any loop bash prints a diagnostic (suppressed under `set -o
+    // posix') and succeeds without unwinding, rather than silently swallowing
+    // the rest of the input.  Mirrors builtins/break.def check_loop_level().
+    if (sh.loop_depth == 0) {
+      if (!sh.opt_posix)
+        std::fprintf(stderr, "%s%s: only meaningful in a `for', `while', or `until' loop\n",
+                     sh.err_prefix().c_str(), cmd.c_str());
+      st = 0;
+    } else {
+      int n = 1;
+      // Skip a leading `--' end-of-options marker (`break -- 5').
+      size_t ci = 1;
+      if (ci < argv.size() && argv[ci] == "--") ci++;
+      const std::string a = ci < argv.size() ? argv[ci] : std::string();
+      char *end = nullptr;
+      long v = a.empty() ? 1 : std::strtol(a.c_str(), &end, 10);
+      if (!a.empty() && (end == a.c_str() || *end != '\0')) {
+        // A non-numeric count: bash aborts the command (get_numeric_arg); we
+        // report and terminate every enclosing loop, the closest observable
+        // approximation without the top-level throw.
+        std::fprintf(stderr, "%s%s: %s: numeric argument required\n",
+                     sh.err_prefix().c_str(), cmd.c_str(), a.c_str());
+        sh.break_count = sh.loop_depth;
+        st = 1;
+      } else if (v <= 0) {
+        // A non-positive count breaks out of every enclosing loop (bash sets
+        // `breaking = loop_level' for both break and continue), status 1.
+        std::fprintf(stderr, "%s%s: %s: loop count out of range\n",
+                     sh.err_prefix().c_str(), cmd.c_str(), a.c_str());
+        sh.break_count = sh.loop_depth;
+        st = 1;
+      } else {
+        // Requesting more levels than are active caps at the outermost loop, so
+        // the remaining count never unwinds past the loop nest.
+        n = static_cast<int>(v);
+        if (n > sh.loop_depth) n = sh.loop_depth;
+        if (cmd == "break") sh.break_count = n;
+        else sh.continue_count = n;
+        st = 0;
+      }
+    }
   } else if (cmd == "eval") {
     std::string saved_ctx = sh.error_context;
     sh.error_context = "eval";  // parse errors report `NAME: eval: line N: ...'
@@ -4299,7 +4343,9 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // DEBUG trap, and functions it defines all use the file's own lines).
         int saved_src_base = sh.lineno_base;
         sh.lineno_base = 0;
+        sh.source_depth++;  // `return' is legal while sourcing
         st = sh.run_string(ss.str());
+        sh.source_depth--;
         sh.lineno_base = saved_src_base;
         // `return' inside a sourced file ends the file (and sets its status),
         // like reaching EOF -- it must not unwind past `source' or exit the

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2531,6 +2531,28 @@ int signame_to_num(const std::string &s) {
 }
 
 int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
+  static const char *kUsage =
+      "kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... "
+      "or kill -l [sigspec]\n";
+  // Resolve a signal spec (a name like INT/SIGINT, or a number) to its number,
+  // or -1 if it names no known signal.  signame_to_num() falls back to SIGTERM
+  // for garbage, so a name is confirmed by round-tripping it back to canonical.
+  auto resolve_sig = [](const std::string &spec) -> int {
+    if (spec.empty()) return -1;
+    if (std::isdigit(static_cast<unsigned char>(spec[0]))) {
+      char *end = nullptr;
+      long n = std::strtol(spec.c_str(), &end, 10);
+      if (*end != '\0') return -1;
+      return trapname_from_num(static_cast<int>(n)) ? static_cast<int>(n) : -1;
+    }
+    std::string n = spec;
+    if (n.rfind("SIG", 0) == 0) n = n.substr(3);
+    for (char &c : n) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    int num = signame_to_num(spec);
+    const char *canon = trapname_from_num(num);
+    return (canon && n == canon) ? num : -1;  // reject the SIGTERM fallback
+  };
+
   // `kill -l [sigspec ...]' / `kill -L ...': list signal names and numbers.
   if (argv.size() > 1 && (argv[1] == "-l" || argv[1] == "-L")) {
     if (argv.size() == 2) { print_signal_list(); return 0; }  // list them all
@@ -2546,30 +2568,85 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
                        sh.err_prefix().c_str(), a.c_str());
           st = 1;
         }
+      } else if (int n = resolve_sig(a); n > 0) {
+        std::printf("%d\n", n);  // name -> number
       } else {
-        std::printf("%d\n", signame_to_num(a));  // name -> number
+        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
+                     sh.err_prefix().c_str(), a.c_str());
+        st = 1;
       }
     }
     return st;
   }
+
+  // Determine the signal from the options, and where the pid/jobspec list starts.
   int sig = SIGTERM;
   size_t i = 1;
-  if (argv.size() > 1 && argv[1].size() > 1 && argv[1][0] == '-') {
-    sig = signame_to_num(argv[1].substr(1));
+  if (argv.size() > 1 && argv[1].size() > 1 && argv[1][0] == '-' && argv[1] != "--") {
+    std::string opt = argv[1];
+    if (opt == "-s" || opt == "-n") {
+      // The signal is the next word: `-s TERM' / `-n 15'.
+      if (argv.size() < 3) {
+        std::fprintf(stderr, "%skill: %s: option requires an argument\n",
+                     sh.err_prefix().c_str(), opt.c_str());
+        return 1;
+      }
+      sig = resolve_sig(argv[2]);
+      if (sig < 0) {
+        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
+                     sh.err_prefix().c_str(), argv[2].c_str());
+        return 1;
+      }
+      i = 3;
+    } else {
+      // `-INT' / `-9' / `-SIGHUP': the spec is the option itself.
+      sig = resolve_sig(opt.substr(1));
+      if (sig < 0) {
+        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
+                     sh.err_prefix().c_str(), opt.substr(1).c_str());
+        return 1;
+      }
+      i = 2;
+    }
+  } else if (argv.size() > 1 && argv[1] == "--") {
     i = 2;
   }
+  // With no pid/jobspec operand, bash prints usage and fails with status 2.
+  if (i >= argv.size()) { std::fputs(kUsage, stderr); return 2; }
+
   int st = 0;
   for (; i < argv.size(); i++) {
     const std::string &t = argv[i];
     pid_t target;
     if (!t.empty() && t[0] == '%') {
       Shell::Job *j = sh.job_by_spec(t);
-      if (!j) { std::fprintf(stderr, "gnash: kill: %s: no such job\n", t.c_str()); st = 1; continue; }
+      if (!j) {
+        std::fprintf(stderr, "%skill: %s: no such job\n", sh.err_prefix().c_str(), t.c_str());
+        st = 1;
+        continue;
+      }
       target = static_cast<pid_t>(-j->pgid);
     } else {
+      // A pid must be a (possibly signed) decimal integer; anything else (an
+      // empty word, `@12', `abc') is rejected WITHOUT signaling -- crucially,
+      // atol("") is 0, and kill(0, sig) would signal the whole process group.
+      size_t p = (t[0] == '+' || t[0] == '-') ? 1 : 0;
+      bool numeric = p < t.size();
+      for (; p < t.size(); p++)
+        if (!std::isdigit(static_cast<unsigned char>(t[p]))) numeric = false;
+      if (!numeric) {
+        std::fprintf(stderr, "%skill: `%s': not a pid or valid job spec\n",
+                     sh.err_prefix().c_str(), t.c_str());
+        st = 1;
+        continue;
+      }
       target = static_cast<pid_t>(std::atol(t.c_str()));
     }
-    if (kill(target, sig) != 0) { std::fprintf(stderr, "gnash: kill: %s\n", std::strerror(errno)); st = 1; }
+    if (kill(target, sig) != 0) {
+      std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(),
+                   static_cast<long>(target), std::strerror(errno));
+      st = 1;
+    }
   }
   return st;
 }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1070,6 +1070,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     bool had_return = rtit != sh_.traps.end();
     std::string return_before = had_return ? rtit->second : std::string();
     status = unwinding() ? sh_.last_status : run(fit->second);
+    // Deliver a signal caught during the body while the function scope is still
+    // active, so its trap runs in-context (bash): a `return' in the trap then
+    // returns from THIS function rather than erroring at the outer level.
+    if (!unwinding()) sh_.run_pending_traps();
     // The RETURN trap fires when the function returns, in its own scope, with $?
     // set to the return status.  It runs when inherited (functrace) or installed
     // inside the function.  A function invoked while the DEBUG trap is running

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1051,6 +1051,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     int saved_lineno_base = sh_.lineno_base;
     auto lbit = sh_.func_lineno_base.find(argv[0]);
     if (lbit != sh_.func_lineno_base.end()) sh_.lineno_base = lbit->second;
+    // A `break'/`continue' in the function body refers to a loop in that body,
+    // not the caller's -- bash saves and zeroes loop_level across the call.
+    int saved_loop_depth = sh_.loop_depth;
+    sh_.loop_depth = 0;
     // Under functrace, bash fires the DEBUG trap once for the function body as a
     // whole on entry, before the per-command traps inside it.
     if (sh_.opt_functrace && sh_.traps.count("DEBUG") && !sh_.in_debug_trap) {
@@ -1086,6 +1090,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       }
     }
     sh_.lineno_base = saved_lineno_base;
+    sh_.loop_depth = saved_loop_depth;
     if (!sh_.persona_restore.empty()) {
       if (sh_.persona_restore.back()) sh_.set_personality(*sh_.persona_restore.back());
       sh_.persona_restore.pop_back();
@@ -1286,6 +1291,7 @@ int Executor::run_subshell(const Subshell *c) {
   if (pid == 0) {
     sh_.job_control = false;  // the subshell runs as one unit; no nested tty control
     sh_.subshell_level++;
+    sh_.loop_depth = 0;  // a `break' in a subshell doesn't break the outer loop
     // A subshell does not inherit the parent's EXIT trap; only one it sets for
     // itself runs when it exits.
     sh_.traps.erase("EXIT");
@@ -1330,6 +1336,7 @@ int Executor::run_if(const IfCommand *c) {
 
 int Executor::run_loop(const LoopCommand *c) {
   int st = 0;
+  sh_.loop_depth++;
   while (!unwinding()) {
     sh_.errexit_suppress++;
     int cond = run(c->cond.get());
@@ -1342,6 +1349,7 @@ int Executor::run_loop(const LoopCommand *c) {
     // to the enclosing loop; N==1 continues this loop.
     if (sh_.continue_count) { if (--sh_.continue_count) break; else continue; }
   }
+  sh_.loop_depth--;
   return st;
 }
 
@@ -1386,6 +1394,7 @@ int Executor::run_for(const ForCommand *c) {
     // this a broken step expression like `7++' would spin forever.
     aeval(c->a_init);
     if (!ok) return 1;
+    sh_.loop_depth++;
     for (;;) {
       if (!c->a_cond.empty()) {
         long long cv = aeval(c->a_cond);
@@ -1401,6 +1410,7 @@ int Executor::run_for(const ForCommand *c) {
       aeval(c->a_update);
       if (!ok) { st = 1; break; }
     }
+    sh_.loop_depth--;
     return st;
   }
 
@@ -1415,6 +1425,7 @@ int Executor::run_for(const ForCommand *c) {
     for (const std::string &it : items) line += " " + it;
     std::fprintf(stderr, "%s\n", line.c_str());
   }
+  sh_.loop_depth++;
   for (const std::string &item : items) {
     // A nameref loop variable is special: each iteration *retargets* the
     // reference to name ITEM rather than writing ITEM through to its current
@@ -1435,6 +1446,7 @@ int Executor::run_for(const ForCommand *c) {
     if (sh_.continue_count) { if (--sh_.continue_count) break; else continue; }
     if (unwinding()) break;
   }
+  sh_.loop_depth--;
   return st;
 }
 


### PR DESCRIPTION
Fixes the dominant cascade in `errors.tests` (170→128) plus a `trap` improvement (20→17), all through control-flow builtin conformance. Closes #228.

## The cascade
Running `errors.tests`, gnash produced only **30 of bash's 166** output lines. Three separate builtins silently aborted the rest of the script:

1. **`break`/`continue` outside a loop** set the internal break/continue count with no loop to consume it, so the executor unwound the whole remaining input with no diagnostic (line 123 wiped out ~130 lines).
2. **`return` outside a function or sourced script** did the same via the `returning` flag (line 299).
3. **`kill -INT ""`** (and `kill -HUP @12`, `kill abc`) ran `atol("")` → `kill(0, sig)`, signaling the **entire process group** — a dangerous self-signal that killed the rest of the run (line 328).

## Commits
1. **Diagnose break/continue/return used outside their valid scope** — track loop nesting (`loop_depth`, reset across function/subshell boundaries) and source nesting (`source_depth`); the builtins now print bash's diagnostic and continue instead of unwinding. Also validates the loop count (`numeric argument required`, `loop count out of range`, `--` marker, count capping).
2. **Validate kill's signal and target arguments** — reject a target that isn't a pid or `%jobspec` (no more `kill(0)`), validate signal specs (rejecting the SIGTERM fallback), handle `-s`/`-n` missing args and the no-target usage message.
3. **Run a signal trap while the interrupted function is still active** — drain pending traps at the end of a function body (before the scope pops) so a `return` in the trap returns from that function, as bash does. This also improved `trap` 20→17.

## Verification
- `errors` 170→**128**; `trap` 20→**17**; no other scoreboard file changed (comsub, heredoc, func, arith, varenv, cond, array, nameref, assoc, builtins, dbg-support, set-x, exp, posixexp, quotearray all unchanged).
- `ctest --test-dir build`: 22/22.
- `run_diff.sh`: all 221 scripts match bash.