### PR TITLE
testsuite batch102: unset current-scope local, EXIT-trap FUNCNAME

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -193,6 +193,11 @@ class Shell {
   void push_src_frame(const std::string &name, const std::string &source, int line, bool is_func);
   void pop_src_frame();
   void sync_source_arrays();  // rewrite BASH_SOURCE/FUNCNAME/BASH_LINENO
+  // The call-frame stack captured when `exit' is invoked inside a function, so
+  // the EXIT trap runs with that context ($FUNCNAME etc.) still visible as bash
+  // does, even though the frames have unwound by the time the trap fires.
+  std::vector<SrcFrame> exit_src_frames;
+  bool have_exit_frames = false;
 
   // --- traps -------------------------------------------------------------
   std::map<std::string, std::string> traps;  // signal name (e.g. "EXIT") -> command

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4886,6 +4886,9 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     sh.exiting = true;
     sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
     st = sh.exit_status;
+    // `exit' inside a function runs the EXIT trap with that function's frame
+    // still active ($FUNCNAME), so snapshot the call stack before it unwinds.
+    if (sh.in_function()) { sh.exit_src_frames = sh.src_frames; sh.have_exit_frames = true; }
   } else if (cmd == "return") {
     // `return' is only meaningful in a function or a sourced script; elsewhere
     // it is an error and must not unwind the current input (bash).

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -515,6 +515,12 @@ int main(int argc, char **argv) {
     std::string cmd = it->second;
     sh.traps.erase(it);
     sh.exiting = false;
+    // If `exit' fired inside a function, restore that call context so the trap
+    // sees $FUNCNAME/BASH_SOURCE as bash does.
+    if (sh.have_exit_frames) {
+      sh.src_frames = sh.exit_src_frames;
+      sh.sync_source_arrays();
+    }
     sh.run_string(cmd);
   }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1209,7 +1209,20 @@ void Shell::unset(const std::string &n_in, bool force, bool noref) {
   std::string n = (force || noref) ? n_in : deref(n_in);
   if (n == "POSIXLY_CORRECT") opt_posix = false;  // unsetting leaves POSIX mode
   auto it = vars.find(n);
-  if (it != vars.end() && (force || !it->second.readonly)) vars.erase(it);
+  if (it != vars.end() && (force || !it->second.readonly)) {
+    // Unsetting a variable that is local to the CURRENT function scope leaves
+    // the (now unset) local binding in place rather than removing it, so it
+    // keeps shadowing any enclosing value and a later assignment reuses the
+    // local -- `local v=x; unset v; declare -p v' still reports `declare -- v'
+    // (bash).  A forced unset (getopts clearing OPTARG) and a non-local target
+    // are removed outright.
+    bool cur_local = false;
+    if (!force && !local_stack.empty())
+      for (auto &e : local_stack.back())
+        if (e.first == n) { cur_local = true; break; }
+    if (cur_local) { Variable v; v.invisible = true; vars[n] = v; }
+    else vars.erase(it);
+  }
 }
 
 std::string Shell::ifs() const {


### PR DESCRIPTION
Batch 102 — `varenv` **109 → 99**. Two local/scope behaviors.

**`unset` of a current-scope local leaves it declared-but-unset** — bash keeps the (now unset) local binding so it keeps shadowing an enclosing value and a later assignment reuses it:

```sh
v=global; f(){ local v=x; unset v; declare -p v; echo "[$v]"; }; f   # declare -- v   /   []
v=g;      f(){ local v=x; unset v; v=new; declare -p v; }; f          # declare -- v="new"  (global stays g)
```

A forced unset (getopts clearing `OPTARG`) and a non-local target are still removed outright.

**EXIT trap runs with the exiting function's frame active** — `exit` inside a function fires the EXIT trap while that function's frame is still current, so `$FUNCNAME` names the function. gnash ran the trap only after the frames unwound, leaving it empty:

```sh
trap 'echo trap:$FUNCNAME' EXIT; f(){ exit; }; f    # trap:f   (was trap:)
```

The call stack is snapshotted when `exit` fires inside a function and restored before the trap runs.

`ctest` 22/22, `run_diff` all 238 scripts match bash, `func`/`array`/`assoc` unchanged. No regressions.