### PR TITLE
shell: keep the invocation name in errors after a BASH_ARGV0 assignment

### DIFF
--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1078,9 +1078,10 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
       return false;
     }
   }
-  // Assigning BASH_ARGV0 resets $0 (and the name used in error messages), as
-  // bash does; still stored so `$BASH_ARGV0' reads back the value.
-  if (n == "BASH_ARGV0") { arg0 = v; shell_name = v; }
+  // Assigning BASH_ARGV0 resets $0 but NOT the name shown in error messages:
+  // bash reports errors against the source file, not the mutable $0.  $0 already
+  // resolves through arg0; still stored so `$BASH_ARGV0' reads back the value.
+  if (n == "BASH_ARGV0") { arg0 = v; }
   // Assigning to a dynamic variable seeds/rebases it rather than storing.
   if (n == "RANDOM") {
     rand_seed = static_cast<unsigned long>(std::strtoul(v.c_str(), nullptr, 10));


### PR DESCRIPTION
Fixes #261.

## Root cause
Assigning `BASH_ARGV0` updated both `arg0` (`$0`) and `shell_name` (the program name in error messages), so an error after such an assignment was misattributed to the new `$0` (`arg0: line N: ...`) instead of the script. bash sets only `$0`; it reports errors against the source file.

## Fix
Drop `shell_name = v` from the `BASH_ARGV0` assignment. `$0` already resolves through `arg0`, so it still reflects `BASH_ARGV0`, while error messages keep the invocation name.

## Verification
- `BASH_ARGV0=zzz; echo $0; (( 1/0 ))` now matches bash: `$0` is `zzz`, the error names the script.
- **dynvar test-suite file: 2 -> 0 byte-diffs.**
- Execution differential 234/234; no regressions.
