### PR TITLE
dstack: fix pushd/popd -n and DIRSTACK[N]= assignment

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -856,7 +856,9 @@ int bi_pushd(Shell &sh, const std::vector<std::string> &argv) {
     std::rotate(v.begin(), v.begin() + idx, v.end());
     if (!no_cd && change_dir(sh, v[0], false, "pushd") != 0) return 1;
     sh.dir_stack.assign(v.begin() + 1, v.end());
-    return bi_dirs(sh, {"dirs"});
+    // A numeric rotation under `-n' manipulates the stack but does not cd and,
+    // unlike `pushd -n dir', prints nothing at all (bash).
+    return no_cd ? 0 : bi_dirs(sh, {"dirs"});
   }
   // A `+'/`-' argument that isn't a numeric index is a malformed rotation count.
   if (a.size() > 1 && (a[1][0] == '+' || a[1][0] == '-')) {
@@ -885,25 +887,30 @@ int bi_pushd(Shell &sh, const std::vector<std::string> &argv) {
 }
 
 int bi_popd(Shell &sh, const std::vector<std::string> &argv) {
-  if (argv.size() > 1 && (argv[1][0] == '+' || argv[1][0] == '-') && argv[1].size() > 1 &&
-      std::isdigit(static_cast<unsigned char>(argv[1][1]))) {
+  // A leading `-n' suppresses the directory change (only the stack is touched);
+  // it does not otherwise change which entry is removed.
+  std::vector<std::string> a(argv.begin(), argv.end());
+  bool no_cd = false;
+  if (a.size() > 1 && a[1] == "-n") { no_cd = true; a.erase(a.begin() + 1); }
+  if (a.size() > 1 && (a[1][0] == '+' || a[1][0] == '-') && a[1].size() > 1 &&
+      std::isdigit(static_cast<unsigned char>(a[1][1]))) {
     std::vector<std::string> v = full_dirstack(sh);
-    int idx = rot_index(argv[1], v.size());
-    if (idx < 0) { std::fprintf(stderr, "%spopd: %s: directory stack index out of range\n", sh.err_prefix().c_str(), argv[1].c_str()); return 1; }
-    if (idx == 0) {  // removing the top: cd to the next entry
+    int idx = rot_index(a[1], v.size());
+    if (idx < 0) { std::fprintf(stderr, "%spopd: %s: directory stack index out of range\n", sh.err_prefix().c_str(), a[1].c_str()); return 1; }
+    if (idx == 0) {  // removing the top: cd to the next entry (unless `-n')
       if (sh.dir_stack.empty()) { std::fprintf(stderr, "%spopd: directory stack empty\n", sh.err_prefix().c_str()); return 1; }
       std::string target = sh.dir_stack.front();
       sh.dir_stack.erase(sh.dir_stack.begin());
-      if (change_dir(sh, target, false, "popd") != 0) return 1;
+      if (!no_cd && change_dir(sh, target, false, "popd") != 0) return 1;
     } else {
       sh.dir_stack.erase(sh.dir_stack.begin() + (idx - 1));
     }
     return bi_dirs(sh, {"dirs"});
   }
-  // A `+'/`-' argument that isn't a numeric index (and isn't the `-n' option).
-  if (argv.size() > 1 && (argv[1][0] == '+' || argv[1][0] == '-') && argv[1] != "-n") {
+  // A `+'/`-' argument that isn't a numeric index is a malformed number.
+  if (a.size() > 1 && (a[1][0] == '+' || a[1][0] == '-')) {
     std::fprintf(stderr, "%spopd: %s: invalid number\n", sh.err_prefix().c_str(),
-                 argv[1].c_str());
+                 a[1].c_str());
     std::fprintf(stderr, "popd: usage: popd [-n] [+N | -N]\n");
     return 2;
   }
@@ -911,9 +918,11 @@ int bi_popd(Shell &sh, const std::vector<std::string> &argv) {
     std::fprintf(stderr, "%spopd: directory stack empty\n", sh.err_prefix().c_str());
     return 1;
   }
+  // Remove the entry that would become the current directory; `popd' cd's to it,
+  // `popd -n' leaves the current directory in place (so it drops the next entry).
   std::string target = sh.dir_stack.front();
   sh.dir_stack.erase(sh.dir_stack.begin());
-  if (change_dir(sh, target, false, "popd") != 0) return 1;
+  if (!no_cd && change_dir(sh, target, false, "popd") != 0) return 1;
   return bi_dirs(sh, {"dirs"});
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -673,6 +673,16 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
     hashed[sub] = full;
     return;
   }
+  // DIRSTACK is the live directory stack: DIRSTACK[N]=dir rewrites a stack entry
+  // (index 0 is $PWD, kept implicit; 1.. map to dir_stack[N-1]).  Assigning it
+  // must update the real stack, not create a shadow array that reads ignore.
+  if (n == "DIRSTACK" && !is_zsh()) {
+    bool ok = true;
+    long long k = eval_arith(*this, sub, &ok);
+    if (ok && k >= 1 && k - 1 < static_cast<long long>(dir_stack.size()))
+      dir_stack[k - 1] = val;
+    return;
+  }
   Variable &v = vars[n];
   if (v.readonly) return;
   v.invisible = false;  // an assignment makes a declared-but-unset array visible


### PR DESCRIPTION
## Summary
Closes the `dstack` scoreboard file (33 → 0) via three directory-stack fixes surfaced by `tests/dstack.tests`.

1. **`pushd -n +N` silent** — a numeric rotation under `-n` manipulated the stack correctly but printed it afterward; bash prints nothing for that form (a `pushd -n dir` still prints).
2. **`popd -n` parsed** — `popd -n` (bare or with `+N`/`-N`) was never parsed; the `-n` was treated as a non-option and popd popped the top with a cd. Now it strips `-n`, suppresses only the directory change, and removes the same entry it otherwise would.
3. **`DIRSTACK[N]=dir` write-through** — assigning a DIRSTACK element created a shadow array that reads ignored; now `array_set` rewrites the live `dir_stack` (index 0 is `$PWD`, `N≥1` → `dir_stack[N-1]`).

Two commits (builtins.cpp for the `-n` handling, shell.cpp for the DIRSTACK write-through).

## Verification
- `dstack` scoreboard **33 → 0**.
- `ctest`: **22/22**; `run_diff.sh`: **all 238 scripts match**; no regressions (`array`, `assoc`, `varenv`, `builtins` unchanged).

Closes #331.