### PR TITLE
parser, executor: implement named file-descriptor redirections ({var}>file)

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -54,6 +54,9 @@ struct Redirect {
   Word target;          // filename, fd word, or here-doc delimiter
   std::string heredoc_body;
   bool heredoc_quoted = false;  // delimiter was quoted => no expansion
+  // `{var}<file' etc.: a fresh descriptor is allocated, the redirection opened on
+  // it, and its number stored in this variable (empty => ordinary redirection).
+  std::string fd_var;
 };
 
 // Command flags (subset of bash's).

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -53,8 +53,8 @@ int effective_source_fd(const Redirect &r) {
 void print_redirects(const std::vector<Redirect> &redirs, std::string &out) {
   for (const Redirect &r : redirs) {
     out += ' ';
-    int sfd = effective_source_fd(r);
-    if (sfd >= 0) out += std::to_string(sfd);
+    if (!r.fd_var.empty()) { out += '{'; out += r.fd_var; out += '}'; }
+    else { int sfd = effective_source_fd(r); if (sfd >= 0) out += std::to_string(sfd); }
     out += op_string(r.op);
     out += r.target.text;
   }
@@ -238,8 +238,8 @@ struct MPrinter {
 
   void print_redir(const Redirect &r) {
     out += ' ';
-    int sfd = effective_source_fd(r);
-    if (sfd >= 0) out += std::to_string(sfd);
+    if (!r.fd_var.empty()) { out += '{'; out += r.fd_var; out += '}'; }
+    else { int sfd = effective_source_fd(r); if (sfd >= 0) out += std::to_string(sfd); }
     switch (r.op) {
       case RedirOp::HereDoc: out += "<<"; out += r.target.text; return;
       case RedirOp::HereDocStrip: out += "<<-"; out += r.target.text; return;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -88,6 +88,72 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
     }
   }
 
+  // `{var}<file' etc.: allocate a fresh high, close-on-exec descriptor, open the
+  // redirection on it, and store its number in the variable.  The descriptor is
+  // recorded as an originally-closed fd so a normal command closes it afterwards
+  // while `exec' (discard_saved_fds) keeps it open.  `{var}>&-' / `{var}<&-'
+  // instead close the descriptor whose number the variable currently holds.
+  if (!r.fd_var.empty()) {
+    auto assign_fd = [&](int f) {
+      int hi = fcntl(f, F_DUPFD_CLOEXEC, 10);
+      if (hi >= 0) { close(f); f = hi; }
+      saved.push_back({f, -1});
+      sh.set(r.fd_var, std::to_string(f));
+      return true;
+    };
+    auto open_var = [&](int flags) -> bool {
+      std::string fn = ex.expand_no_split(r.target.text, true);
+      int f = open(fn.c_str(), flags, 0666);
+      if (f < 0) {
+        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(),
+                     std::strerror(errno));
+        return false;
+      }
+      return assign_fd(f);
+    };
+    switch (r.op) {
+      case RedirOp::InputRedir:   return open_var(O_RDONLY);
+      case RedirOp::OutputRedir:
+      case RedirOp::Clobber:      return open_var(O_WRONLY | O_CREAT | O_TRUNC);
+      case RedirOp::AppendOutput: return open_var(O_WRONLY | O_CREAT | O_APPEND);
+      case RedirOp::InputOutput:  return open_var(O_RDWR | O_CREAT);
+      case RedirOp::DupOutput:
+      case RedirOp::DupInput: {
+        std::string w = ex.expand_no_split(r.target.text);
+        if (w == "-") {  // close the descriptor the variable names
+          std::string cur = sh.get(r.fd_var);
+          if (!cur.empty()) { int n = std::atoi(cur.c_str()); if (n >= 0) close(n); }
+          return true;
+        }
+        int src = std::atoi(w.c_str());
+        int f = fcntl(src, F_DUPFD_CLOEXEC, 10);
+        if (f < 0) {
+          std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), w.c_str(),
+                       std::strerror(errno));
+          return false;
+        }
+        saved.push_back({f, -1});
+        sh.set(r.fd_var, std::to_string(f));
+        return true;
+      }
+      case RedirOp::HereDoc:
+      case RedirOp::HereDocStrip: {
+        std::string body = r.heredoc_quoted ? r.heredoc_body : ex.expand_heredoc(r.heredoc_body);
+        int f = heredoc_fd(body);
+        if (f < 0) return false;
+        return assign_fd(f);
+      }
+      case RedirOp::HereString: {
+        std::string body = ex.expand_no_split(r.target.text) + "\n";
+        int f = heredoc_fd(body);
+        if (f < 0) return false;
+        return assign_fd(f);
+      }
+      default: break;
+    }
+    return true;
+  }
+
   switch (r.op) {
     case RedirOp::InputRedir: {
       std::string fn = ex.expand_no_split(r.target.text, true);

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -218,8 +218,33 @@ struct Parser {
     }
   }
 
-  bool parse_redirect(std::vector<Redirect> &redirs) {
+  // A redirection *operator* token (not an IoNumber): what may follow a `{var}'
+  // fd-variable specifier or an IoNumber.
+  static bool is_redir_op(Tok t) {
+    switch (t) {
+      case Tok::Less: case Tok::Great: case Tok::DGreat: case Tok::DLess:
+      case Tok::DLessDash: case Tok::TLess: case Tok::LessAnd: case Tok::GreatAnd:
+      case Tok::LessGreat: case Tok::Clobber: case Tok::AndGreat: case Tok::AndDGreat:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // If W is a `{name}' fd-variable specifier (`{fd}>file'), return `name', else
+  // "".  Only a bare identifier in braces qualifies.
+  static std::string fd_var_name(const std::string &w) {
+    if (w.size() < 3 || w.front() != '{' || w.back() != '}') return "";
+    std::string n = w.substr(1, w.size() - 2);
+    if (!(std::isalpha(static_cast<unsigned char>(n[0])) || n[0] == '_')) return "";
+    for (char c : n)
+      if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) return "";
+    return n;
+  }
+
+  bool parse_redirect(std::vector<Redirect> &redirs, const std::string &fd_var = "") {
     Redirect r;
+    r.fd_var = fd_var;
     if (is(Tok::IoNumber)) {
       r.source_fd = std::atoi(cur().text.c_str());
       advance();
@@ -259,8 +284,24 @@ struct Parser {
     return true;
   }
 
+  // An unquoted `{name}' glued to a redirection operator (`{fd}>file'); returns
+  // the variable name via NAME.
+  bool at_var_redirect(std::string &name) {
+    if (cur().type == Tok::Word && !cur().quoted && is_redir_op(peek(1).type) &&
+        !peek(1).preceded_by_blank) {
+      name = fd_var_name(cur().text);
+      return !name.empty();
+    }
+    return false;
+  }
+
   void parse_redirect_list(std::vector<Redirect> &redirs) {
-    while (!err && at_redirect()) parse_redirect(redirs);
+    for (;;) {
+      if (!err && at_redirect()) { parse_redirect(redirs); continue; }
+      std::string fv;
+      if (!err && at_var_redirect(fv)) { advance(); parse_redirect(redirs, fv); continue; }
+      break;
+    }
   }
 
   // -- lists ---------------------------------------------------------------
@@ -464,6 +505,17 @@ struct Parser {
         parse_redirect(sc->redirects);
         got = true;
         continue;
+      }
+      // `{var}<file': an unquoted `{name}' glued to a redirection operator names
+      // the variable that receives the freshly allocated descriptor.
+      {
+        std::string fv;
+        if (at_var_redirect(fv)) {
+          advance();  // consume `{name}'
+          parse_redirect(sc->redirects, fv);
+          got = true;
+          continue;
+        }
       }
       if (cur().type == Tok::Word) {
         int wf = cur().quoted ? W_QUOTED : 0;


### PR DESCRIPTION
Fixes #275.

## Root cause
The `{varname}` file-descriptor redirection form was unsupported — `{fd}` was taken as an ordinary word (`exec {fd}>file` → `exec: {fd}: not found`).

## Implementation
- **AST**: `Redirect.fd_var`.
- **Parser**: recognize an unquoted `{name}` glued to a redirection operator (in both `parse_simple` and `parse_redirect_list`), so a `{name}` before a redirection is the fd-variable specifier rather than a command word.
- **Executor**: `apply_redirect` allocates a fresh high, close-on-exec descriptor, opens the redirection on it, and stores its number in the variable. It is recorded as an originally-closed fd, so a normal command closes it afterwards while `exec` keeps it open (the variable keeps the number). `{var}>&-`/`{var}<&-` close the descriptor the variable currently names.
- **to_string**: `declare -f` reconstruction emits the `{name}` prefix.

Supports `<`, `>`, `>>`, `<>`, `>&N`, `<&N`, `>&-`, `<&-`, and `<<EOF`, on simple and compound commands, with `exec` (permanent) or a command (temporary).

## Verification
- `exec {fd}>file; echo hi >&$fd; exec {fd}>&-; cat file` → `hi`; `{fd}<file` reads; `{fd}<>file`, `{fd}>&1`, heredoc `{v}<<EOF`, group `{ ...; } {fd}<file` — all match bash 5.3; the variable holds an integer ≥ 10.
- Non-glued `{fd} >file`, quoted `"{fd}"`, and brace expansion `{a,b}>file` are unaffected.
- **vredir scoreboard: 125 → 33.**
- Execution differential 234/234; real-script parser corpus 429/429; negative corpus 68/68 (0 leniency).

## Known limitations (the residual vredir diffs)
- bash's exact `cannot assign fd to variable` / `ambiguous redirect` / `Bad file descriptor` error text for unassignable (nameref/readonly) or invalid fd-vars is not reproduced; because those cases now *run* instead of failing to parse, `nameref` ticks up slightly (248 → 258) — a byte-diff artifact, not broken behavior.
- Array-element fd targets (`{fd[0]}<&0`) and bash's specific high-descriptor numbering are not implemented.
