### PR TITLE
jobs listing format + subshell spacing (batch88)

### DIFF
--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -94,9 +94,10 @@ void Connection::print(std::string &out) const {
 
 void Subshell::print(std::string &out) const {
   invert_prefix(this, out);
-  out += "(";
+  // bash renders a subshell with inner spaces: `( list )'.
+  out += "( ";
   if (body) body->print(out);
-  out += ")";
+  out += " )";
   print_redirects(redirects, out);
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -233,9 +233,17 @@ void Shell::reap_jobs(bool notify) {
 
 void Shell::print_jobs() {
   reap_jobs(false);
+  // bash marks the current job `+' and the previous job `-' (others a space);
+  // approximate with the two most recently started jobs (the last two entries).
+  int cur = jobs.empty() ? -1 : jobs.back().id;
+  int prev = jobs.size() >= 2 ? jobs[jobs.size() - 2].id : -1;
   for (const Job &j : jobs) {
     const char *state = j.done ? "Done" : (j.stopped ? "Stopped" : "Running");
-    std::printf("[%d]%c  %-22s %s\n", j.id, '+', state, j.command.c_str());
+    char mark = j.id == cur ? '+' : j.id == prev ? '-' : ' ';
+    // A running background job is shown with a trailing ` &' (bash: RUNNING &&
+    // not foreground); the status field is padded to LONGEST_SIGNAL_DESC (27).
+    const char *amp = (j.background && !j.done && !j.stopped) ? " &" : "";
+    std::printf("[%d]%c  %-27s%s%s\n", j.id, mark, state, j.command.c_str(), amp);
   }
 }
 


### PR DESCRIPTION
## Summary

Two related formatting fixes (`jobs` 83 → 67, `comsub2` 35 → 27, zero regressions).

### 1. jobs listing format
The `jobs` listing diverged from bash in three ways:
- the status field was padded to 22 columns instead of bash's 27 (`LONGEST_SIGNAL_DESC`);
- every job was marked `+` instead of `+` for the current job, `-` for the previous, and a space otherwise;
- a running background job was missing its trailing ` &`.

Now pads the status to 27, marks the two most recently started jobs `+`/`-` (an approximation of bash's current/previous job), and appends ` &` to a running background job.

### 2. subshell spacing
The single-line AST printer emitted `(list)` without the spaces bash uses. Emit `( list )` to match bash's deparser (the multi-line function pretty-printer already spaced it). This also fixed subshells inside command substitutions, hence the `comsub2` improvement.

```
[1]   Running                    sleep 5 &
[2]-  Running                    sleep 5 &
[3]+  Running                    ( sleep 2; exit 4 ) &
```

## Testing
- ctest 22/22
- Scoreboard: `jobs` 83 → 67, `comsub2` 35 → 27, zero regressions across the full suite
- Verified listing width/markers/` &` and subshell rendering (jobs, declare -f, type, trap) against bash 5.3

Closes #293.