### PR TITLE
lexer, expand: keep a case pattern paren from closing a command substitution

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -52,19 +52,44 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
                      bool firstclose = false) {
   int depth = 0;
   bool wasdol = false;  // previous char was an unquoted `$` (LEX_WASDOL)
+  // When scanning a `$( ... )' command substitution, a `)' that terminates a
+  // `case' pattern (`case x in x)') is not the closer.  Track the depth of each
+  // command-position `case' body (mirrors the lexer's scan_paren).  Inactive for
+  // `[' / `{' scans, which are byte-identical to before.
+  const bool case_aware = (open == '(');
+  bool cmd_pos = true;
+  std::vector<int> case_stack;
+  std::string word;
+  bool word_plain = true;
+  bool saw_word = false;
+  auto boundary = [&]() {
+    if (case_aware && saw_word) {
+      if (cmd_pos && word_plain && word == "case") case_stack.push_back(depth);
+      else if (cmd_pos && word_plain && word == "esac" && !case_stack.empty())
+        case_stack.pop_back();
+      cmd_pos = word_plain && (word == "then" || word == "do" ||
+                               word == "else" || word == "elif");
+    }
+    word.clear();
+    word_plain = true;
+    saw_word = false;
+  };
+  auto contaminate = [&]() { if (case_aware) { saw_word = true; word_plain = false; } };
   for (; i < t.size(); i++) {
     char c = t[i];
-    if (c == '\\') { i++; wasdol = false; continue; }
+    if (c == '\\') { contaminate(); i++; wasdol = false; continue; }
     if (c == '$' && i + 1 < t.size() && t[i + 1] == '\'') {
       // $'...': ANSI-C quoting, where a backslash escapes the next character
       // (so \' is not a terminator).
+      contaminate();
       i += 2;
       while (i < t.size() && t[i] != '\'') { if (t[i] == '\\' && i + 1 < t.size()) i++; i++; }
       wasdol = false;
       continue;
     }
-    if (c == '\'') { while (++i < t.size() && t[i] != '\'') {} wasdol = false; continue; }
+    if (c == '\'') { contaminate(); while (++i < t.size() && t[i] != '\'') {} wasdol = false; continue; }
     if (c == '"') {
+      contaminate();
       while (++i < t.size() && t[i] != '"')
         if (t[i] == '\\') i++;
       wasdol = false;
@@ -81,8 +106,33 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
       continue;
     }
     if (c == open) {
+      if (case_aware) boundary();
       if (!firstclose || open != '{' || depth == 0 || wasdol) depth++;
-    } else if (c == close) { if (--depth == 0) return i; }
+      if (case_aware) cmd_pos = true;
+    } else if (c == close) {
+      if (case_aware) {
+        boundary();
+        if (!case_stack.empty() && case_stack.back() == depth) {
+          cmd_pos = true;  // case pattern terminator: keep depth, stay open
+          wasdol = false;
+          continue;
+        }
+      }
+      if (--depth == 0) return i;
+      if (case_aware) cmd_pos = true;
+    } else if (case_aware && (c == ';' || c == '&' || c == '|' || c == '\n')) {
+      boundary();
+      cmd_pos = true;
+    } else if (case_aware && (c == ' ' || c == '\t')) {
+      boundary();
+    } else if (case_aware && c == '$') {
+      saw_word = true;
+      word_plain = false;
+    } else if (case_aware) {
+      saw_word = true;
+      if (word_plain && (std::isalnum(static_cast<unsigned char>(c)) || c == '_')) word += c;
+      else word_plain = false;
+    }
     wasdol = (c == '$');
   }
   return std::string::npos;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -141,27 +141,81 @@ struct Lexer {
   }
   void scan_paren(std::string &w) {  // pos at '('
     int depth = 0;
+    // A `)' that terminates a `case' pattern (`case x in x)') must not be
+    // mistaken for the substitution's closing paren.  Track the paren depth of
+    // each active (command-position) `case' body; a `)' at that depth is a
+    // pattern terminator, not the closer.  Keyword recognition is gated on
+    // command position so a `case'/`esac' used as an argument is unaffected.
+    bool cmd_pos = true;          // next plain word starts a command
+    std::vector<int> case_stack;  // paren depths of open `case' bodies
+    std::string word;             // current unquoted identifier word
+    bool word_plain = true;       // word is only identifier chars (a keyword?)
+    bool saw_word = false;        // any word content since the last delimiter
+    auto boundary = [&]() {
+      if (saw_word) {
+        if (cmd_pos && word_plain && word == "case") case_stack.push_back(depth);
+        else if (cmd_pos && word_plain && word == "esac" && !case_stack.empty())
+          case_stack.pop_back();
+        // Most words consume the command slot; a few reopen command position.
+        cmd_pos = word_plain && (word == "then" || word == "do" ||
+                                 word == "else" || word == "elif");
+      }
+      word.clear();
+      word_plain = true;
+      saw_word = false;
+    };
     do {
       char c = in[pos];
       if (c == '(') {
+        boundary();
         depth++;
         w += c;
         pos++;
+        cmd_pos = true;
       } else if (c == ')') {
-        depth--;
+        boundary();
+        if (!case_stack.empty() && case_stack.back() == depth) {
+          w += c;  // case pattern terminator: keep depth, stay open
+          pos++;
+        } else {
+          depth--;
+          w += c;
+          pos++;
+        }
+        cmd_pos = true;
+      } else if (c == ';' || c == '&' || c == '|' || c == '\n') {
+        boundary();
+        w += c;
+        pos++;
+        cmd_pos = true;
+      } else if (c == ' ' || c == '\t') {
+        boundary();
         w += c;
         pos++;
       } else if (c == '\'') {
+        saw_word = true; word_plain = false;
         scan_single(w);
       } else if (c == '"') {
+        saw_word = true; word_plain = false;
         scan_double(w);
       } else if (c == '`') {
+        saw_word = true; word_plain = false;
         scan_backtick(w);
       } else if (c == '\\') {
+        saw_word = true; word_plain = false;
         w += c;
         pos++;
         if (pos < n) w += in[pos++];
+      } else if (c == '$') {
+        saw_word = true; word_plain = false;
+        w += c;
+        pos++;
       } else {
+        saw_word = true;
+        if (word_plain && (std::isalnum(static_cast<unsigned char>(c)) || c == '_'))
+          word += c;
+        else
+          word_plain = false;
         w += c;
         pos++;
       }


### PR DESCRIPTION
Fixes #267.

## Root cause
Both the lexer (`scan_paren`) and the expander (`scan_balanced`) found the end of `$( … )` by plain parenthesis balancing. A `)` that terminates a `case` pattern (`case x in x)`) was counted as a closing paren, so the substitution was truncated — `$(case x in x) esac)` failed to parse, and the residual `arith-for` test diff was a `case` in an arithmetic-`for` header.

## Fix
Track the parenthesis depth of each command-position `case` body and treat a `)` at that depth as a pattern terminator (not the closer) until the matching `esac`. Applied consistently in both scanners.

- Keyword recognition is gated on **command position**, so `case`/`esac` used as an ordinary argument (`$(echo case)`) is unaffected.
- The expander change is gated on the `(` scan, so `[ … ]` / `{ … }` spans are byte-identical to before.

## Verification
- `$(case x in x) esac)`, `$(case … echo …;; esac)`, quoted `"$(case …)"`, a `case` inside a `for` in a comsub, and the arith-`for` header command-sub all match bash 5.3.
- Regressions hold: `$(echo case)`, nested `$(…$(…))`, subshells, `(x)` leading-paren patterns, brace expansion in comsub — all unchanged.
- **Scoreboard: arith-for 1→0, comsub 120→43, comsub2 60→41.**
- Execution differential 234/234; real-script parser corpus 429/429 (100%); negative corpus 68/68 (0 leniency).
