### PR TITLE
executor: keep spaces in an unquoted compound-array subscript

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -231,7 +231,26 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
   // subscript mode: a later bare word is an error.  An all-bare list is a valid
   // flat key/value list, so only reject a bare word once a subscript was seen.
   bool saw_sub = false;
-  for (const Token &t : tokenize(inner)) {
+  // The general tokenizer word-splits an unquoted subscript that contains a
+  // space ([a b]=v -> "[a", "b]=v"); reassemble any element whose leading `['
+  // subscript is not yet closed so the [sub]=value parse below sees the whole
+  // key.  (A quoted subscript ["a b"] already survives as a single token.)
+  // Runs of whitespace inside the subscript collapse to one space -- quote the
+  // key to preserve exact spacing, as in bash.
+  std::vector<Token> toks = tokenize(inner);
+  std::vector<Token> elems;
+  for (size_t k = 0; k < toks.size(); k++) {
+    Token t = toks[k];
+    while (t.type == Tok::Word && !t.text.empty() && t.text[0] == '[' &&
+           skip_subscript(t.text, 0) == std::string::npos &&
+           k + 1 < toks.size() && toks[k + 1].type == Tok::Word) {
+      t.text += ' ' + toks[k + 1].text;
+      t.quoted = t.quoted || toks[k + 1].quoted;
+      k++;
+    }
+    elems.push_back(t);
+  }
+  for (const Token &t : elems) {
     if (t.type == Tok::Eof) break;
     if (t.type != Tok::Word) continue;
     const std::string &e = t.text;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -144,6 +144,10 @@ scripts=(
   'declare -a arr=(1 2 3); echo "${#arr[@]} ${arr[1]}"'
   'declare -a a=(one "two three" four); echo "${#a[@]}: ${a[1]}"'
   'declare -A m=([x]=1 [y]=2); echo "${m[x]}${m[y]} ${#m[@]}"'
+  # an unquoted space inside a compound-initializer subscript is part of the key
+  'declare -A m=([a b]="c d"); echo "[${m[a b]}]"'
+  'declare -A m=([one]=1 [two words]=2 [x]=3); echo "${m[two words]} ${#m[@]}"'
+  'declare -A m=([a b]=1 [c d]=2); echo "${m[a b]}${m[c d]} n=${#m[@]}"'
   'y="hi there"; declare z=$y; echo "$z"; declare -i n=3+4; echo "$n"'
   'f(){ local -a la=(p q r); echo "${la[2]}"; }; f'
   'x=${ echo hello world; }; echo "[$x]"'


### PR DESCRIPTION
Fixes #250.

## Root cause
`parse_array_elems` tokenized the compound body `([key]=value ...)` with the general tokenizer, which word-splits an unquoted subscript containing a space — `[a b]=v` → `[a`, `b]=v` — so the key was stored as `[a` instead of `a b`. The quoted form `["a b"]=v` already worked (quotes keep it one token).

## Fix
Reassemble any element whose leading `[` subscript is not yet closed (via `skip_subscript`) before the `[sub]=value` parse, so `[a b]=v` becomes one element. Whitespace runs collapse to a single space; quote the key for exact spacing, as in bash.

## Verification
`declare -A m=([a b]="c d"); echo "[${m[a b]}]"` → `[c d]`; keys enumerate as `a b`; multiple space-keys and mixed quoted/unquoted keys all match bash. Full differential harness: **234/234 match bash** (3 new regression cases).