### PR TITLE
Keep the zsh menu-completion listing visible while cycling

### DIFF
--- a/libreadline/src/complete.cpp
+++ b/libreadline/src/complete.cpp
@@ -368,6 +368,17 @@ int menu_step(int dir) {
   rl_insert_text((menu_filenames ? quote_filename(pick) : pick).c_str());
   // zsh appends `/' when the chosen completion is a directory.
   if (menu_filenames && completion_is_dir(pick)) rl_insert_text("/");
+  // Keep the candidate listing visible below the input line while cycling, as
+  // zsh does: the read loop erased the previous copy before this keystroke, so
+  // repaint it and drop the cursor back onto the input line for the pending
+  // redisplay.  Without this the list vanishes as soon as cycling begins.
+  FILE *o = rl_outstream ? rl_outstream : stdout;
+  int rows = completion_grid(menu_items, /*print=*/true);
+  if (rows > 0) {
+    std::fprintf(o, "\033[%dA\r", rows + 1);
+    std::fflush(o);
+    menu_below = 1;
+  }
   return 0;
 }
 


### PR DESCRIPTION
Fixes #311.

Under the zsh personality, TAB menu-completion lists the candidates below the input line on the first TAB, then cycles through them. But the listing vanished as soon as cycling started: the read loop erases it (`rl_clear_menu_below`) before every keystroke and the menu-step continuation never repainted it.

Now each menu-step continuation repaints the listing (the read loop has just cleared the previous copy) and drops the cursor back onto the input line for the pending redisplay. The candidate list stays visible below the command line while TAB / Shift-TAB cycle through the matches, matching zsh.

Verified over a pseudo-terminal in `--personality zsh`: typing `ls foo`↹↹↹ against `foobar foobaz fooqux` keeps `foobar  foobaz  fooqux` shown below while the input line cycles `ls foobar` → `ls foobaz` → …. `ctest` 22/22, `run_diff` all 234 scripts match bash; the non-zsh personas (TAB = `rl_complete`) are unaffected.