### PR TITLE
Fix >&file redirect-both regression (ambiguous redirect on /dev/null)

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -311,6 +311,28 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
         valid_fd = false;
       }
       if (!valid_fd) {
+        // A bare `>&word' (no explicit source fd) whose word is a filename
+        // rather than an fd is bash's shorthand for redirecting BOTH stdout and
+        // stderr to that file, equivalent to `&>word'.  With an explicit source
+        // fd (`2>&word') or for input (`<&word') a non-fd word is ambiguous.
+        if (r.op == RedirOp::DupOutput && target_fd < 0 && !w.empty()) {
+          int f = open_redir_output(sh, w, true);  // `>&file' honors noclobber
+          if (f == kNoclobberRefused) {
+            std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
+                         sh.err_prefix().c_str(), w.c_str());
+            return false;
+          }
+          if (f < 0) {
+            std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), w.c_str(),
+                         std::strerror(errno));
+            return false;
+          }
+          redir_to(f, 1);
+          save_fd(2, saved);
+          dup2(f, 2);
+          close(f);
+          return true;
+        }
         std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
                      w.c_str());
         return false;


### PR DESCRIPTION
Fixes #313. Regression from #306.

Batch 95's dup-target validation (`<&word`/`>&word` must be an fd number, else *ambiguous redirect*) also rejected the **bare `>&file`** form, which bash treats as redirecting *both* stdout and stderr to the file (`&>file`). A login shell whose startup files use `>&/dev/null` then failed with `/dev/null: ambiguous redirect`.

Now a bare `>&` (no explicit source fd) with a non-fd word opens the file (honoring noclobber) and dups it onto fd 1 and fd 2, matching bash. `2>&file` (explicit fd) and `<&file` correctly remain ambiguous.

```
echo hi >&/dev/null                       # no output (both streams discarded)
{ echo o; echo e >&2; } >&f; cat f        # o / e     (both captured)
echo hi 2>&/dev/null                       # ambiguous redirect  (unchanged)
cat <&/dev/null                            # ambiguous redirect  (unchanged)
```

`ctest` 22/22, `run_diff` all 234 scripts match bash. The `redir` scoreboard improves further (130 → 122) since the redirect-both form is now correct.