### PR TITLE
builtins: scope local -p NAME to the current function frame

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1920,9 +1920,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         }
       }
     } else {
+      // `local -p NAME' reports only variables local to the CURRENT function
+      // frame; a NAME visible only through an enclosing scope (e.g. one made
+      // readonly at a previous scope) is `not found', matching bash.  This is
+      // the `local' builtin specifically -- a `declare -p NAME' in a function
+      // (also force_local) still finds enclosing/global variables.
+      bool local_p = argv[0] == "local";
+      std::set<std::string> cur_locals;
+      if (local_p && !sh.local_stack.empty())
+        for (const auto &pr : sh.local_stack.back()) cur_locals.insert(pr.first);
       for (; i < argv.size(); i++) {
         auto it = sh.vars.find(argv[i]);
-        if (it == sh.vars.end()) {
+        if (it == sh.vars.end() ||
+            (local_p && !cur_locals.count(argv[i]))) {
           std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
                        argv[0].c_str(), argv[i].c_str());
           st = 1;


### PR DESCRIPTION
Fixes #323.

## Root cause

bash's `local -p NAME` lists only variables local to the **current** function
frame; a name reachable only through an enclosing scope (e.g. one made
`readonly` at a previous scope, as in `varenv25.sub`) is reported `not found`.
gnash's `-p NAME` display path in `bi_declare` resolved the name through any
scope and printed it.

## Fix

For the `local` builtin specifically, the `-p NAME` path now requires the name
to appear in the current frame's local set (`local_stack.back()`) before
printing; otherwise it emits `local: NAME: not found`. The gate keys on
`argv[0] == "local"`, **not** the `force_local` parameter: `declare`/`typeset`
inside a function are also dispatched with `force_local = true` (declare is
local-by-default there), so gating on `force_local` would wrongly break
`declare -p NAME` for enclosing/global variables — verified this was the case
in an intermediate version and corrected.

## Verification

- `varenv` **99 → 85** (−14); `varenv25.sub` now byte-perfect against bash.
- `ctest --test-dir build`: 22/22.
- `run_diff.sh`: all scripts match bash.
- Clean before/after scoreboard on the local/declare-heavy files —
  `builtins` 170, `func` 39, `nameref` 236, `array` 195, `assoc` 86 — all
  unchanged, so no regressions.
