### PR TITLE
Batch 77: implement the readonly-function attribute (errors 52→43, func 111→39)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -383,6 +383,7 @@ class Shell {
   std::map<std::string, const Command *> functions;
   std::vector<CommandPtr> retained;  // keeps eval/source/def trees alive
   std::set<std::string> exported_functions;  // `export -f': passed to children
+  std::set<std::string> readonly_functions;  // `readonly -f'/`declare -fr': cannot rebind/unset
   // Import `BASH_FUNC_name%%=() {...}' definitions from the environment (called
   // once at startup); parses each safely, ignoring any trailing commands.
   void import_env_functions();

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1016,7 +1016,16 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   static const std::set<std::string> kNoUnset = {"BASH_LINENO", "BASH_SOURCE",
                                                  "BASH_ARGV", "BASH_ARGC"};
   for (; i < argv.size(); i++) {
-    if (funcs) { sh.functions.erase(argv[i]); continue; }
+    if (funcs) {
+      if (sh.readonly_functions.count(argv[i])) {
+        std::fprintf(stderr, "%sunset: %s: cannot unset: readonly function\n",
+                     sh.err_prefix().c_str(), argv[i].c_str());
+        ret = 1;
+      } else {
+        sh.functions.erase(argv[i]);
+      }
+      continue;
+    }
     if (kNoUnset.count(argv[i])) {
       std::fprintf(stderr, "%sunset: %s: cannot unset\n", sh.err_prefix().c_str(),
                    argv[i].c_str());
@@ -1785,6 +1794,29 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     }
     return st;
   }
+  // Set or remove the readonly attribute on named functions: `readonly -f f',
+  // `declare -fr f' mark; `declare -f +r f' tries to remove it (an error on a
+  // readonly function).  A name that is not a function is reported.
+  if (funcs && (readonly || rm_readonly) && i < argv.size()) {
+    int st = 0;
+    for (; i < argv.size(); i++) {
+      const std::string &fn = argv[i];
+      if (!sh.functions.count(fn)) {
+        std::fprintf(stderr, "%s%s: %s: not a function\n", sh.err_prefix().c_str(),
+                     argv[0].c_str(), fn.c_str());
+        st = 1;
+      } else if (rm_readonly) {
+        if (sh.readonly_functions.count(fn)) {
+          std::fprintf(stderr, "%s%s: %s: readonly function\n", sh.err_prefix().c_str(),
+                       argv[0].c_str(), fn.c_str());
+          st = 1;
+        }
+      } else {
+        sh.readonly_functions.insert(fn);
+      }
+    }
+    return st;
+  }
   // -f / -F: display function definitions or names.  With -x, restrict to
   // exported functions (gnash doesn't export functions, so none qualify).
   if (funcs || funcnames) {
@@ -1792,7 +1824,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (exported) return i >= argv.size() ? 0 : 1;
     if (i >= argv.size()) {  // all functions
       for (const auto &kv : sh.functions) {
-        if (funcnames) std::printf("declare -f %s\n", kv.first.c_str());
+        bool ro = sh.readonly_functions.count(kv.first) > 0;
+        if (readonly && !ro) continue;  // `-r' lists only readonly functions
+        if (funcnames) std::printf("declare -f%s %s\n", ro ? "r" : "", kv.first.c_str());
         else std::printf("%s\n", named_function_string(kv.first, kv.second, sh.opt_posix).c_str());
       }
       return 0;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1519,6 +1519,12 @@ int Executor::run_funcdef(const FunctionDef *c) {
                  sh_.err_prefix().c_str(), c->name.c_str());
     return (sh_.last_status = 1);
   }
+  // A readonly function cannot be redefined.
+  if (sh_.readonly_functions.count(c->name)) {
+    std::fprintf(stderr, "%s%s: readonly function\n", sh_.err_prefix().c_str(),
+                 c->name.c_str());
+    return (sh_.last_status = 1);
+  }
   sh_.functions[c->name] = c->body.get();
   sh_.func_src[c->name] = sh_.current_source();  // file it was defined in, for BASH_SOURCE
   sh_.func_lineno_base[c->name] = sh_.lineno_base;  // for $LINENO inside the body


### PR DESCRIPTION
Continues the `errors.tests` conformance work (batch76, #237). Implements the readonly-function attribute, which gnash previously ignored. Closes #238.

`readonly -f NAME` / `declare -fr NAME` now mark a function readonly (tracked in a new `Shell::readonly_functions` set), and the attribute is enforced everywhere:
- redefining the function → `NAME: readonly function` (reported at the definition)
- `unset -f NAME` → `unset: NAME: cannot unset: readonly function`
- `declare -f +r NAME` → cannot clear it (`declare: NAME: readonly function`)
- `declare -F` lists a readonly function as `declare -fr NAME`; `declare -Fr` lists only the readonly ones

## Verification
- `errors` 52 → **43** (−9); bonus **`func` 111 → 39** (−72 — the attribute + `declare -Fr` formatting covers much of func.tests); every other scoreboard file unchanged.
- `ctest`: 22/22. `run_diff.sh`: all 221 scripts match bash.
- Confirmed `readonly -f nonexistent` → `not a function`, and normal `declare -F`/`declare -F name` unaffected.