### PR TITLE
Conform redirections: ambiguous redirect + noclobber (batch80)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -324,6 +324,7 @@ class Shell {
   bool opt_verbose = false;   // -v
   bool opt_noexec = false;    // -n: read/parse commands but don't execute them
   bool opt_pipefail = false;  // -o pipefail: pipeline status = last non-zero stage
+  bool opt_noclobber = false; // -C / -o noclobber: `>' won't overwrite an existing file
   bool opt_functrace = false; // -T / -o functrace: DEBUG/RETURN traps inherited
   bool opt_history = false;     // -o history: record command lines in the history
   bool opt_histexpand = false;  // -H / -o histexpand: `!' history expansion

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1279,6 +1279,7 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   else if (o == "noexec") { if (!sh.interactive) sh.opt_noexec = on; }
   else if (o == "functrace" || o == "errtrace") sh.opt_functrace = on;
   else if (o == "pipefail") sh.opt_pipefail = on;
+  else if (o == "noclobber") sh.opt_noclobber = on;
   else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
   else if (o == "histexpand") sh.opt_histexpand = on;
   else if (o == "posix") sh.opt_posix = on;
@@ -1303,7 +1304,7 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   // (a script may set them; erroring would diverge from bash, which knows them).
   else if (o == "allexport" || o == "braceexpand" || o == "hashall" ||
            o == "ignoreeof" || o == "interactive-comments" || o == "nolog" ||
-           o == "notify" || o == "noclobber" || o == "onecmd")
+           o == "notify" || o == "onecmd")
     ;  // no-op
   else return false;
   return true;
@@ -1324,7 +1325,7 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"hashall", true},      {"histexpand", sh.opt_histexpand},
       {"history", sh.opt_history}, {"ignoreeof", false},
       {"interactive-comments", true}, {"keyword", sh.opt_keyword},
-      {"monitor", sh.job_control || sh.opt_monitor}, {"noclobber", false},
+      {"monitor", sh.job_control || sh.opt_monitor}, {"noclobber", sh.opt_noclobber},
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
       {"nolog", false},       {"notify", false},
       {"nounset", sh.opt_nounset}, {"onecmd", false},
@@ -1371,6 +1372,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'E': sh.opt_functrace = on; break;  // errtrace: ERR trap inheritance
           case 'H': sh.opt_histexpand = on; break;  // `!' history expansion
           case 'm': sh.opt_monitor = on; break;     // monitor: job control
+          case 'C': sh.opt_noclobber = on; break;   // noclobber: `>' won't truncate
           case 'p': sh.opt_privileged = on; break;  // privileged mode
           case 'r':  // restricted: can be turned on, never off
             if (on) sh.opt_restricted = true;
@@ -1400,8 +1402,8 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
             break;
           }
           // Flags accepted as no-ops where the behavior is unimplemented:
-          // allexport/notify/hashall/onecmd/braceexpand/noclobber.
-          case 'a': case 'b': case 'h': case 't': case 'B': case 'C': break;
+          // allexport/notify/hashall/onecmd/braceexpand.
+          case 'a': case 'b': case 'h': case 't': case 'B': break;
           default:
             std::fprintf(stderr, "%sset: %c%c: invalid option\n", sh.err_prefix().c_str(),
                          a[0], a[k]);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -59,6 +59,51 @@ void save_fd(int fd, std::vector<SavedFd> &saved) {
   saved.push_back({fd, s});
 }
 
+// Expand a redirection target with the full pipeline (brace, parameter/command/
+// arithmetic substitution, word splitting, and pathname expansion) and require
+// exactly one resulting word, matching bash's redirection_expand (redir.c): a
+// target that expands to zero or more than one word is an `ambiguous redirect'.
+// On ambiguity, prints the diagnostic with the ORIGINAL unexpanded word text and
+// returns false; otherwise stores the single word in `out'.
+static bool expand_redir_target(Shell &sh, const Word &w, std::string &out) {
+  Expander ex(sh);
+  std::vector<std::string> words = ex.expand_args({w});
+  if (words.size() != 1) {
+    std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
+                 w.text.c_str());
+    return false;
+  }
+  out = std::move(words[0]);
+  return true;
+}
+
+// Sentinel from open_redir_output: `set -o noclobber' refused to overwrite an
+// existing regular file.
+static const int kNoclobberRefused = -2;
+
+// Open an output-redirect target for truncation.  When `set -o noclobber' is in
+// effect and this is a clobbering operator (`>' or `&>', not `>|'), refuse to
+// overwrite an existing regular file, mirroring bash's noclobber_open (redir.c):
+// an existing regular file returns kNoclobberRefused; a missing file is created
+// exclusively; a non-regular file (device, fifo, /dev/null) is opened without
+// truncation.  Returns the fd, -1 on a system error (errno set), or
+// kNoclobberRefused.
+static int open_redir_output(Shell &sh, const std::string &fn, bool clobbering) {
+  int flags = O_WRONLY | O_CREAT | O_TRUNC;
+  if (!(sh.opt_noclobber && clobbering))
+    return open(fn.c_str(), flags, 0666);
+  struct stat st;
+  int r = stat(fn.c_str(), &st);
+  if (r == 0 && S_ISREG(st.st_mode)) return kNoclobberRefused;
+  flags &= ~O_TRUNC;  // never truncate under noclobber
+  if (r != 0) {       // did not exist: create it, failing if someone races us
+    int fd = open(fn.c_str(), flags | O_EXCL, 0666);
+    return (fd < 0 && errno == EEXIST) ? kNoclobberRefused : fd;
+  }
+  int fd = open(fn.c_str(), flags, 0666);  // existed, non-regular: append/write
+  return (fd < 0 && errno == EEXIST) ? kNoclobberRefused : fd;
+}
+
 // Apply one redirect in-process; returns false on error.
 bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
   Expander ex(sh);
@@ -102,7 +147,8 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
       return true;
     };
     auto open_var = [&](int flags) -> bool {
-      std::string fn = ex.expand_no_split(r.target.text, true);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), flags, 0666);
       if (f < 0) {
         std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(),
@@ -156,7 +202,8 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
 
   switch (r.op) {
     case RedirOp::InputRedir: {
-      std::string fn = ex.expand_no_split(r.target.text, true);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), O_RDONLY);
       if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 0 : target_fd);
@@ -165,15 +212,23 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
     }
     case RedirOp::OutputRedir:
     case RedirOp::Clobber: {
-      std::string fn = ex.expand_no_split(r.target.text, true);
-      int f = open(fn.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
+      // `>' honors noclobber; `>|' (Clobber) always overrides it.
+      int f = open_redir_output(sh, fn, r.op == RedirOp::OutputRedir);
+      if (f == kNoclobberRefused) {
+        std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
+                     sh.err_prefix().c_str(), fn.c_str());
+        return false;
+      }
       if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 1 : target_fd);
       close(f);
       return true;
     }
     case RedirOp::AppendOutput: {
-      std::string fn = ex.expand_no_split(r.target.text, true);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0666);
       if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 1 : target_fd);
@@ -181,7 +236,8 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
       return true;
     }
     case RedirOp::InputOutput: {
-      std::string fn = ex.expand_no_split(r.target.text, true);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), O_RDWR | O_CREAT, 0666);
       if (f < 0) return false;
       redir_to(f, target_fd < 0 ? 0 : target_fd);
@@ -190,9 +246,19 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
     }
     case RedirOp::AndOutput:
     case RedirOp::AndAppend: {
-      std::string fn = ex.expand_no_split(r.target.text, true);
-      int flags = O_WRONLY | O_CREAT | (r.op == RedirOp::AndAppend ? O_APPEND : O_TRUNC);
-      int f = open(fn.c_str(), flags, 0666);
+      std::string fn;
+      if (!expand_redir_target(sh, r.target, fn)) return false;
+      int f;
+      if (r.op == RedirOp::AndAppend) {
+        f = open(fn.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0666);
+      } else {  // `&>' truncates, so it honors noclobber
+        f = open_redir_output(sh, fn, true);
+        if (f == kNoclobberRefused) {
+          std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
+                       sh.err_prefix().c_str(), fn.c_str());
+          return false;
+        }
+      }
       if (f < 0) return false;
       redir_to(f, 1);
       save_fd(2, saved);
@@ -202,7 +268,10 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
     }
     case RedirOp::DupOutput:
     case RedirOp::DupInput: {
-      std::string w = ex.expand_no_split(r.target.text);
+      // `<&word' / `>&word' likewise reject a word that splits to zero or more
+      // than one field (an unset or multi-word fd, e.g. `<&$unset').
+      std::string w;
+      if (!expand_redir_target(sh, r.target, w)) return false;
       int deffd = (r.op == RedirOp::DupInput) ? 0 : 1;
       int fd = target_fd < 0 ? deffd : target_fd;
       if (w == "-") { save_fd(fd, saved); close(fd); return true; }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -335,6 +335,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_verbose) f += 'v';
     if (sh_.opt_xtrace) f += 'x';
     f += 'B';                       // braceexpand: on by default
+    if (sh_.opt_noclobber) f += 'C';   // noclobber: `>' won't overwrite a file
     if (sh_.opt_histexpand) f += 'H';  // histexpand (set -H; interactive default)
     if (sh_.opt_physical) f += 'P';    // physical: resolve symlinks in cd/pwd
     if (sh_.invocation_char) f += sh_.invocation_char;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -341,6 +341,7 @@ int main(int argc, char **argv) {
         case 'v': sh.opt_verbose = set; break;
         case 'n': sh.opt_noexec = set; break;  // read but don't execute
         case 'r': if (set) sh.opt_restricted = true; break;  // restricted shell
+        case 'C': sh.opt_noclobber = set; break;  // noclobber: `>' won't overwrite
         case 'm': case 'B': case 'h': case 'H':
           break;  // accepted, not (yet) acted on
         // `-c' takes its command from the next word, but other flags grouped in


### PR DESCRIPTION
## Summary

Two coherent redirection-conformance fixes surfaced by `redir.tests` (byte-diff 186 → 178, no regressions elsewhere).

### 1. Ambiguous redirect (closes #277)
A redirection target is expanded (brace, parameter/command/arithmetic substitution, word splitting, pathname expansion) and bash requires the result to be **exactly one word**; zero or multiple words is an `ambiguous redirect`. gnash used `expand_no_split` (joining fields into one literal word), so `z="a b"; cat < $z` opened a file literally named `a b`.

New `expand_redir_target` runs the full pipeline and errors with the **original** unexpanded word text when the result isn't a single word. Applied to every filename redirection (`<`, `>`, `>|`, `>>`, `<>`, `&>`, `&>>`, `{var}<file`) and to the fd-dup operators (`<&word` / `>&word`).

```
$ z="a b"; cat < $z          → gnash: line 1: $z: ambiguous redirect
$ cat < $undefined            → gnash: line 1: $undefined: ambiguous redirect
$ echo hi > {a,b}             → gnash: line 1: {a,b}: ambiguous redirect
$ exec 3<&$unset             → gnash: line 1: $unset: ambiguous redirect
```

### 2. noclobber
`set -o noclobber` / `set -C` / `-C` was recognized but had no effect. Wire `opt_noclobber` through `set`/`set -o`, `$-`, and `$SHELLOPTS`, and honor it when opening a truncating output redirection.

`open_redir_output` mirrors bash's `noclobber_open`: a clobbering redirect (`>`/`&>`, **not** the overriding `>|`) refuses to overwrite an existing regular file (`cannot overwrite existing file`), creates a missing file exclusively, and writes to a non-regular file (device, fifo, /dev/null) without truncating. `>>`, `&>>`, and `<>` are unaffected.

## Testing
- ctest 22/22
- Scoreboard: `redir` 186 → 178, zero regressions across the full test suite
- Verified each case byte-for-byte against source-built bash 5.3