### PR TITLE
testsuite batch96: nameref array-assignment conformance

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -948,6 +948,17 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
       return 1;
     }
   }
+  // A nameref target must resolve to a plain array name: mapfile fills a whole
+  // array and cannot write through a nameref that points at an element
+  // (`declare -n ref=XXX[0]'), which bash rejects as not a valid identifier.
+  {
+    std::string resolved = sh.deref(name);
+    if (resolved.find('[') != std::string::npos) {
+      std::fprintf(stderr, "%smapfile: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), resolved.c_str());
+      return 1;
+    }
+  }
 
   std::string data;
   char buf[4096];
@@ -1573,6 +1584,17 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                  arrayname.c_str());
     return 1;
+  }
+  // `read -a' fills a whole array, so a nameref target must resolve to a plain
+  // array name; one that points at an element (`declare -n ref=XXX[0]') is
+  // rejected as not a valid identifier, as in bash.
+  if (!arrayname.empty()) {
+    std::string resolved = sh.deref(arrayname);
+    if (resolved.find('[') != std::string::npos) {
+      std::fprintf(stderr, "%sread: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), resolved.c_str());
+      return 1;
+    }
   }
   for (const std::string &nm : names)
     if (!valid_read_name(nm)) {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -817,8 +817,26 @@ void Shell::array_assign(
     const std::vector<std::pair<std::optional<std::string>, std::string>> &elems,
     bool append, bool assoc) {
   std::string n = deref(n_in);
+  // A compound assignment through a nameref that points at an array element
+  // (`declare -n ref=XXX[0]; ref+=(...)') has no valid whole-array target: bash
+  // rejects the resolved `XXX[0]' as not a valid identifier and assigns nothing.
+  if (n.find('[') != std::string::npos) {
+    std::fprintf(stderr, "%s`%s': not a valid identifier\n", err_prefix().c_str(),
+                 n.c_str());
+    return;
+  }
   Variable &v = vars[n];
   if (v.readonly) return;
+  // Array-assigning to an unset nameref (deref stopped on the nameref itself)
+  // converts it into a real array and drops the nameref attribute, with bash's
+  // warning (assign_array_var_from_word_list -> make_variable_value).  A nameref
+  // with a valid target resolves to that target above, so this never fires for
+  // it.
+  if (v.nameref) {
+    std::fprintf(stderr, "%swarning: %s: removing nameref attribute\n",
+                 err_prefix().c_str(), n.c_str());
+    v.nameref = false;
+  }
   v.invisible = false;  // even `b=()' makes a declared-but-unset array visible
   if (!append) {
     v.idx.clear();


### PR DESCRIPTION
Batch 96 — the `nameref` test (byte-diffs 247 → 237 vs bash 5.3). Two fixes around how a nameref that resolves to an array element is treated as a whole-array target.

**shell: array-assignment nameref handling**
- A compound assignment through a nameref pointing at an element (`declare -n ref=XXX[0]; ref+=(...)`) has no whole-array target — bash rejects the resolved `XXX[0]` as *not a valid identifier* and assigns nothing. gnash was creating a variable literally named `XXX[0]`.
- Array-assigning to an *unset* nameref (`declare -n r; r=(a b)`) converts it into a real array and drops the nameref attribute with `NAME: removing nameref attribute`. gnash kept the attribute, printing `declare -an r=(...)`.

**builtins: mapfile/read**
- `mapfile ref` / `read -a ref` validated the literal argument but not the nameref target it resolves to, so a nameref at an element made them create a variable literally named `XXX[0]`. Both fill a whole array, so a resolved target carrying a subscript is now rejected as *not a valid identifier*.

### Scoreboard
`nameref` 247 → 237. `ctest` 22/22, `run_diff` all 234 scripts match bash. No regressions (array, assoc, mapfile, read unchanged).

The deeper nameref11/18 clusters (element double-subscript through `declare`/`array_set`, coproc/getopts/exec nameref targets, line-number offsets) remain — they interact through several code paths and are deferred.