### PR TITLE
testsuite batch101: local inherits exported attr and temp-env value

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -154,6 +154,10 @@ class Shell {
   std::vector<std::vector<std::pair<std::string, std::optional<Variable>>>> local_stack;
   // Per-scope saved getopt state, set when that scope localizes OPTIND.
   std::vector<std::optional<std::tuple<size_t, std::string, int>>> getopt_scope_saves;
+  // Names currently bound by a `VAR=val cmd' temporary environment.  make_local
+  // inherits such a variable's value/attributes when a called function localizes
+  // it (`v=t f; f(){ local v; }' -> the local is `v=t', exported), matching bash.
+  std::set<std::string> temp_env_active;
 
   // --- shell state for builtins -----------------------------------------
   bool login_shell = false;                  // logout only works in a login shell

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1204,6 +1204,7 @@ int Executor::run_simple(const SimpleCommand *c) {
   std::vector<std::pair<std::string, std::optional<Variable>>> restore;
   auto apply_temp = [&]() {
     for (const auto &a : assigns) {
+      sh_.temp_env_active.insert(a.first);  // let a called function's `local' inherit it
       auto it = sh_.vars.find(a.first);
       restore.push_back({a.first,
                          it == sh_.vars.end() ? std::nullopt : std::optional<Variable>(it->second)});
@@ -1228,6 +1229,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       else sh_.vars.erase(it->first);
     }
     restore.clear();
+    for (const auto &a : assigns) sh_.temp_env_active.erase(a.first);
   };
 
   int status = 0;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -987,8 +987,20 @@ bool Shell::make_local(const std::string &n, bool inherit_force) {
   // rejected before we reach here, so an inherited copy is always assignable.)
   auto liv = shopt_opts.find("localvar_inherit");
   bool shopt_on = liv != shopt_opts.end() && liv->second;
-  bool inherit = it != vars.end() && (inherit_force || shopt_on);
-  if (!inherit) vars[n] = Variable{};  // fresh empty local
+  // A variable passed in the temporary environment (`v=t f') is inherited by a
+  // `local'/`typeset' of the same name inside the called function -- value and
+  // (exported) attributes -- unconditionally, like `-I'/localvar_inherit do.
+  bool inherit = it != vars.end() &&
+                 (inherit_force || shopt_on || temp_env_active.count(n) != 0);
+  if (!inherit) {
+    // A local of an exported variable stays exported even without inheriting
+    // its value, so the environment the function passes to child processes is
+    // unchanged (bash): `export V; f(){ local V; }' keeps V in the environment,
+    // and a temp-env `V=x f' makes the local `V' exported too.
+    bool was_exported = it != vars.end() && it->second.exported;
+    vars[n] = Variable{};  // fresh (unset) local
+    vars[n].exported = was_exported;
+  }
   // Localizing OPTIND saves and resets the getopts scan state (bash restores
   // it when the function returns).
   if (n == "OPTIND" && !getopt_scope_saves.empty() && !getopt_scope_saves.back()) {


### PR DESCRIPTION
Batch 101 — `varenv` **115 → 109**. Two bash local-scoping behaviors around exported and temporary-environment variables.

**Local of an exported variable stays exported** — so the environment the function passes to its children is unchanged:

```sh
export v=g; f(){ local v=x; declare -p v; }; f   # declare -x v="x"   (was declare -- v="x")
```

**A temp-env variable is inherited by a `local`/`typeset` of the same name** in the called function — value and exported attribute, unconditionally (as `-I`/`localvar_inherit` do):

```sh
v=t f;   f(){ local v; declare -p v; }             # declare -x v="t"
x=12 f;  f(){ typeset i=0 x="${x-10}"; echo "|$x|"; }   # |12|
```

A new `temp_env_active` set, maintained by the executor's apply/undo of the temporary environment, tells `make_local` which names to inherit.

`ctest` 22/22, `run_diff` all 238 scripts match bash; `func`/`array` unchanged; common temp-env paths (`IFS=: read`, `VAR=v extcmd`, `x=2 :`) verified against bash. No regressions.