### PR TITLE
Evaluate declare -ai/-Ai array-literal elements arithmetically (batch85)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2062,6 +2062,13 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // A subscripted name implies an indexed array even without `-a'
     // (`declare -r c[100]' creates an empty readonly array c).
     else if (subscript0) sh.make_array(name, false);
+    // bash applies declared attributes before the assignment, so a `declare -i'
+    // array/associative literal (`declare -ai a=(1+1 2*3)') evaluates each
+    // element arithmetically.  apply_array_assign reads the integer attribute
+    // from the variable, so set it now rather than after the assignment (the
+    // scalar path already honors the -i flag directly).
+    if (integer && eq != std::string::npos && !name.empty() && !nameref)
+      sh.vars[name].integer = true;
     if (eq != std::string::npos) {
       std::string val = a.substr(eq + 1);
       bool arraylit = val.size() >= 2 && val.front() == '(' && val.back() == ')';


### PR DESCRIPTION
## Summary

`declare`'s `-i` attribute was applied *after* the value was assigned, so an integer array or associative literal stored its elements literally instead of evaluating them:

```
$ declare -ai a=(1+1 2*3); declare -p a
declare -ai a=([0]="1+1" [1]="2*3")     # was (gnash)
declare -ai a=([0]="2" [1]="6")         # now (matches bash)
```

`apply_array_assign` already evaluates elements when the target variable has the integer attribute, but `bi_declare` ran the array-literal assignment before applying `-i`, so the check saw a non-integer variable. Single-element (`a[0]=3+4`) and `+=` assignments already worked because they pass the flag directly.

Fix: set the integer attribute on the target before running an array/associative literal assignment (the scalar path already honors the `-i` flag directly).

## Testing
- ctest 22/22
- Scoreboard: `array` 237 → 225, zero regressions across the full suite
- Verified indexed/associative/out-of-order/`+=`/non-integer-control cases against bash 5.3

Closes #287.