### PR TITLE
builtins: conform let to bash for -- and expression errors

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2223,13 +2223,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
 }
 
 int bi_let(Shell &sh, const std::vector<std::string> &argv) {
-  if (argv.size() < 2) {  // `let' with no expression
+  // A single leading `--' ends option processing (bash), so `let -- EXPR' and
+  // the common `alias let="let --"' idiom evaluate EXPR rather than treating
+  // `--' as an expression.  Only the first `--' is consumed.
+  size_t start = (argv.size() > 1 && argv[1] == "--") ? 2 : 1;
+  if (start >= argv.size()) {  // `let' / `let --' with no expression
     std::fprintf(stderr, "%slet: expression expected\n", sh.err_prefix().c_str());
     return 1;
   }
   long long last = 0;
   bool ok = true;
-  for (size_t i = 1; i < argv.size(); i++) last = eval_arith_msg(sh, argv[i], "let", &ok);
+  // bash stops at the first expression that fails to evaluate (later ones, and
+  // their side effects, are skipped) and returns failure.
+  for (size_t i = start; i < argv.size() && ok; i++) last = eval_arith_msg(sh, argv[i], "let", &ok);
   return (ok && last != 0) ? 0 : 1;
 }
 


### PR DESCRIPTION
Fixes #271.

## Fixes
Two related corrections to `bi_let`:

1. **Leading `--`** ends option processing, so `let -- EXPR` evaluates `EXPR` instead of treating `--` as an arithmetic expression — this makes the common `alias let="let --"` idiom work. Only the first `--` is consumed (`let - 2` and a second `--` still error).
2. **Stop on error**: `let` now stops at the first expression that fails to evaluate and returns failure, matching bash — `let a=1 - b=2` sets `a` but not `b` and returns 1. Previously a later successful expression could reset the status to 0.

## Verification (rc + output + side effects all match bash 5.3)
- `let -- 1==1`→0, `let -- 0`→1, `let --`→1 (expression expected), `let -- -- 2`→1, `let - 2`→1, `let 5 0`→1, `let 0 5`→0.
- `alias let="let --"; let "1 == 1"` → status 0.
- `let a=1 - b=2` → `a=1`, `b` unset, rc 1.
- **comsub scoreboard: 39→35.**
- Execution differential 234/234; no regressions.
