### PR TITLE
expand: apply full quote removal to a pattern-substitution replacement

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1618,10 +1618,13 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       if (body2[k] == '/') { slash = k; break; }
     }
     std::string pat = ex.expand_pattern(slash == std::string::npos ? body2 : body2.substr(0, slash));
-    // The replacement is expanded in double-quote context when the whole
-    // expansion is quoted, so nested quotes (`${a/#/"-n '"}') behave like bash.
-    std::string rep = slash == std::string::npos ? std::string()
-                                                 : expand_word(body2.substr(slash + 1));
+    // The replacement undergoes full quote removal like a normal word --
+    // independent of whether the enclosing ${...} is double-quoted -- so single
+    // quotes, double quotes, and a backslash before any character are all
+    // processed (`\'' -> `'', `'ab'' -> `ab'), matching bash.
+    std::string rep = slash == std::string::npos
+                          ? std::string()
+                          : ex.expand_no_split(body2.substr(slash + 1));
     // `#' matches the longest prefix, `%' the longest suffix; one replacement.
     if (anchor == '#') {
       for (size_t j = val.size() + 1; j-- > 0;)


### PR DESCRIPTION
Fixes #263.

## Root cause
The replacement in `${var/pat/rep}` was expanded with double-quote rules (`expand_dq_word`) when the enclosing `${...}` was double-quoted, so a backslash before an ordinary character and single quotes were kept literally. bash treats the replacement like a normal word and removes them, regardless of the outer quoting.

## Fix
Always expand the replacement with `expand_no_split` (full word quote removal) — matching what gnash already did when the outer `${...}` was unquoted.

## Verification
- `"${w/z/\a}"`→`a`, `"${w/z/\'}"`→`'`, `"${w/z/'ab'}"`→`ab`, plus double-quote and `\\`/`\$` cases — all match bash 5.3.
- **Scoreboard: nquote 2→0, iquote 25→0, quote 75→71, quotearray 132→124.**
- Execution differential 234/234; no regressions.
