### PR TITLE
printf: support the %(FMT)T time-format conversion

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <fstream>
 #include <regex.h>
 #include <set>
@@ -344,6 +345,31 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
         while (j < fmt.size() && std::strchr("-+ #0123456789.", fmt[j])) j++;
         if (j >= fmt.size()) { out += '%'; break; }
         char conv = fmt[j];
+        // %(DATEFMT)T: format an epoch-seconds argument through strftime.  The
+        // conversion char sits after the parenthesized format, so it is scanned
+        // separately from the ordinary single-letter conversions below.
+        if (conv == '(') {
+          size_t close = fmt.find(")T", j);
+          if (close != std::string::npos) {
+            std::string datefmt = fmt.substr(j + 1, close - (j + 1));
+            std::string a = next();
+            time_t when;
+            if (a.empty()) when = std::time(nullptr);
+            else {
+              long v = std::strtol(a.c_str(), nullptr, 10);
+              when = (v < 0) ? std::time(nullptr) : static_cast<time_t>(v);
+            }
+            struct tm tmv;
+            localtime_r(&when, &tmv);
+            char tbuf[256];
+            tbuf[0] = '\0';
+            std::strftime(tbuf, sizeof tbuf, datefmt.c_str(), &tmv);
+            out += tbuf;
+            consumed_any = true;
+            i = close + 1;  // land on the 'T'; the loop ++ steps past it
+            continue;
+          }
+        }
         std::string spec = fmt.substr(i, j - i + 1);
         if (conv == '%') {
           out += '%';

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -113,6 +113,10 @@ scripts=(
   'printf "%b|" "\101" "\0101" "\x41" "a\tb"; echo'
   'printf -v out "%s=%05d" foo 7; echo "[$out]"'
   'printf "%-8s|%5.2f|%3d\n" hi 3.14159 42'
+  # printf %(FMT)T time conversion (epoch arg; both shells share the ambient TZ)
+  'printf "%(%Y-%m-%d)T\n" 0'
+  'printf "[%(%H:%M:%S)T]\n" 0'
+  'printf "pre-%d-%(%Y)T-post\n" 5 0'
   'echo "*.md"; echo '\''*.md'\''; x="*"; echo "$x"'
   'printf "<%s>" "" a ""; echo'
   'set -- "" x ""; echo $#; for a in "$@"; do echo "[$a]"; done'


### PR DESCRIPTION
Fixes #244.

## Root cause
`bi_printf`'s conversion scanner read optional flag characters then took the next byte as the conversion char. For `%(FMT)T` that byte is `(`, which matched no conversion and fell through to the literal-echo branch — so gnash printed `%(%Y)T` verbatim.

## Fix
Recognize `(` as the start of a time conversion: scan to the matching `)T`, take the argument as epoch seconds (`-1` or absent = now, negative = now), and format via `strftime`. Added `<ctime>`.

## Verification
- `printf "%(%Y-%m-%d)T\n" 0` → `1970-01-01` (matches bash under the same TZ)
- Compound formats and interleaved conversions (`printf "pre-%d-%(%Y)T-post\n" 5 0`) match bash.
- Full differential harness: **224/224 scripts match bash** (3 new %(...)T regression cases added).