### PR TITLE
testsuite batch99: declare -I flag, IGNOREEOF binding, shopt -o width

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -144,11 +144,12 @@ class Shell {
   size_t getopt_charidx = 1;
   std::string getopt_curarg;
   int getopt_optind = 0;
-  // Save the outer binding and create a fresh local.  Returns true when
-  // `shopt -s localvar_inherit' made the local inherit the enclosing value and
-  // attributes instead of starting unset (the caller then skips the usual
-  // declared-but-unset marking).
-  bool make_local(const std::string &n);
+  // Save the outer binding and create a fresh local.  Returns true when the
+  // local inherited the enclosing value and attributes instead of starting
+  // unset (the caller then skips the usual declared-but-unset marking) --
+  // either because `shopt -s localvar_inherit' is set or because INHERIT_FORCE
+  // (the declare/local `-I' flag) was passed.
+  bool make_local(const std::string &n, bool inherit_force = false);
   bool in_function() const { return !local_stack.empty(); }
   std::vector<std::vector<std::pair<std::string, std::optional<Variable>>>> local_stack;
   // Per-scope saved getopt state, set when that scope localizes OPTIND.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1357,10 +1357,15 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   else if (o == "monitor") sh.opt_monitor = on;
   else if (o == "privileged") sh.opt_privileged = on;
   else if (o == "hashall") sh.opt_hashall = on;
+  // `ignoreeof' is backed by $IGNOREEOF: `set -o ignoreeof' seeds it to 10 and
+  // `set +o' unsets it, while the option's reported state tracks whether the
+  // variable is set (so a direct `IGNOREEOF=n' also turns it on) -- matching
+  // bash's binding.
+  else if (o == "ignoreeof") { if (on) sh.set("IGNOREEOF", "10"); else sh.unset("IGNOREEOF"); }
   // Valid bash `set -o' names whose behavior is unimplemented: accept as no-ops
   // (a script may set them; erroring would diverge from bash, which knows them).
   else if (o == "allexport" || o == "braceexpand" ||
-           o == "ignoreeof" || o == "interactive-comments" || o == "nolog" ||
+           o == "interactive-comments" || o == "nolog" ||
            o == "notify" || o == "onecmd")
     ;  // no-op
   else return false;
@@ -1380,7 +1385,7 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
       {"hashall", sh.opt_hashall}, {"histexpand", sh.opt_histexpand},
-      {"history", sh.opt_history}, {"ignoreeof", false},
+      {"history", sh.opt_history}, {"ignoreeof", sh.is_set("IGNOREEOF")},
       {"interactive-comments", true}, {"keyword", sh.opt_keyword},
       {"monitor", sh.job_control || sh.opt_monitor}, {"noclobber", sh.opt_noclobber},
       {"noexec", sh.opt_noexec}, {"noglob", sh.opt_noglob},
@@ -3540,7 +3545,11 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
       }
       if (set_s || unset_u) set_o_option(sh, n, set_s);
       else if (quiet_q) { if (!cur) st = 1; }
-      else show_o(n, cur);
+      // A named `shopt -o NAME' query prints through the shopt path, which pads
+      // the option name to width 20 -- unlike the `shopt -o'/`set -o' full
+      // listing (width 15).  bash preserves this difference.
+      else if (print_p) std::printf("set %co %s\n", cur ? '-' : '+', n.c_str());
+      else std::printf("%-20s\t%s\n", n.c_str(), cur ? "on" : "off");
     }
     return st;
   }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1810,6 +1810,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   bool capcase = false;               // -c capitalize-first attribute
   bool funcs = false, funcnames = false;  // -f (definitions) / -F (names)
   bool fp = false;                        // -p (display reproducibly)
+  bool force_inherit = false;             // -I: inherit a surrounding value/attrs
   size_t i = 1;
   // `+X' flags remove an attribute rather than adding it (`typeset +n foo').
   bool rm_integer = false, rm_readonly = false, rm_exported = false;
@@ -1857,6 +1858,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           case 'u': (add ? ucase : rm_ucase) = true; break;
           case 'c': (add ? capcase : rm_capcase) = true; break;
           case 'p': fp = true; break;
+          // `-I': inherit the value and attributes of a surrounding variable of
+          // the same name for this local, as `shopt -s localvar_inherit' does
+          // globally.
+          case 'I': force_inherit = true; break;
           default: break;
         }
       }
@@ -2118,7 +2123,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         for (auto &e : sh.local_stack.back())
           if (e.first == name) { fresh_local = false; break; }  // a re-declaration
       }
-      if (sh.make_local(name)) inherited_local = true;
+      if (sh.make_local(name, force_inherit)) inherited_local = true;
     }
     // An array cannot be switched between indexed and associative in place; bash
     // rejects the redeclaration and leaves the variable unchanged.

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -972,21 +972,22 @@ void Shell::pop_scope() {
   }
 }
 
-bool Shell::make_local(const std::string &n) {
+bool Shell::make_local(const std::string &n, bool inherit_force) {
   if (local_stack.empty()) return false;  // `local' outside a function: no-op scope
   auto &scope = local_stack.back();
   for (auto &e : scope)
     if (e.first == n) return false;  // already made local in this scope
   auto it = vars.find(n);
   scope.emplace_back(n, it == vars.end() ? std::nullopt : std::optional<Variable>(it->second));
-  // Under `shopt -s localvar_inherit' a fresh local inherits the value and
-  // attributes of the nearest enclosing variable of the same name rather than
-  // starting unset (bash); a later `=value' on the local overrides the value.
-  // The enclosing binding is still live in `vars[n]', so inheriting just means
-  // leaving it in place.  (A readonly enclosing global is rejected before we
-  // reach here, so an inherited copy is always assignable.)
+  // A fresh local inherits the value and attributes of the nearest enclosing
+  // variable of the same name rather than starting unset when `-I' was given or
+  // `shopt -s localvar_inherit' is set (bash); a later `=value' on the local
+  // overrides the value.  The enclosing binding is still live in `vars[n]', so
+  // inheriting just means leaving it in place.  (A readonly enclosing global is
+  // rejected before we reach here, so an inherited copy is always assignable.)
   auto liv = shopt_opts.find("localvar_inherit");
-  bool inherit = it != vars.end() && liv != shopt_opts.end() && liv->second;
+  bool shopt_on = liv != shopt_opts.end() && liv->second;
+  bool inherit = it != vars.end() && (inherit_force || shopt_on);
   if (!inherit) vars[n] = Variable{};  // fresh empty local
   // Localizing OPTIND saves and resets the getopts scan state (bash restores
   // it when the function returns).


### PR DESCRIPTION
Batch 99 — `varenv` test **140 → 131**. Three fixes.

**`declare`/`local -I` inherit flag** — `-I` was a recognized option letter that did nothing. It now forces a local to inherit the value and attributes of a surrounding same-name variable for that one command (the per-command form of `shopt -s localvar_inherit`, added in batch98):

```sh
x=OUT;          f(){ local -I x; declare -p x; }; f   # declare -- x="OUT"
declare -i x=5; f(){ local -I x; x=2+2; declare -p x; }  # declare -i x="4"
```

**`ignoreeof` ↔ `$IGNOREEOF`** — was an inert no-op; now `set -o ignoreeof` seeds `IGNOREEOF=10`, `set +o ignoreeof` unsets it, and the reported state tracks whether the variable is set (so a direct `IGNOREEOF=n` turns it on too).

**`shopt -o NAME` width** — a named query pads the option name to width 20 (the shopt column), while the `set -o`/`shopt -o` full listing uses 15. bash preserves this per-context difference; gnash used 15 everywhere.

`ctest` 22/22, `run_diff` all 238 scripts match bash, `shopt` still byte-perfect. No regressions.