### PR TITLE
testsuite batch98: implement the localvar_inherit shopt

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -144,7 +144,11 @@ class Shell {
   size_t getopt_charidx = 1;
   std::string getopt_curarg;
   int getopt_optind = 0;
-  void make_local(const std::string &n);  // save outer binding, create fresh local
+  // Save the outer binding and create a fresh local.  Returns true when
+  // `shopt -s localvar_inherit' made the local inherit the enclosing value and
+  // attributes instead of starting unset (the caller then skips the usual
+  // declared-but-unset marking).
+  bool make_local(const std::string &n);
   bool in_function() const { return !local_stack.empty(); }
   std::vector<std::vector<std::pair<std::string, std::optional<Variable>>>> local_stack;
   // Per-scope saved getopt state, set when that scope localizes OPTIND.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2084,6 +2084,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       }
     }
     bool fresh_local = false;  // a genuinely new local created by this `local'
+    bool inherited_local = false;  // localvar_inherit copied an enclosing value
     if (local && !global) {
       // bash disallows a local copy of a readonly GLOBAL variable
       // (make_local_variable in variables.c): `readonly x; f(){ local x=1; }'
@@ -2117,7 +2118,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         for (auto &e : sh.local_stack.back())
           if (e.first == name) { fresh_local = false; break; }  // a re-declaration
       }
-      sh.make_local(name);
+      if (sh.make_local(name)) inherited_local = true;
     }
     // An array cannot be switched between indexed and associative in place; bash
     // rejects the redeclaration and leaves the variable unchanged.
@@ -2325,7 +2326,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // its current value/visibility.
     bool fresh_var = fresh_local || sh.vars.find(aname) == sh.vars.end();
     Variable &v = sh.vars[aname];
-    if (fresh_var && eq == std::string::npos && v.kind == VarKind::Scalar)
+    // A localvar_inherit'd local already holds the enclosing value, so it stays
+    // visible; only a genuinely empty fresh scalar is marked declared-but-unset.
+    if (fresh_var && !inherited_local && eq == std::string::npos && v.kind == VarKind::Scalar)
       v.invisible = true;  // includes a targetless `declare -n foo' (unset nameref)
     if (readonly) v.readonly = true;
     if (exported) v.exported = true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -972,14 +972,22 @@ void Shell::pop_scope() {
   }
 }
 
-void Shell::make_local(const std::string &n) {
-  if (local_stack.empty()) return;  // `local' outside a function: no-op scope
+bool Shell::make_local(const std::string &n) {
+  if (local_stack.empty()) return false;  // `local' outside a function: no-op scope
   auto &scope = local_stack.back();
   for (auto &e : scope)
-    if (e.first == n) return;  // already made local in this scope
+    if (e.first == n) return false;  // already made local in this scope
   auto it = vars.find(n);
   scope.emplace_back(n, it == vars.end() ? std::nullopt : std::optional<Variable>(it->second));
-  vars[n] = Variable{};  // fresh empty local
+  // Under `shopt -s localvar_inherit' a fresh local inherits the value and
+  // attributes of the nearest enclosing variable of the same name rather than
+  // starting unset (bash); a later `=value' on the local overrides the value.
+  // The enclosing binding is still live in `vars[n]', so inheriting just means
+  // leaving it in place.  (A readonly enclosing global is rejected before we
+  // reach here, so an inherited copy is always assignable.)
+  auto liv = shopt_opts.find("localvar_inherit");
+  bool inherit = it != vars.end() && liv != shopt_opts.end() && liv->second;
+  if (!inherit) vars[n] = Variable{};  // fresh empty local
   // Localizing OPTIND saves and resets the getopts scan state (bash restores
   // it when the function returns).
   if (n == "OPTIND" && !getopt_scope_saves.empty() && !getopt_scope_saves.back()) {
@@ -988,6 +996,7 @@ void Shell::make_local(const std::string &n) {
     getopt_curarg.clear();
     getopt_optind = 0;
   }
+  return inherit;
 }
 
 bool Shell::get_if_set(const std::string &n_in, std::string &out) const {


### PR DESCRIPTION
Batch 98 — `varenv` test **165 → 140**.

`localvar_inherit` was registered as a shopt but did nothing. With it set, a new local created by `local`/`declare` inside a function now inherits the value **and** attributes of the nearest enclosing variable of the same name, instead of starting unset — matching bash:

```sh
shopt -s localvar_inherit
x=OUT;          f(){ local x; declare -p x; }; f      # declare -- x="OUT"
declare -i x=5; f(){ local x; x=3+3; declare -p x; }  # declare -i x="6"   (integer attr inherited)
declare -a x=(a b); f(){ local x; declare -p x; }     # declare -a x=([0]="a" [1]="b")
declare -i x=5; f(){ local x=10; declare -p x; }      # declare -i x="10"  (value overridden, attr kept)
```

`make_local` leaves the enclosing binding in place (rather than zeroing it) when the shopt is on and reports that it inherited, so the declare path skips its declared-but-unset marking. **With the shopt off — the default — `make_local` behaves exactly as before**, so no other behavior changes.

`ctest` 22/22, `run_diff` all 238 scripts match bash. No regressions (`func`, `builtins` unchanged).