### PR TITLE
executor: quote xtrace words and assignment values like bash

### DIFF
--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -37,6 +37,10 @@ std::string declare_var_string(const std::string &name, const Variable &v,
                                const std::string &cmd = "declare",
                                bool posix = false);
 
+// Quote WORD as bash's `set -x' (xtrace) does: '' for empty, $'...' for a word
+// with non-printable bytes, '...' for one with shell metacharacters, else bare.
+std::string xtrace_quote_word(const std::string &w);
+
 }  // namespace gnash::core
 
 #endif  // GNASH_CORE_BUILTINS_HPP

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -720,6 +720,35 @@ int bi_pwd(Shell &sh, const std::vector<std::string> &argv) {
 }  // namespace (reopened below)
 }  // namespace gnash::core
 namespace gnash::core {
+// bash's xtrace word quoting (xtrace_print_word_list, print_cmd.c): an empty
+// word prints as '', a word with any non-printable byte is ANSI-C quoted
+// ($'...'), one containing a shell metacharacter is single-quoted ('...'), and a
+// plain word is printed as-is.  ANSI-C is tried BEFORE the metacharacter test so
+// a word mixing whitespace and a control byte (` \t\n') renders as $' \t\n'.  `~'
+// and `#' are metacharacters only at the start of the word.
+std::string xtrace_quote_word(const std::string &w) {
+  if (w.empty()) return "''";
+  if (q_needs_ansic(w)) return q_ansic(w);
+  bool meta = false;
+  for (size_t i = 0; i < w.size() && !meta; i++) {
+    switch (static_cast<unsigned char>(w[i])) {
+      case ' ': case '\t': case '\n': case '\'': case '"': case '\\':
+      case '|': case '&': case ';': case '(': case ')': case '<': case '>':
+      case '!': case '{': case '}': case '*': case '[': case '?': case ']':
+      case '^': case '$': case '`':
+        meta = true; break;
+      case '~': case '#':
+        if (i == 0) meta = true;
+        break;
+      default: break;
+    }
+  }
+  if (!meta) return w;
+  std::string r = "'";
+  for (char c : w) { if (c == '\'') r += "'\\''"; else r += c; }
+  return r + "'";
+}
+
 std::vector<std::string> Shell::dirstack() const {
   std::vector<std::string> v;
   std::string pwd = get("PWD");

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1007,6 +1007,11 @@ int Executor::run_simple(const SimpleCommand *c) {
   } psg{sh_, sh_.procsubs.size()};
   std::vector<std::pair<std::string, std::string>> assigns;
   std::vector<std::string> argv;
+  // Pre-formatted `set -x' trace lines for the assignment words, in source
+  // order: a scalar assignment as NAME=<quoted-value> (or NAME+=...), an array
+  // compound assignment as its verbatim source word, so xtrace matches bash even
+  // for values needing single- or ANSI-C quoting.  Only built when xtrace is on.
+  std::vector<std::string> xtrace_lines;
   bool prefix = true;
   // Track command substitutions in the assignment RHS: a pure-assignment
   // command takes the status of the last one (bash), or 0 if there were none.
@@ -1022,6 +1027,10 @@ int Executor::run_simple(const SimpleCommand *c) {
       Assign a;
       parse_assign(w.text, a);
       if (a.sub || a.is_array) {
+        // NOTE: an array/element assignment is not xtrace'd here -- bash prints it
+        // via its compound-assignment word-list deparser (each element expanded
+        // then re-quoted, e.g. source `$'\t'' -> `'<tab>''), which gnash does not
+        // reproduce; tracing the verbatim source word would not match.  Deferred.
         apply_array_assign(sh_, ex, a);  // array element / literal: applied now
       } else {
         auto vit = sh_.vars.find(a.name);
@@ -1042,6 +1051,9 @@ int Executor::run_simple(const SimpleCommand *c) {
           sh_.set(pa.first, pa.second);
         }
         std::string v = ex.expand_assignment(a.value);
+        // The traced value is the expanded RHS as written (for `+=' the appended
+        // part, not the concatenation); overwritten with the result for integers.
+        std::string xtrace_rhs = v;
         // Only the old value is needed for `+=' / integer arithmetic; reading it
         // for a plain assignment would spuriously resolve a circular nameref.
         std::string cur = (integer || a.append)
@@ -1060,9 +1072,14 @@ int Executor::run_simple(const SimpleCommand *c) {
           if (ok && a.append) rv = eval_arith_msg(sh_, cur, "", &ok) + rv;
           if (!ok) { sh_.arith_error = true; break; }
           v = std::to_string(rv);
+          xtrace_rhs = v;
         } else if (a.append) {
           v = cur + v;
         }
+        if (sh_.opt_xtrace)
+          xtrace_lines.push_back(a.name + (a.append ? "+=" : "=") +
+                                 (xtrace_rhs.empty() ? std::string()
+                                                     : xtrace_quote_word(xtrace_rhs)));
         if (is_arr) sh_.array_set(a.name, "0", v);
         else assigns.emplace_back(a.name, v);
       }
@@ -1094,15 +1111,17 @@ int Executor::run_simple(const SimpleCommand *c) {
     Expander xex(sh_);
     std::string xt_prefix = xex.expand_no_split(expand_prompt(sh_, ps4), false, false);
     // bash traces each temporary/standalone assignment on its own line, then the
-    // command word list (if any) on a separate line.
-    for (const auto &a : assigns)
-      std::fprintf(stderr, "%s%s=%s\n", xt_prefix.c_str(), a.first.c_str(), a.second.c_str());
+    // command word list (if any) on a separate line.  Assignment lines were
+    // pre-formatted in source order (scalar values and command words are quoted
+    // as bash's sh_single_quote/ANSI-C xtrace conventions require).
+    for (const auto &a : xtrace_lines)
+      std::fprintf(stderr, "%s%s\n", xt_prefix.c_str(), a.c_str());
     if (!argv.empty()) {
       std::string line = xt_prefix;
       bool first = true;
       for (const auto &a : argv) {
         if (!first) line += ' ';
-        line += a;
+        line += xtrace_quote_word(a);
         first = false;
       }
       std::fprintf(stderr, "%s\n", line.c_str());


### PR DESCRIPTION
## Summary
Under `set -x`, gnash printed command words and assignment values raw. This adds bash's xtrace quoting conventions.

- New `xtrace_quote_word` reproduces bash's `xtrace_print_word_list`: empty → `''`; a word with a non-printable byte → ANSI-C `$'...'`; one with a shell metacharacter → single-quoted `'...'`; a plain word → bare. ANSI-C is tried first so ` \t\n` → `$' \t\n'`; `~`/`#` are metacharacters only at word start.
- Command words are quoted with it: `: | & ;` now traces as `+ : '|' '&' ';'`, a tab word as `+ : $'\t'`.
- Assignment trace lines are built in source order, keeping the operator and quoting only the value: `foo+=two` → `+ foo+=two`, `foo="a b"` → `+ foo='a b'`.

## Verification
- `set-x` scoreboard **22 → 14**.
- `ctest`: **22/22**; `run_diff.sh`: **all 238 scripts match bash**; xtrace-heavy `dbg-support` unchanged.

## Deferred
- **BASH_XTRACEFD** (redirect xtrace to a given fd) — a separate feature touching every xtrace emission site.
- **Compound array assignment xtrace** (`metas=(...)`) — bash renders it via its word-list deparser (each element expanded then re-quoted); gnash does not reproduce that deparser.

Closes #327.