### PR TITLE
testsuite batch100: temp-env declare -r promotion, scalar-to-array element 0

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2316,7 +2316,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             continue;
           }
         }
-        if (!sh.set(name, val)) ret = 1;  // e.g. assignment to a readonly var
+        // A scalar value assigned to a name that is already an array targets
+        // element 0 (`declare a=0' on an existing array a sets a[0], as a plain
+        // `a=0' does); Shell::set would otherwise write only the scalar shadow,
+        // leaving `declare -p' showing an empty array.
+        std::string atgt = sh.deref(name);
+        auto ait = sh.vars.find(atgt);
+        if (ait != sh.vars.end() && (ait->second.kind == VarKind::Indexed ||
+                                     ait->second.kind == VarKind::Assoc))
+          sh.array_set(atgt, "0", val);
+        else if (!sh.set(name, val))
+          ret = 1;  // e.g. assignment to a readonly var
       }
     }
     // Applying an attribute to an existing nameref (without a `-n'/`+n' on this

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1330,14 +1330,18 @@ int Executor::run_simple(const SimpleCommand *c) {
     undo_temp();
   } else if ((apply_temp(), run_builtin(sh_, argv, &status))) {
     // A preceding `VAR=val builtin' applies to the builtin (e.g. IFS=, read),
-    // then is restored.  Two exceptions keep it permanent: the assignment
-    // builtins `export'/`readonly' (and `declare -x', which exports too) always
-    // do, and in posix mode so do all the POSIX special builtins.
+    // then is restored.  It keeps effect permanently when the builtin makes the
+    // variable readonly or exported: `export'/`readonly' always do, `declare'/
+    // `typeset' when given `-r' (readonly) or `-x' (export) -- a temp-env var so
+    // marked is promoted to a real, still-exported variable (`x=4 declare -r x'
+    // -> `declare -rx x="4"'), where a plain `-i' does not persist.  In posix
+    // mode all the POSIX special builtins persist too.
     builtin = true;
     bool persist = argv[0] == "export" || argv[0] == "readonly";
     if (!persist && (argv[0] == "declare" || argv[0] == "typeset")) {
       for (size_t k = 1; k < argv.size() && argv[k].size() > 1 && argv[k][0] == '-'; k++)
-        if (argv[k].find('x') != std::string::npos) { persist = true; break; }
+        if (argv[k].find('x') != std::string::npos ||
+            argv[k].find('r') != std::string::npos) { persist = true; break; }
     }
     if (!persist && sh_.opt_posix) {
       static const std::set<std::string> kSpecial = {


### PR DESCRIPTION
Batch 100 — `varenv` **131 → 115** and `array` **209 → 195**. Two fixes.

**temp-env `declare -r` promotion** — a `VAR=val declare -r VAR` reverted VAR afterward: the temp-env persist check for declare/typeset looked only for `-x`, so `-r` (which also makes the variable permanent, and exported since it came from the temporary environment) was undone.

```sh
x=4 declare -r x   # declare -rx x="4"   (persists, readonly, exported)
x=4 declare -i x   # declare: x: not found   (unchanged — -i does not persist)
```

**scalar declare assignment to an array → element 0** — `declare a=0` (or `declare -r a=0`, `local a=0`) on a name that is already an indexed/associative array assigned only the scalar shadow, so `declare -p` showed an empty array. Now the value is routed through `array_set` to element/key 0 when the target is an array, matching a plain `a=0`:

```sh
declare -a a=(); declare -r a=0; declare -p a   # declare -ar a=([0]="0")
```

The second fix also improves the `array` test (−14). `ctest` 22/22, `run_diff` all 238 scripts match bash; `assoc` unchanged. No regressions.