### PR TITLE
Match quoted glob chars literally in [[ == ]] patterns (batch87)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5239,6 +5239,13 @@ struct CondEval {
     Expander ex(sh);
     return ex.expand_no_split(s);
   }
+  // A `=='/`!=' right-hand side is a pattern: quoted/backslash-escaped glob
+  // metacharacters must match literally (bash quotes them before matching), so
+  // expand it like a case pattern rather than removing the quotes.
+  std::string expand_pat(const std::string &s) {
+    Expander ex(sh);
+    return ex.expand_pattern(s);
+  }
 
   bool or_expr() {
     bool v = and_expr();
@@ -5314,12 +5321,12 @@ struct CondEval {
         std::string rhs_raw = at_end() ? "" : t[i].text;
         if (!at_end()) i++;
         if (op == "==" || op == "=") {
-          std::string pat = expand(rhs_raw);
+          std::string pat = expand_pat(rhs_raw);
           std::string p = pat, l = lhs;
           return strmatch(p.data(), l.data(), FNM_EXTMATCH) == 0;
         }
         if (op == "!=") {
-          std::string pat = expand(rhs_raw);
+          std::string pat = expand_pat(rhs_raw);
           std::string p = pat, l = lhs;
           return strmatch(p.data(), l.data(), FNM_EXTMATCH) != 0;
         }


### PR DESCRIPTION
## Summary

The right-hand side of `[[ word == pattern ]]` (and `!=`) is a pattern in which a quoted or backslash-escaped glob metacharacter matches *literally*, but `CondEval` expanded it with `expand_no_split` (quote removal), so the protecting quotes were stripped before `strmatch`:

```
$ [[ abc == a\* ]]; echo $?      # was 0 (matched)  → now 1
$ [[ ab == a"*" ]]; echo $?      # was 0            → now 1
$ [[ axb == a"*"b ]]; echo $?    # was 0            → now 1
```

Fix: expand the `==`/`!=` right-hand side with `expand_pattern` (which backslash-escapes quoted glob chars while leaving unquoted ones active) — the same expansion the `case` statement already uses. Active (unquoted) globs still match.

## Testing
- ctest 22/22
- Scoreboard: `cond` 79 → 75, `comsub2` 37 → 35 (bonus), zero regressions
- Verified quoted/escaped vs active glob (`*`/`?`), `==`/`!=`, and literal cases against bash 5.3

Closes #291.