### PR TITLE
testsuite batch94: declare/unalias/exec/hash/unset diagnostics + ${a[@]@A}

### DIFF
--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -29,6 +29,14 @@ std::vector<std::string> command_completions(Shell &sh, const std::string &prefi
 // Called at startup so $BASHOPTS reflects the defaults before any `shopt' runs.
 void shopt_seed(Shell &sh);
 
+// The `declare -p'-form string that recreates variable V named NAME (e.g.
+// "declare -A a=([k]=\"v\" )"), without a trailing newline.  CMD selects the
+// builtin personality for POSIX readonly/export output.  Shared with the
+// ${var@A} parameter transformation so both render identically.
+std::string declare_var_string(const std::string &name, const Variable &v,
+                               const std::string &cmd = "declare",
+                               bool posix = false);
+
 }  // namespace gnash::core
 
 #endif  // GNASH_CORE_BUILTINS_HPP

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -344,6 +344,7 @@ class Shell {
   bool opt_vi = false;          // -o vi: vi command-line editing mode
   bool opt_monitor = false;     // -m / -o monitor: job control
   bool opt_privileged = false;  // -p / -o privileged
+  bool opt_hashall = true;      // -h / -o hashall: remember command locations
   // Set when a top-level $((...)) / $[...] arithmetic expansion failed (bad
   // expression or an assignment to a readonly variable); run_simple aborts the
   // current command (bash aborts but the shell continues).

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -109,7 +109,9 @@ class Shell {
   void array_set(const std::string &n, const std::string &sub, const std::string &v);
   // Remove one element of an array (`unset a[2]'); a `@'/`*' subscript unsets
   // the whole array.  A negative index on an indexed array counts from the end.
-  void array_unset(const std::string &n, const std::string &sub);
+  // Returns false when the subscript resolves out of range (a negative index
+  // below the first element) so the caller can report a bad array subscript.
+  bool array_unset(const std::string &n, const std::string &sub);
   int array_count(const std::string &n) const;
   // Under `shopt -s array_expand_once', an already-expanded array subscript is
   // not re-expanded: for an indexed array it is evaluated strictly here, so a

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1118,7 +1118,14 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
         ret = 1;
         continue;
       }
-      sh.array_unset(base, sub);
+      // A negative subscript below the array's first element is rejected
+      // (`unset a[-2]' on an empty or too-short indexed array); bash names just
+      // the bracketed subscript, not the array.
+      if (!sh.array_unset(base, sub)) {
+        std::fprintf(stderr, "%sunset: [%s]: bad array subscript\n",
+                     sh.err_prefix().c_str(), sub.c_str());
+        ret = 1;
+      }
       continue;
     }
     // A readonly variable cannot be unset.  Resolve through a nameref (unless

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1224,6 +1224,15 @@ std::string declare_sub_quote(const std::string &k) {
 // used.
 void declare_print_var(const std::string &name, const Variable &v,
                        const std::string &cmd = "declare", bool posix = false) {
+  std::printf("%s\n", declare_var_string(name, v, cmd, posix).c_str());
+}
+
+}  // anon namespace (reopened after the exported string builder below)
+
+// Build the `declare -p'-form string for V without a trailing newline; shared
+// by declare_print_var and the ${var@A} transform (see builtins.hpp).
+std::string declare_var_string(const std::string &name, const Variable &v,
+                               const std::string &cmd, bool posix) {
   bool posix_cmd = posix && (cmd == "readonly" || cmd == "export");
   // Attribute letters in bash's fixed order (var_attribute_string):
   // a A f i n r t x c l u.  gnash models the subset a A i n r x l u.
@@ -1273,8 +1282,10 @@ void declare_print_var(const std::string &name, const Variable &v,
     // case (`declare x' / `export bar') is handled by the branch above.
     decl += "=" + declare_quote(v.value);
   }
-  std::printf("%s\n", decl.c_str());
+  return decl;
 }
+
+namespace {  // reopen the anonymous namespace
 
 void set_print_var(const std::string &name, const Variable &v) {
   if (v.kind == VarKind::Indexed) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1327,9 +1327,10 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   }
   else if (o == "monitor") sh.opt_monitor = on;
   else if (o == "privileged") sh.opt_privileged = on;
+  else if (o == "hashall") sh.opt_hashall = on;
   // Valid bash `set -o' names whose behavior is unimplemented: accept as no-ops
   // (a script may set them; erroring would diverge from bash, which knows them).
-  else if (o == "allexport" || o == "braceexpand" || o == "hashall" ||
+  else if (o == "allexport" || o == "braceexpand" ||
            o == "ignoreeof" || o == "interactive-comments" || o == "nolog" ||
            o == "notify" || o == "onecmd")
     ;  // no-op
@@ -1349,7 +1350,7 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"emacs", i ? (rl_editing_mode == 1) : sh.opt_emacs},
       {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
-      {"hashall", true},      {"histexpand", sh.opt_histexpand},
+      {"hashall", sh.opt_hashall}, {"histexpand", sh.opt_histexpand},
       {"history", sh.opt_history}, {"ignoreeof", false},
       {"interactive-comments", true}, {"keyword", sh.opt_keyword},
       {"monitor", sh.job_control || sh.opt_monitor}, {"noclobber", sh.opt_noclobber},
@@ -1428,9 +1429,10 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
             k = a.size();  // -o consumes the rest of the word
             break;
           }
+          case 'h': sh.opt_hashall = on; break;  // -h/+h: hashall
           // Flags accepted as no-ops where the behavior is unimplemented:
-          // allexport/notify/hashall/onecmd/braceexpand.
-          case 'a': case 'b': case 'h': case 't': case 'B': break;
+          // allexport/notify/onecmd/braceexpand.
+          case 'a': case 'b': case 't': case 'B': break;
           default:
             std::fprintf(stderr, "%sset: %c%c: invalid option\n", sh.err_prefix().c_str(),
                          a[0], a[k]);
@@ -3303,6 +3305,13 @@ int bi_logout(Shell &sh, const std::vector<std::string> &argv) {
 }
 
 int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
+  // With `set +o hashall' (`set +h') the hash table is unavailable: every form
+  // of `hash' -- listing, adding, `-r', or an invalid option -- fails before
+  // any processing (hash.def checks hashing_enabled first).
+  if (!sh.opt_hashall) {
+    std::fprintf(stderr, "%shash: hashing disabled\n", sh.err_prefix().c_str());
+    return 1;
+  }
   bool list_l = false, del_d = false, print_t = false, expunge = false;
   std::string ppath;
   size_t i = 1;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1758,6 +1758,8 @@ std::vector<std::string> builtin_names_sorted() {
   return v;
 }
 
+static bool valid_identifier(const std::string &s);
+
 // Shared logic for declare/local/readonly/typeset.
 int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local, bool force_ro) {
   bool mk_array = false, mk_assoc = false, integer = false, readonly = force_ro;
@@ -1917,6 +1919,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       return 0;
     }
     for (; i < argv.size(); i++) {
+      // `-f'/`-F' cannot create functions: an argument carrying an assignment
+      // (`declare -f name=value') is rejected outright and stops processing,
+      // always naming `-f' in the diagnostic even under `-F' (declare.def).
+      if (argv[i].find('=') != std::string::npos) {
+        std::fprintf(stderr, "%s%s: cannot use `-f' to make functions\n",
+                     sh.err_prefix().c_str(), argv[0].c_str());
+        return 1;
+      }
       auto it = sh.functions.find(argv[i]);
       if (it == sh.functions.end()) {
         // `declare -fp NAME' (the -p form) reports a missing function; the bare
@@ -1990,6 +2000,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (subscript0 && nameref) {
       std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
       std::fprintf(stderr, "%s%s: %s: reference variable cannot be an array\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+      ret = 1;
+      continue;
+    }
+    // The name must be a valid identifier (a `[subscript]' was stripped from
+    // `name' above and is allowed).  `declare /bin/sh', or a stray `-z' left
+    // as an operand after `--', is rejected; the offending name is reported
+    // and skipped while the remaining arguments are still processed.  `local -'
+    // is the one exception: for `local' a bare `-' is the special save-options
+    // operand (bash), not an identifier, so it is not rejected here.
+    if (!valid_identifier(name) && !(local && a == "-")) {
+      std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
+      std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
                    sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
       ret = 1;
       continue;
@@ -2225,7 +2248,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           if (!sh.in_function()) sh.vars.erase(name);
           continue;
         }
-        sh.set(name, val);
+        // declare/typeset/local report a readonly-assignment failure with the
+        // builtin name prefixed (bind_variable in declare.def), where a plain
+        // `name=val' -- and readonly/export -- print it bare via Shell::set.
+        if (argv[0] == "declare" || argv[0] == "typeset" || argv[0] == "local") {
+          auto rit = sh.vars.find(name);
+          if (rit != sh.vars.end() && rit->second.readonly && !rit->second.nameref) {
+            std::fprintf(stderr, "%s%s: %s: readonly variable\n",
+                         sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+            ret = 1;
+            continue;
+          }
+        }
+        if (!sh.set(name, val)) ret = 1;  // e.g. assignment to a readonly var
       }
     }
     // Applying an attribute to an existing nameref (without a `-n'/`+n' on this
@@ -2284,7 +2319,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // `+X' removes attributes.  Applied after the assignment so `typeset +n
     // foo=other' writes through the still-active nameref to its target before
     // the reference is torn down, matching bash.
-    if (rm_readonly) v.readonly = false;
+    // `+r' cannot clear an existing readonly attribute: bash reports the
+    // variable as readonly and leaves the flag set (declare.def refuses to
+    // turn off att_readonly).  Only declare/typeset/local reach here with a
+    // removable readonly, and they carry the builtin-name prefix.
+    if (rm_readonly) {
+      if (v.readonly) {
+        std::fprintf(stderr, "%s%s: %s: readonly variable\n",
+                     sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+        ret = 1;
+      }
+    }
     if (rm_exported) v.exported = false;
     if (rm_integer) v.integer = false;
     if (rm_nameref) v.nameref = false;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3794,6 +3794,11 @@ int bi_unalias(Shell &sh, const std::vector<std::string> &argv) {
     sh.suffix_aliases.clear();
     return 0;
   }
+  // With neither `-a' nor any name to remove, unalias reports a usage error.
+  if (i >= argv.size()) {
+    std::fprintf(stderr, "unalias: usage: unalias [-a] name [name ...]\n");
+    return 2;
+  }
   int st = 0;
   for (; i < argv.size(); i++) {
     bool removed;
@@ -5171,6 +5176,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     if (bad_opt) {
       std::fprintf(stderr, "%sexec: %s: invalid option\n", sh.err_prefix().c_str(),
                    argv[i].c_str());
+      std::fprintf(stderr, "exec: usage: exec [-cl] [-a name] [command "
+                           "[argument ...]] [redirection ...]\n");
       st = 2;
     } else if (i >= argv.size()) {
       // No command word: `exec' with only options/redirections is a no-op here

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -7,6 +7,7 @@
 // yet covered: arrays (${a[@]}), ${!prefix*}, some locale/case operators; these
 // are follow-ons.
 
+#include "gnash/core/builtins.hpp"
 #include "gnash/core/expand.hpp"
 #include "gnash/core/subscript.hpp"
 
@@ -993,7 +994,28 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       char asel;
       if (array_op_ref(body, aoname, asel, arest)) {
         std::vector<std::string> items;
-        if (arest == "@k" || arest == "@K") {
+        if (arest == "@A") {
+          // Whole-array @A: a single `declare' statement recreating the array,
+          // emitted as its three top-level words (`declare', `-flags',
+          // `name=(...)') -- quoted it stays three words, unquoted the third is
+          // then IFS-split, matching bash.  Reuses declare -p's exact rendering.
+          std::string dn = sh_.deref(aoname);
+          auto vit = sh_.vars.find(dn);
+          if (vit != sh_.vars.end()) {
+            std::string ds = declare_var_string(dn, vit->second, "declare", false);
+            // Split off the leading `declare' and `-flags' words; keep the
+            // `name=(...)' remainder whole (it may contain spaces).
+            size_t s1 = ds.find(' ');
+            size_t s2 = s1 == std::string::npos ? s1 : ds.find(' ', s1 + 1);
+            if (s2 == std::string::npos) {
+              items.push_back(ds);
+            } else {
+              items.push_back(ds.substr(0, s1));
+              items.push_back(ds.substr(s1 + 1, s2 - s1 - 1));
+              items.push_back(ds.substr(s2 + 1));
+            }
+          }
+        } else if (arest == "@k" || arest == "@K") {
           // Key/value transforms.  @k emits the keys interleaved with values as
           // raw words; @K collapses to one "key value ..." string (values, and
           // assoc keys, quoted for re-input).

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -326,7 +326,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     std::string f;
     if (sh_.opt_errexit) f += 'e';
     if (sh_.opt_noglob) f += 'f';
-    f += 'h';                       // hashall: on by default
+    if (sh_.opt_hashall) f += 'h'; // hashall: on by default, dropped by `set +h'
     if (sh_.interactive) f += 'i';  // rc files test `case $- in *i*)'
     if (sh_.opt_keyword) f += 'k';  // keyword: assignments anywhere
     if (sh_.job_control) f += 'm';  // monitor: interactive job control

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -368,7 +368,8 @@ int main(int argc, char **argv) {
         case 'n': sh.opt_noexec = set; break;  // read but don't execute
         case 'r': if (set) sh.opt_restricted = true; break;  // restricted shell
         case 'C': sh.opt_noclobber = set; break;  // noclobber: `>' won't overwrite
-        case 'm': case 'B': case 'h': case 'H':
+        case 'h': sh.opt_hashall = set; break;  // hashall (on by default)
+        case 'm': case 'B': case 'H':
           break;  // accepted, not (yet) acted on
         // `-c' takes its command from the next word, but other flags grouped in
         // the same word still apply -- `-ce cmd' means both `-c' and `-e'.  So

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -703,12 +703,12 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   if (k == 0) v.value = val;
 }
 
-void Shell::array_unset(const std::string &n_in, const std::string &sub) {
+bool Shell::array_unset(const std::string &n_in, const std::string &sub) {
   std::string n = deref(n_in);
   auto it = vars.find(n);
-  if (it == vars.end()) return;  // unsetting an element of a missing array: no-op
+  if (it == vars.end()) return true;  // element of a missing array: no-op
   Variable &v = it->second;
-  if (v.readonly) return;
+  if (v.readonly) return true;
   // `unset a[@]' / `unset a[*]' clears every element but leaves the (now empty)
   // array in place -- bash still reports `declare -a a=()' afterward.
   if (sub == "@" || sub == "*") {
@@ -716,27 +716,28 @@ void Shell::array_unset(const std::string &n_in, const std::string &sub) {
     v.assoc.clear();
     v.assoc_seq.clear();
     v.value.clear();
-    return;
+    return true;
   }
   if (v.kind == VarKind::Assoc) {
     v.assoc.erase(sub);
     v.assoc_seq.erase(std::remove(v.assoc_seq.begin(), v.assoc_seq.end(), sub),
                       v.assoc_seq.end());
-    return;
+    return true;
   }
   bool ok = true;
   long long k = eval_arith(*this, sub, &ok);
-  if (!ok) return;
+  if (!ok) return true;
   // A negative index counts back from the highest assigned index (`a[-1]').
   if (k < 0 && v.kind == VarKind::Indexed && !v.idx.empty())
     k += v.idx.rbegin()->first + 1;
-  if (k < 0) return;  // still out of range: bash reports a bad subscript
+  if (k < 0) return false;  // still out of range: bash reports a bad subscript
   if (v.kind == VarKind::Indexed) {
     v.idx.erase(k);
     if (k == 0) v.value.clear();  // element 0 is mirrored in the scalar field
   } else if (v.kind == VarKind::Scalar && k == 0) {
     vars.erase(it);  // a scalar's only element is itself
   }
+  return true;
 }
 
 bool Shell::array_expand_once_ok(const std::string &base, std::string &sub) {


### PR DESCRIPTION
Batch 94 of bash 5.3 test-suite conformance work, driven by the `errors` test (2nd-largest byte-diff after `intl`). Five independent conformance fixes:

**declare/typeset/local diagnostics** — reject non-identifier operands (`declare /bin/sh`, a `-z` left after `--`) with *not a valid identifier*; reject `-f`/`-F` with an assignment (*cannot use `-f' to make functions*); prefix a readonly-assignment failure with the builtin name and propagate its exit status; refuse `+r` clearing an existing readonly. `local -` stays exempt as bash's save-options operand.

**unalias / exec usage** — bare `unalias` (no name) and `exec` with a bad option now print their usage lines.

**`set +o hashall`** — replaced the no-op with a real `opt_hashall` state wired through `set -h`/`+h`, `set -o hashall`, the `-h` invocation flag, `$SHELLOPTS` and `$-`. `hash` now fails with *hashing disabled* when off; `$-` drops `h`.

**unset bad subscript** — `unset a[-2]` on an empty/too-short indexed array now reports *unset: [SUB]: bad array subscript* (exit 1) instead of silently no-op'ing.

**`${a[@]@A}`** — the whole-array `@A` transform applied the per-element scalar operator (garbage `declare -A a=<value>` per element). Extracted `declare -p`'s formatting into `declare_var_string` and reused it, so `${a[@]@A}` recreates the array and `eval "${a[@]@A}"` round-trips byte for byte.

### Scoreboard impact (byte-diffs vs bash 5.3)
| test | before | after |
|------|-------:|------:|
| errors | 297 | 272 |
| nameref | 256 | 247 |
| exp | 44 | 40 |
| assoc | 88 | 86 |

No regressions in any other test. `ctest` 22/22 and `run_diff` all 234 scripts match bash.