### PR TITLE
POSIX-mode readonly/export listings use the builtin name (batch86)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1210,20 +1210,33 @@ std::string declare_sub_quote(const std::string &k) {
 }
 
 // `declare -p NAME': the attribute flags plus the reproducible assignment.
-void declare_print_var(const std::string &name, const Variable &v) {
+// `cmd' is the invoking builtin; in POSIX mode `readonly'/`export' list with
+// their own name and only the array-type attribute (bash show_var_attributes /
+// var_attribute_string, setattr.def), dropping the implied readonly/exported
+// flag and i/n/t/c/l/u.  Otherwise (declare, or non-POSIX) `declare -flags' is
+// used.
+void declare_print_var(const std::string &name, const Variable &v,
+                       const std::string &cmd = "declare", bool posix = false) {
+  bool posix_cmd = posix && (cmd == "readonly" || cmd == "export");
   // Attribute letters in bash's fixed order (var_attribute_string):
   // a A f i n r t x c l u.  gnash models the subset a A i n r x l u.
   std::string f;
   if (v.kind == VarKind::Indexed) f += 'a';
   if (v.kind == VarKind::Assoc) f += 'A';
-  if (v.integer) f += 'i';
-  if (v.nameref) f += 'n';
-  if (v.readonly) f += 'r';
-  if (v.exported) f += 'x';
-  if (v.capcase) f += 'c';
-  if (v.lcase) f += 'l';
-  if (v.ucase) f += 'u';
-  std::string decl = "declare -" + (f.empty() ? std::string("-") : f);
+  if (!posix_cmd) {  // POSIX readonly/export keep only the array-type attribute
+    if (v.integer) f += 'i';
+    if (v.nameref) f += 'n';
+    if (v.readonly) f += 'r';
+    if (v.exported) f += 'x';
+    if (v.capcase) f += 'c';
+    if (v.lcase) f += 'l';
+    if (v.ucase) f += 'u';
+  }
+  std::string decl;
+  if (posix_cmd)
+    decl = f.empty() ? cmd : cmd + " -" + f;
+  else
+    decl = "declare -" + (f.empty() ? std::string("-") : f);
   decl += ' ' + name;
   if (v.invisible) {
     // Declared with no value (`declare -a b'): bash prints just the attributes
@@ -1826,7 +1839,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             if (std::find(seen.begin(), seen.end(), pr.first) != seen.end()) continue;
             seen.push_back(pr.first);
             auto it = sh.vars.find(pr.first);
-            if (it != sh.vars.end()) declare_print_var(pr.first, it->second);
+            if (it != sh.vars.end()) declare_print_var(pr.first, it->second, argv[0], sh.opt_posix);
           }
         }
       } else {
@@ -1846,7 +1859,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           if (lcase && !v.lcase) continue;
           if (ucase && !v.ucase) continue;
           if (capcase && !v.capcase) continue;
-          declare_print_var(kv.first, v);
+          declare_print_var(kv.first, v, argv[0], sh.opt_posix);
         }
       }
     } else {
@@ -1857,7 +1870,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
                        argv[0].c_str(), argv[i].c_str());
           st = 1;
         } else {
-          declare_print_var(argv[i], it->second);
+          declare_print_var(argv[i], it->second, argv[0], sh.opt_posix);
         }
       }
     }
@@ -1937,7 +1950,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       if (lcase && !v.lcase) continue;
       if (ucase && !v.ucase) continue;
       if (capcase && !v.capcase) continue;
-      declare_print_var(kv.first, v);
+      declare_print_var(kv.first, v, argv[0], sh.opt_posix);
     }
     return 0;
   }


### PR DESCRIPTION
## Summary

In POSIX mode, `readonly` and `export` list variables with their own name as the prefix and only the array-type attribute — the implied readonly/exported flag and `i`/`n`/`t`/`c`/`l`/`u` are dropped (bash `show_var_attributes` / `var_attribute_string`, setattr.def):

```
$ set -o posix; readonly x=5; readonly -a a=(1 2); declare -i n=7; readonly n; readonly -p
readonly -a a=([0]="1" [1]="2")
readonly n="7"
readonly x="5"
```

gnash always printed `declare -ar a=...` / `declare -r x="5"` regardless of POSIX mode. Added a `cmd`/`posix` pair to `declare_print_var`; `declare`/`typeset`/`local` and all non-POSIX listings are unchanged.

## Testing
- ctest 22/22
- Scoreboard: `array` 225 → 221, zero regressions across the full suite
- Verified scalar/integer/array/assoc and non-POSIX control cases against bash 5.3

Closes #289.