### PR TITLE
csh: read environment variables from the shared shell table

### DIFF
--- a/core/src/csh.cpp
+++ b/core/src/csh.cpp
@@ -308,17 +308,30 @@ struct Interp {
     auto it = sh.csh_vars.find(n);
     return it == sh.csh_vars.end() ? nullptr : &it->second;
   }
+  // An environment variable as csh sees it: the shared shell's exported
+  // variables come first, so an `export FOO=bar' run under the bash/zsh/ksh
+  // personalities (which store it only in the shell table, never touching the
+  // process environment via libc setenv) is visible here.  The process
+  // environment is the fallback.  Returns false when NAME is unset.
+  bool env_get(const std::string &n, std::string &out) const {
+    auto it = sh.vars.find(n);
+    if (it != sh.vars.end() && it->second.exported) { out = it->second.value; return true; }
+    const char *e = std::getenv(n.c_str());
+    if (e) { out = e; return true; }
+    return false;
+  }
   std::string var_str(const std::string &n) {  // first-word/scalar view
     if (n == "status" || n == "?") return std::to_string(status);
     if (n == "0") return sh.arg0;
     auto *v = var_ptr(n);
     if (v) { std::string r; for (size_t i = 0; i < v->size(); i++) { if (i) r += ' '; r += (*v)[i]; } return r; }
-    const char *e = std::getenv(n.c_str());
-    return e ? e : "";
+    std::string e;
+    return env_get(n, e) ? e : "";
   }
   bool var_set(const std::string &n) {
     if (n == "status" || n == "?" || n == "0") return true;
-    return var_ptr(n) != nullptr || std::getenv(n.c_str()) != nullptr;
+    std::string e;
+    return var_ptr(n) != nullptr || env_get(n, e);
   }
 
   // Expand a word-initial, unquoted tilde: ~, ~/path, ~user, ~user/path.
@@ -442,7 +455,7 @@ struct Interp {
     else if (v) vals = *v;
     else if (name == "status" || name == "?") vals = {std::to_string(status)};
     else if (name == "0") vals = {sh.arg0};
-    else { const char *e = std::getenv(name.c_str()); if (e) vals = {e}; }
+    else { std::string e; if (env_get(name, e)) vals = {e}; }
 
     std::vector<std::string> result;
     if (!index.empty()) {

--- a/tests/harness/personality_test.sh
+++ b/tests/harness/personality_test.sh
@@ -54,6 +54,19 @@ check "emulate absent in bash mode" "127" bash \
 check "-c csh runs csh syntax" "b" bash \
   'personality csh -c '\''set x = (a b c); echo $x[2]'\'''
 
+# an exported variable set under one personality is visible under another;
+# csh reads the shared shell environment, not just the process environ
+check "exported var crosses bash->csh" "frombash" bash \
+  'export FOO=frombash; personality csh -c '\''echo $FOO'\'''
+check "exported var crosses zsh->csh" "fromzsh" zsh \
+  'export ZED=fromzsh; personality csh -c '\''echo $ZED'\'''
+# csh setenv is visible back in bash (the reverse direction still works)
+check "csh setenv crosses csh->bash" "fromcsh" csh \
+  'setenv BAZ fromcsh; personality bash -c '\''echo $BAZ'\'''
+# a non-exported variable is not an environment variable and does not cross
+check "non-exported var does not cross to csh" "0" bash \
+  'PLAIN=local; personality csh -c '\''echo $?PLAIN'\'''
+
 # an unknown personality name is rejected
 check "unknown name is an error" "1" bash \
   'personality nonesuch >/dev/null 2>&1; echo $?'


### PR DESCRIPTION
Fixes #321.

## Root cause

The bash/zsh/ksh/sh personalities share a single shell variable table
(`Shell::vars`); `export` records the value there and never calls libc
`setenv`, so the process `environ` is not updated. The csh interpreter
resolved undefined variables only through `std::getenv()`, so a variable
exported under another personality was invisible once execution switched to
csh.

## Fix

Add an `env_get` helper in the csh interpreter that consults the shared
shell's exported variables first and falls back to the process environment,
and route `var_str`, `var_set`, and the `expand_dollar_list` fallback through
it. Environment variables set in one personality are now visible in all of
them. csh's own `setenv` already wrote to both `environ` and the shell table,
so the reverse direction is unchanged; non-exported and csh-local `set`
variables still do not cross, matching each personality's variable model.

## Verification

- Manual reproduction now passes:
  `gnash --personality=bash -c 'export FOO=frombash; personality csh -c "echo $FOO"'`
  prints `frombash`.
- Added four regression checks to `tests/harness/personality_test.sh`
  (bash→csh, zsh→csh, csh→bash setenv, and non-exported does-not-cross);
  the suite passes.
- `run_diff_csh.sh` still matches tcsh on all 36 corpus scripts.
