### PR TITLE
parser: treat a function body missing at EOF as incomplete input

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -999,6 +999,10 @@ struct Parser {
     expect(Tok::Lparen, "(");
     expect(Tok::Rparen, ")");
     newline_list();
+    // The body may be on a later line (`foo()' then `{...}' next line): at EOF
+    // the input is incomplete, not erroneous -- let the line reader fetch more
+    // rather than hard-failing (which would leak the body to the top level).
+    if (is(Tok::Eof)) incomplete = true;
     if (!err && !at_function_body()) {
       fail(is(Tok::Eof) ? std::string("unexpected end of file")
                         : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
@@ -1025,6 +1029,10 @@ struct Parser {
       expect(Tok::Rparen, ")");
     }
     newline_list();
+    // The body may be on a later line (`foo()' then `{...}' next line): at EOF
+    // the input is incomplete, not erroneous -- let the line reader fetch more
+    // rather than hard-failing (which would leak the body to the top level).
+    if (is(Tok::Eof)) incomplete = true;
     if (!err && !at_function_body()) {
       fail(is(Tok::Eof) ? std::string("unexpected end of file")
                         : std::string("near unexpected token `") + tok_to_text(cur()) + "'");


### PR DESCRIPTION
Fixes #257.

## Root cause (regression from #256)
The shell reads input line by line. For a K&R function definition — head on one line, `{ ... }` on the next — it parses the head alone first, reaching EOF right after the parentheses. The compound-body check added in #256 hard-failed at that EOF instead of reporting the parse as *incomplete*, so the line reader never fetched the body: the definition was abandoned and its body leaked to the top level and **executed**. With a here-document body (a `while read <<HERE ...; do ...; done`) the leaked loop ran forever — bash's `heredoc` test spewed 840,884 lines.

`gnash-parse` (whole-file) never showed this; only the incremental line reader did.

## Fix
Set `incomplete = true` when the body is absent because of EOF (mirroring `parse_simple`), so the reader fetches the following lines before deciding. A genuine non-compound body token (`f() echo hi`) is still rejected, and a function head at true end of input still errors like bash.

## Verification
- `foo()` newline `{ echo hi; }` now defines and runs correctly (was: leaked `echo hi`, `foo: command not found`).
- The here-document-in-body case no longer loops.
- `f() echo hi` still rejected; `foo()` at true EOF errors identically to bash (exit 2, same message).
- **`heredoc` scoreboard test: 840,884 → 106 byte-diffs.**
- Execution differential 234/234; negative corpus 68/68 (0 leniency); real-script parser corpus 429/429.
