### PR TITLE
ast: keep the here-document body of an if/while condition in declare -f

### DIFF
--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -383,8 +383,8 @@ struct MPrinter {
     }
     if (const auto *ic = dynamic_cast<const IfCommand *>(c)) {
       out += "if ";
-      inline_line_here(ic->cond.get());
-      out += "; then";
+      if (inline_line_here(ic->cond.get())) { nl(I); out += "then"; }
+      else out += "; then";
       nl(I + 4);
       list(ic->then_part.get(), I + 4);
       clause_semi();
@@ -402,8 +402,8 @@ struct MPrinter {
     }
     if (const auto *lc = dynamic_cast<const LoopCommand *>(c)) {
       out += lc->until ? "until " : "while ";
-      inline_line_here(lc->cond.get());
-      out += "; do";
+      if (inline_line_here(lc->cond.get())) { nl(I); out += "do"; }
+      else out += "; do";
       nl(I + 4);
       list(lc->body.get(), I + 4);
       clause_semi();
@@ -490,10 +490,34 @@ struct MPrinter {
   }
 
   // A condition (if/while) or subshell body on one line.
-  void inline_line_here(const Command *c) {
-    MPrinter sub;
-    sub.inline_line(c);
-    out += sub.out;
+  // Collect the here-document redirections of a command (in source order) so a
+  // condition line can emit their bodies.  The condition is a simple command or
+  // a pipeline/and-or of them, so recurse through Connection nodes.
+  static void collect_heredocs(const Command *c, std::vector<const Redirect *> &hds) {
+    if (c == nullptr) return;
+    if (const auto *sc = dynamic_cast<const SimpleCommand *>(c)) {
+      for (const Redirect &r : sc->redirects)
+        if (r.op == RedirOp::HereDoc || r.op == RedirOp::HereDocStrip) hds.push_back(&r);
+    } else if (const auto *cn = dynamic_cast<const Connection *>(c)) {
+      collect_heredocs(cn->first.get(), hds);
+      collect_heredocs(cn->second.get(), hds);
+    }
+  }
+
+  // Print a compound-command header line (an if/while condition) inline, then
+  // emit any here-document bodies it carries (bash prints them right after the
+  // condition line, before `then'/`do').  Returns true if a body was emitted,
+  // so the caller starts `then'/`do' on a fresh line instead of `; '.
+  bool inline_line_here(const Command *c) {
+    inline_line(c);
+    std::vector<const Redirect *> hds;
+    collect_heredocs(c, hds);
+    for (const Redirect *r : hds) {
+      out += '\n';
+      out += r->heredoc_body;  // body lines keep their own newlines
+      out += r->target.text;
+    }
+    return !hds.empty();
   }
   void inline_line(const Command *c) {
     std::string one;


### PR DESCRIPTION
Fixes #259.

## Root cause
The multi-line printer renders an if/while condition via `inline_line_here`, which printed it with the node's single-line `print()` and then discarded any here-documents on it — the `MPrinter` here-doc queue was never populated for the condition. So `declare -f` emitted `while read v <<HERE; do`, losing the body and joining with `;`.

## Fix
Collect the condition's here-document redirections directly (walking pipeline/and-or nodes) and emit their bodies after the condition line; when any are present, start `do`/`then` on a fresh line instead of `; do`/`; then`.

## Verification
- `declare -pf` of a function with a `while read <<HERE …; do … done` or `if cat <<HERE …; then … fi` body now matches bash 5.3 byte-for-byte.
- Bash's `heredoc9.sub` (function bodies with here-documents) matches bash exactly.
- `heredoc` scoreboard test: 106 → 96 byte-diffs (the reconstruction diffs are gone; the rest is unrelated error-text wording).
- Execution differential 234/234; no regressions.
