### PR TITLE
echo escape conformance: xpg_echo + the \0nnn octal rule (batch83)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -50,7 +50,11 @@ std::string join(const std::vector<std::string> &v, size_t from) {
 
 // printf %b: like echo -e but also interprets octal (\nnn, \0nnn) and hex
 // (\xHH) escapes, and \c which stops all further output.
-std::string decode_b(const std::string &s, bool &stop) {
+// Decode backslash escapes (\n \t \0nnn \xHH ...).  `bare_octal' controls the
+// `\nnn' form without a leading 0: printf's %b interprets it as octal, but echo
+// (even with -e / xpg_echo) does NOT -- it accepts only `\0nnn', leaving a bare
+// `\1'..'\7' literal (bash echo.def vs printf.def).
+std::string decode_b(const std::string &s, bool &stop, bool bare_octal = true) {
   std::string out;
   stop = false;
   for (size_t i = 0; i < s.size(); i++) {
@@ -88,6 +92,7 @@ std::string decode_b(const std::string &s, bool &stop) {
       }
       case '1': case '2': case '3':
       case '4': case '5': case '6': case '7': {
+        if (!bare_octal) { out += '\\'; out += e; break; }  // echo: only \0nnn
         int v = e - '0', k = 1;
         while (k < 3 && i + 1 < s.size() && s[i + 1] >= '0' && s[i + 1] <= '7') {
           v = v * 8 + (s[++i] - '0');
@@ -123,7 +128,7 @@ int bi_echo(Shell &, const std::vector<std::string> &argv) {
   bool stop = false;
   for (size_t j = i; j < argv.size() && !stop; j++) {
     if (j > i) out += ' ';
-    out += escapes ? decode_b(argv[j], stop) : argv[j];
+    out += escapes ? decode_b(argv[j], stop, /*bare_octal=*/false) : argv[j];
   }
   std::fwrite(out.data(), 1, out.size(), stdout);
   if (newline && !stop) std::fputc('\n', stdout);  // \c suppresses everything after

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -107,11 +107,17 @@ std::string decode_b(const std::string &s, bool &stop, bool bare_octal = true) {
   return out;
 }
 
-int bi_echo(Shell &, const std::vector<std::string> &argv) {
+int bi_echo(Shell &sh, const std::vector<std::string> &argv) {
   size_t i = 1;
-  bool newline = true, escapes = false;
+  // `shopt -s xpg_echo' makes echo interpret backslash escapes by default
+  // (bash echo.def: do_v9 = xpg_echo), as if `-e' were always given.
+  bool xpg = sh.shopt_opts.count("xpg_echo") && sh.shopt_opts.at("xpg_echo");
+  bool newline = true, escapes = xpg;
+  // In POSIX mode with xpg_echo, echo takes no options at all -- `-n'/`-e'/`-E'
+  // are printed literally (bash: `posixly_correct && xpg_echo' skips parsing).
+  bool parse_opts = !(sh.opt_posix && xpg);
   // Leading options; combined flags like -ne are accepted.
-  for (; i < argv.size(); i++) {
+  for (; parse_opts && i < argv.size(); i++) {
     const std::string &a = argv[i];
     if (a.size() < 2 || a[0] != '-') break;
     bool all_flags = true;


### PR DESCRIPTION
## Summary

Two related `echo` escape-handling fixes surfaced by `builtins2.sub` (`builtins` byte-diff 179 → 172, no regressions).

### 1. echo octal is `\0nnn`, not a bare `\nnn`
bash's `echo` (with `-e`, and with `xpg_echo`) accepts only the `\0nnn` octal escape; a bare `\1`..`\7` stays literal — unlike `printf %b`, which interprets `\nnn`. gnash's shared `decode_b` interpreted the bare form in both, so `echo -e "\101"` printed `A` instead of literal `\101`. Added a `bare_octal` parameter (default true, preserving `printf %b`) and pass false from `echo`.

### 2. honor the xpg_echo shopt
`shopt -s xpg_echo` now makes `echo` interpret backslash escapes by default (as if `-e`), matching bash (`do_v9 = xpg_echo`). In POSIX mode with xpg_echo, option parsing is skipped entirely so `-n`/`-e`/`-E` print literally (bash's `posixly_correct && xpg_echo` short-circuit). gnash previously recognized the shopt name but ignored it.

```
$ shopt -s xpg_echo; echo 'a\tb'      →  a<TAB>b
$ echo -e '\101 \0101'               →  \101 A
$ printf '%b\n' '\101'               →  A
```

## Testing
- ctest 22/22
- Scoreboard: `builtins` 179 → 172, zero regressions across the full suite
- `builtins2.sub` now matches bash byte-for-byte; verified octal/hex/xpg/posix cases against bash 5.3

Closes #283.