### PR TITLE
lexer, expand: skip comments when scanning a command substitution

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -125,6 +125,9 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
       cmd_pos = true;
     } else if (case_aware && (c == ' ' || c == '\t')) {
       boundary();
+    } else if (case_aware && c == '#' && !saw_word) {
+      // A comment runs to the end of the line: a `)' in it is not the closer.
+      while (i + 1 < t.size() && t[i + 1] != '\n') i++;
     } else if (case_aware && c == '$') {
       saw_word = true;
       word_plain = false;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -192,6 +192,9 @@ struct Lexer {
         boundary();
         w += c;
         pos++;
+      } else if (c == '#' && !saw_word) {
+        // A comment runs to the end of the line: a `)' in it is not the closer.
+        while (pos < n && in[pos] != '\n') { w += in[pos]; pos++; }
       } else if (c == '\'') {
         saw_word = true; word_plain = false;
         scan_single(w);


### PR DESCRIPTION
Fixes #269.

## Root cause
The comsub scanners (`scan_paren` in the lexer, `scan_balanced` in the expander) balanced parentheses with quote/backtick/`case` awareness but did not skip `#` comments, so a `)` inside a comment was counted as the closing paren and the substitution was truncated — `$(#comment )` closed at the comment's `)`, losing everything after.

## Fix
When a `#` starts a word (comment position) inside a `$( … )`, skip to the end of the line in both scanners; a `)` there is not the closer. Gated to the `(` scan, so `[ … ]` / `${ … }` are unaffected, and a `#` mid-word (`a#b`, `2#101`) is untouched.

## Verification
- `$(#comment )` … next-line `)`, multiple `)` in a comment, and a `case` clause with a trailing `# … )` comment all match bash 5.3.
- Regressions hold: `$(echo a#b)`, `$((2#101))`, `$(echo case)`, array literals — unchanged.
- **Scoreboard: comsub 43→39, comsub-posix 102→92.**
- Execution differential 234/234; real-script parser corpus 429/429 (100%); negative corpus 68/68 (0 leniency).
