### PR TITLE
Reject local copies of readonly global variables (batch81)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1991,7 +1991,36 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         else sh.vars.erase(name);
       }
     }
-    if (local && !global) sh.make_local(name);
+    if (local && !global) {
+      // bash disallows a local copy of a readonly GLOBAL variable
+      // (make_local_variable in variables.c): `readonly x; f(){ local x=1; }'
+      // errors with the builtin's name and leaves the global value visible.  A
+      // readonly copy of a *calling function's* local is allowed, so reject only
+      // when the readonly binding is global -- i.e. the name is not localized in
+      // any active scope.
+      auto vit = sh.vars.find(name);
+      if (vit != sh.vars.end() && vit->second.readonly) {
+        bool localized = false;
+        for (auto &scope : sh.local_stack) {
+          for (auto &e : scope)
+            if (e.first == name) { localized = true; break; }
+          if (localized) break;
+        }
+        if (!localized) {
+          // A compound (array) value also attempts the array binding, which
+          // reports the readonly violation bare before make_local's prefixed
+          // one, so `local a=(...)' on a readonly global emits both.
+          if (arraylit0)
+            std::fprintf(stderr, "%s%s: readonly variable\n",
+                         sh.err_prefix().c_str(), name.c_str());
+          std::fprintf(stderr, "%s%s: %s: readonly variable\n",
+                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+          ret = 1;
+          continue;
+        }
+      }
+      sh.make_local(name);
+    }
     // An array cannot be switched between indexed and associative in place; bash
     // rejects the redeclaration and leaves the variable unchanged.
     if (mk_array || mk_assoc) {


### PR DESCRIPTION
## Summary

bash's `make_local_variable` (variables.c) refuses to make a function-local shadow of a **readonly global** variable, reporting the error through the builtin and leaving the global value visible. gnash's `make_local` created a fresh local unconditionally, so `readonly v; f(){ local v=1; }` silently shadowed it.

Before localizing, `declare`/`local` now check whether the visible binding is readonly and not localized in any active scope (i.e. it's the global); if so, print `<builtin>: NAME: readonly variable` and skip. A readonly copy of a *calling function's* local is still permitted.

```
$ readonly v=out; f(){ local v=in; echo "in: $v"; }; f
gnash: line 1: local: v: readonly variable
in: out
$ readonly v=out; f(){ declare v=in; echo "$v"; }; f
gnash: line 1: declare: v: readonly variable
out
```

A compound (array) value emits the bare array-binding diagnostic before the prefixed one, matching bash:

```
$ readonly qux=42; f(){ local qux=(one two); echo "$qux"; }; f
gnash: line 1: qux: readonly variable
gnash: line 1: local: qux: readonly variable
42
```

## Testing
- ctest 22/22
- Scoreboard: `varenv` 181 → 175, zero regressions across the full suite
- Verified scalar/no-value/declare/array/nested-local cases byte-for-byte against source-built bash 5.3

Closes #279.