### PR TITLE
testsuite batch97: prefix readonly-through-nameref declare error

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2293,9 +2293,12 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // declare/typeset/local report a readonly-assignment failure with the
         // builtin name prefixed (bind_variable in declare.def), where a plain
         // `name=val' -- and readonly/export -- print it bare via Shell::set.
+        // A nameref that resolves to a readonly target is reported against the
+        // name as written (`declare ref=X' -> `declare: ref: readonly variable')
+        // and the readonly target name (`foo0') is not exposed.
         if (argv[0] == "declare" || argv[0] == "typeset" || argv[0] == "local") {
-          auto rit = sh.vars.find(name);
-          if (rit != sh.vars.end() && rit->second.readonly && !rit->second.nameref) {
+          auto rit = sh.vars.find(sh.deref(name));
+          if (rit != sh.vars.end() && rit->second.readonly) {
             std::fprintf(stderr, "%s%s: %s: readonly variable\n",
                          sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
             ret = 1;


### PR DESCRIPTION
Batch 97 — `nameref` test **237 → 235**. Extends batch94's declare readonly-prefix conformance to the nameref case.

declare/typeset/local prefix a readonly-assignment failure with the builtin name, but only did so for a *direct* readonly variable. Assigning through a nameref to a readonly target fell through to `Shell::set` and printed the bare *target* name:

```
declare -r foo0=x; declare -n ref=foo0; declare ref=X
  bash:  declare: ref: readonly variable
  gnash: foo0: readonly variable      # bare, and leaks the target name
```

Now the nameref is resolved for the readonly test but the diagnostic reports the name as written (`ref`), matching bash. This also collapses the readonly empty-nameref case (`typeset -n r; typeset -r r; typeset r=x`) from gnash's bare-line-plus-prefixed-line to the single prefixed message bash prints.

`ctest` 22/22, `run_diff` all 234 scripts match bash. No regressions (varenv, declare unchanged).

The deeper nameref17 remainders (`typeset +n`/`+r` on a readonly nameref, function-scope readonly namerefs) and the quoted-vs-unquoted `declare -n a=(...)` compound-assignment distinction remain — the latter needs parse-time compound-assignment tracking gnash doesn't preserve in a builtin's argv.