### PR TITLE
Treat declared-but-unassigned variables as unset (batch82)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1991,6 +1991,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         else sh.vars.erase(name);
       }
     }
+    bool fresh_local = false;  // a genuinely new local created by this `local'
     if (local && !global) {
       // bash disallows a local copy of a readonly GLOBAL variable
       // (make_local_variable in variables.c): `readonly x; f(){ local x=1; }'
@@ -2018,6 +2019,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           ret = 1;
           continue;
         }
+      }
+      if (!sh.local_stack.empty()) {
+        fresh_local = true;
+        for (auto &e : sh.local_stack.back())
+          if (e.first == name) { fresh_local = false; break; }  // a re-declaration
       }
       sh.make_local(name);
     }
@@ -2197,7 +2203,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       auto nit = sh.vars.find(name);
       if (nit != sh.vars.end() && nit->second.nameref) aname = sh.deref(name);
     }
+    // A brand-new scalar declared with no value is invisible (unset) until
+    // assigned, matching bash's att_invisible: `declare x' / `local -i n' create
+    // a variable that ${x-word} and `-v' treat as unset.  A `local' makes a fresh
+    // binding (fresh_local); at global scope the var is fresh if it did not
+    // already exist.  Arrays set this in make_array; an existing variable keeps
+    // its current value/visibility.
+    bool fresh_var = fresh_local || sh.vars.find(aname) == sh.vars.end();
     Variable &v = sh.vars[aname];
+    if (fresh_var && eq == std::string::npos && !nameref &&
+        v.kind == VarKind::Scalar)
+      v.invisible = true;
     if (readonly) v.readonly = true;
     if (exported) v.exported = true;
     if (integer) v.integer = true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1005,6 +1005,10 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   // A nameref with no (or a self) target -- deref stops on it -- is unset.
   if (it->second.nameref) return false;
   const Variable &v = it->second;
+  // A declared-but-unassigned (invisible) variable is unset: `declare x' / `local
+  // x' make an att_invisible variable that ${x-default}/${x+...}/-v treat as unset
+  // until it is assigned.
+  if (v.invisible) return false;
   // An array in scalar context is its element 0 (indexed) / "0" (assoc).
   if (v.kind == VarKind::Indexed) {
     if (!v.idx.count(0)) return false;
@@ -1107,6 +1111,7 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
     return false;
   }
   var.value = v;
+  var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
   // Setting POSIXLY_CORRECT (to any value) enables POSIX mode, as in bash.
   if (n == "POSIXLY_CORRECT") opt_posix = true;
   // `declare -u' / `-l' / `-c' fold the value's case on every assignment.
@@ -1139,6 +1144,7 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
   if (var.readonly) return;
   var.value = v;
   var.exported = true;
+  var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
   if (n == "POSIXLY_CORRECT") opt_posix = true;
 }
 


### PR DESCRIPTION
## Summary

bash's `declare NAME` / `local NAME` with no `=value` create an **att_invisible** variable — declared with its attributes but *unset* — so `${NAME-word}`/`${NAME+word}` default and `[[ -v NAME ]]` reports it unset until assigned.

gnash tracked the `invisible` flag only for arrays, and `get_if_set` returned the (empty) value as if the variable were set, so `declare x; echo ${x-DEF}` printed nothing and `${x+SET}` expanded.

This change:
- sets `invisible` on a fresh scalar declared with no value (a genuinely new local — tracked via `fresh_local` so a re-declaration keeps its value — or a new global);
- clears it on assignment (`Shell::set` and `set_exported`);
- reports an invisible variable as unset in `get_if_set` (`is_set` already did).

```
$ declare x; echo "[${x-DEF}]" "[${x+SET}]"; [[ -v x ]] && echo V || echo NOV
[DEF] []
NOV
$ declare -i n; echo "${n-DEF}"; declare -p n
DEF
declare -i n
```

`declare -p` display is intentionally unchanged (an empty scalar still prints without a value, as before) — that avoids a cascade in the deferred nameref suite.

## Testing
- ctest 22/22
- Scoreboard: `varenv` 175 → 167, no regressions (the `read` `-t 0.00001 -e` timeout race is pre-existing — present on the batch81 binary too — not caused by this change)
- Verified scalar/integer/local/assignment/redeclare cases byte-for-byte against bash 5.3

Closes #281.