### PR TITLE
testsuite batch89: assigned-empty vs unset variables

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1260,7 +1260,10 @@ void declare_print_var(const std::string &name, const Variable &v,
     }
     // bash prints a space before the closing paren for a non-empty assoc.
     decl += first ? ")" : " )";
-  } else if (!v.value.empty() || v.integer) {
+  } else {
+    // A visible scalar always prints `=value', even when the value is empty
+    // (`foo=""' / `export baz=' -> `declare -x foo=""'); the unset/invisible
+    // case (`declare x' / `export bar') is handled by the branch above.
     decl += "=" + declare_quote(v.value);
   }
   std::printf("%s\n", decl.c_str());
@@ -2242,9 +2245,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // its current value/visibility.
     bool fresh_var = fresh_local || sh.vars.find(aname) == sh.vars.end();
     Variable &v = sh.vars[aname];
-    if (fresh_var && eq == std::string::npos && !nameref &&
-        v.kind == VarKind::Scalar)
-      v.invisible = true;
+    if (fresh_var && eq == std::string::npos && v.kind == VarKind::Scalar)
+      v.invisible = true;  // includes a targetless `declare -n foo' (unset nameref)
     if (readonly) v.readonly = true;
     if (exported) v.exported = true;
     if (integer) v.integer = true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1148,7 +1148,16 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
   if (n == "POSIXLY_CORRECT") opt_posix = true;
 }
 
-void Shell::export_name(const std::string &n) { vars[n].exported = true; }
+void Shell::export_name(const std::string &n) {
+  // `export NAME' with no value marks NAME for export but does not give it a
+  // value: a previously-unset variable stays unset (bash's att_invisible), so
+  // `${NAME+set}' is empty and `declare -p NAME' prints just `declare -x NAME'
+  // (no `=').  An existing variable keeps its value and visibility.
+  bool fresh = vars.find(n) == vars.end();
+  Variable &var = vars[n];
+  var.exported = true;
+  if (fresh) var.invisible = true;
+}
 
 void Shell::unset(const std::string &n_in, bool force, bool noref) {
   if (n_in == "HISTSIZE" && history_loaded) unstifle_history();

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -78,7 +78,7 @@ int main() {
   ok("echo hi >> log", "echo hi >>log");
 
   // compound commands
-  ok("( a; b )", "(a; b)");
+  ok("( a; b )", "( a; b )");
   ok("{ a; b; }", "{ a; b; }");
   ok("if a; then b; fi", "if a; then b; fi");
   ok("if a; then b; else c; fi", "if a; then b; else c; fi");
@@ -107,7 +107,7 @@ int main() {
   // glued operator like `<' (which the lexer splits) is re-glued, not spaced.
   ok("for ((i=0; i<10; i++)); do echo $i; done", "for ((i=0; i<10; i++)); do echo $i; done");
   // `((cmd); cmd)` is not arithmetic -> falls back to nested subshells
-  ok("(( echo hi ); echo bye )", "((echo hi); echo bye)");
+  ok("(( echo hi ); echo bye )", "( ( echo hi ); echo bye )");
 
   // select, coproc, array assignment
   ok("select x in a b; do echo $x; done", "select x in a b; do echo $x; done");


### PR DESCRIPTION
Fixes #295.

## Summary
bash distinguishes a variable that has been **assigned** a value (even the empty string) from one merely declared/exported without a value (`att_invisible`). gnash conflated them because its `value` is a `std::string` that cannot be null, and the empty-string check stood in for "no value".

- **`declare_print_var`** — a *visible* scalar always prints `=value`, even when empty (`foo=""` → `declare -x foo=""`). The unset case is still handled by the `invisible` branch.
- **`Shell::export_name`** — `export NAME` on a fresh variable now marks it exported **and invisible**, so it stays unset (`${NAME+X}` is empty) until assigned, matching bash.
- **`bi_declare`** — a targetless `declare -n foo` (unset nameref) is now marked invisible too, so it prints `declare -n foo`, not `declare -n foo=""`.

Second commit updates `parser_test` for the spaced subshell rendering introduced in eb89153 (batch88), which had left the unit test failing on HEAD.

## Results
| file | before | after |
|------|-------:|------:|
| builtins | 172 | 170 |
| varenv | 167 | 165 |
| nameref | 258 | 256 |

Zero regressions across the full scoreboard. `ctest` 22/22 (was 21/22 on HEAD — parser_test now fixed), `run_diff` all 234 scripts match.