### PR TITLE
parser: keep trailing whitespace before an arith-for section semicolon

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -678,6 +678,9 @@ struct Parser {
         continue;
       }
       if (is(Tok::Semi) && depth == 0) {
+        // Keep any blank before the `;' on the section just closed, so a section
+        // written as `EXPR ;' reproduces bash's raw text (`7=4 ') in an error.
+        if (!parts.back().empty() && cur().preceded_by_blank) parts.back() += ' ';
         parts.emplace_back();
         advance();
         continue;


### PR DESCRIPTION
Fixes #265.

## Root cause
`parse_arith_for_header` appended a trailing blank before `))` (so the step section reproduces bash's raw text) but not before a section-terminating `;`. A section written as `EXPR ;` therefore dropped the space: `for (( 7=4 ; ... ))` reported `((: 7=4:` instead of bash's `((: 7=4 :` (error token `"=4 "`).

## Fix
Append the trailing blank before a depth-0 `;` when it was preceded by whitespace, mirroring the `))` handling.

## Verification
- `for (( 7=4 ; 7 > 7; ))` error now matches bash byte-for-byte.
- Valid arith-fors (spaced and tight) and their `declare -pf` canonical form are unchanged.
- **arith-for scoreboard: 3 -> 1** (the remaining diff is a separate, deeper lexer issue: a command substitution containing a `case` pattern in the header).
- Execution differential 234/234; no regressions.
