### PR TITLE
parser: require a function body to be a compound command

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -903,6 +903,16 @@ struct Parser {
     return cur().type == Tok::Word && !cur().quoted && is_compound_kw(cur().text);
   }
 
+  // A function body must be a compound command: a brace group, subshell,
+  // arithmetic/conditional command, or a loop/if/case/select.  Unlike the
+  // general compound-start test, `function' and `coproc' are not valid bodies
+  // (bash rejects `f() coproc ...' and `f() function g ...').
+  bool at_function_body() const {
+    if (is(Tok::Lparen)) return true;  // ( subshell or (( arithmetic
+    return cur().type == Tok::Word && !cur().quoted &&
+           cur().text != "function" && is_compound_kw(cur().text);
+  }
+
   CommandPtr parse_coproc() {
     advance();  // coproc
     auto n = std::make_unique<CoprocCommand>();
@@ -989,6 +999,11 @@ struct Parser {
     expect(Tok::Lparen, "(");
     expect(Tok::Rparen, ")");
     newline_list();
+    if (!err && !at_function_body()) {
+      fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                        : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
+      return n;
+    }
     n->body = parse_command({});
     // bash validates the function name at the end of the definition, so an
     // invalid-name error reports the line the definition closes on.
@@ -1010,6 +1025,11 @@ struct Parser {
       expect(Tok::Rparen, ")");
     }
     newline_list();
+    if (!err && !at_function_body()) {
+      fail(is(Tok::Eof) ? std::string("unexpected end of file")
+                        : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
+      return n;
+    }
     n->body = parse_command({});
     n->line = i > 0 ? toks[i - 1].line : cur().line;  // the definition's end line
     return n;


### PR DESCRIPTION
Fixes #255.

## Root cause
`parse_funcdef_paren` and `parse_function` parsed the body with `parse_command`, which falls through to `parse_simple` — so a simple-command body (`f() echo hi`), an assignment, `coproc`, or a `!` pipeline were all accepted. bash requires the body to be a *compound* command.

## Fix
Add `at_function_body` (the compound-start set — `{`, `(`, `((`, `[[`, `if`, `while`, `until`, `for`, `select`, `case` — minus `function`/`coproc`, which bash also rejects as bodies) and raise bash's "near unexpected token" error naming the offending token when the body does not start one.

## Verification
- Rejects `f() echo hi` → near `echo`, plus `f() :`, `f() a=1`, `f() coproc x`, `f() ! true`, `function g echo hi`, `f() function h {...}`, and bare `f()` → unexpected end of file — all match bash (exit 2 + token).
- Accepts every compound body: `{ }`, `( )`, `if`, `for`, `while`, `case`, `(( ))`, `[[ ]]`, and the `function name { ... }` form.
- Execution harness 234/234; real-script parser corpus 429/429 (100%); **negative corpus now 68/68 = 100% rejection agreement, zero leniency.**
