### PR TITLE
Batch 78: cd/shopt/source argument validation (errors 43→36)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3268,6 +3268,11 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
       }
     }
   }
+  if (set_s && unset_u) {
+    std::fprintf(stderr, "%sshopt: cannot set and unset shell options simultaneously\n",
+                 sh.err_prefix().c_str());
+    return 1;
+  }
 
   if (o_names) {
     // `-p' reproduces as `set -o'/`set +o' commands; otherwise a NAME<TAB>state

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4709,6 +4709,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     for (; ai < argv.size(); ai++) {
       if (argv[ai] == "--") { ai++; break; }
       if (argv[ai] == "-p") { pflag = true; if (ai + 1 < argv.size()) ppath = argv[++ai]; continue; }
+      if (argv[ai].size() >= 2 && argv[ai][0] == '-') {  // `. -i': unknown option
+        std::fprintf(stderr, "%s%s: %s: invalid option\n", sh.err_prefix().c_str(),
+                     cmd.c_str(), argv[ai].c_str());
+        std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
+                     cmd.c_str(), cmd.c_str());
+        return 2;
+      }
       break;
     }
     if (ai >= argv.size()) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -599,11 +599,23 @@ int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
     else if (argv[i] == "--") { i++; break; }
     else break;
   }
+  if (argv.size() - i > 1) {
+    std::fprintf(stderr, "%scd: too many arguments\n", sh.err_prefix().c_str());
+    return 1;
+  }
   std::string dir;
-  if (i >= argv.size()) dir = sh.get("HOME");
-  else if (argv[i] == "-") {
+  if (i >= argv.size()) {
+    if (!sh.is_set("HOME")) {
+      std::fprintf(stderr, "%scd: HOME not set\n", sh.err_prefix().c_str());
+      return 1;
+    }
+    dir = sh.get("HOME");
+  } else if (argv[i] == "-") {
+    if (!sh.is_set("OLDPWD")) {
+      std::fprintf(stderr, "%scd: OLDPWD not set\n", sh.err_prefix().c_str());
+      return 1;
+    }
     dir = sh.get("OLDPWD");
-    if (dir.empty()) { std::fprintf(stderr, "gnash: cd: OLDPWD not set\n"); return 1; }
     std::printf("%s\n", dir.c_str());
   } else {
     dir = argv[i];


### PR DESCRIPTION
Continues the `errors.tests` conformance work (batch77, #239). Closes #240.

## Commits
1. **Diagnose cd's too-many-arguments and unset HOME/OLDPWD** — `cd one two three` → `too many arguments`; `cd` with unset HOME → `HOME not set`; `cd -` with unset OLDPWD → `OLDPWD not set` (with the proper location prefix, not a bare `gnash:`).
2. **Reject shopt -s and -u given together** — `shopt -s -u NAME` → `cannot set and unset shell options simultaneously`.
3. **Reject an invalid option to source and .** — `. -i FILE` → `.: -i: invalid option` + usage, instead of treating `-i` as the filename.

## Verification
- `errors` 43 → **36** (−7); every other scoreboard file unchanged.
- `ctest`: 22/22. `run_diff.sh`: all 221 scripts match bash.
- No regression on `cd /tmp`, `shopt -s/-u`, `source /dev/null`, `. missingfile`.

The `readonly PWD; cd /` → `PWD: readonly variable` case is deferred (needs `change_dir` to detect a readonly PWD before updating it).