### PR TITLE
testsuite batch90: unquoted ${a[@]OP} drops elements the operator makes empty

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1021,13 +1021,30 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             if (k) for (char c : j) { out += c; mask += '1'; }
             for (char c : items[k]) { out += c; mask += '1'; }
           }
-        } else {
-          char m = (asel == '@' && dq) ? '1' : '0';
-          if (asel == '@' && dq) absorb_qnull();
+        } else if (asel == '@' && dq) {
+          absorb_qnull();
           for (size_t k = 0; k < items.size(); k++) {
             if (k) { out += FIELD_SEP; mask += MMARK; }
-            if (asel == '@' && dq) { out += QNULL; mask += MMARK; }  // keep empty element
-            for (char c : items[k]) { out += c; mask += m; }
+            out += QNULL; mask += MMARK;  // keep empty element as a field
+            for (char c : items[k]) { out += c; mask += '1'; }
+          }
+        } else if (asel == '*') {
+          // Unquoted ${a[*]OP}: join with the first IFS char, left splittable.
+          std::string is = sh_.ifs();
+          std::string j = is.empty() ? std::string() : std::string(1, is[0]);
+          for (size_t k = 0; k < items.size(); k++) {
+            if (k) for (char c : j) { out += c; mask += '0'; }
+            for (char c : items[k]) { out += c; mask += '0'; }
+          }
+        } else {
+          // Unquoted ${a[@]OP}: an element the operator makes empty produces no
+          // word (it splits away), so skip it rather than emitting an empty field.
+          bool first = true;
+          for (size_t k = 0; k < items.size(); k++) {
+            if (items[k].empty()) continue;
+            if (!first) { out += FIELD_SEP; mask += MMARK; }
+            first = false;
+            for (char c : items[k]) { out += c; mask += '0'; }
           }
         }
         i = end + 1;


### PR DESCRIPTION
## Summary
An unquoted `${a[@]OP}` expansion (per-element operator: `##`/`%%`/pattern substitution/etc.) that reduces an element to empty must drop that element — it splits away — like a plain unquoted `${a[@]}` empty element (batch49). gnash instead emitted a spurious empty field.

## Fix
Restructured the per-element OP path in `expand.cpp` to mirror the proven plain-array path:
- quoted `"@"`: keep empty elements (QNULL)
- unquoted `*`: join with first IFS char (splittable)
- unquoted `@`: skip empty elements

## Scoreboard
- `array` 221 → **209** (−12)
- `assoc` 94 → **88** (−6)
- `exp` 46 → **44** (−2 bonus)

## Verification
- ctest 22/22
- run_diff: all 234 scripts match bash
- Broad rescan (nameref/varenv/posixexp/quotearray/more-exp/quote/builtins/glob/dstack/attr): no regressions

Closes #297