### PR TITLE
array: element-aware ${a[i]...} expansion and -u/-l/-c element folding

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -98,6 +98,10 @@ class Shell {
   // byte.  Public so `declare -p' can print in the same order.
   static std::vector<std::string> assoc_order(const Variable &v);
   std::string array_get(const std::string &n, const std::string &sub) const;
+  // True when the array element NAME[sub] currently exists (is set), as opposed
+  // to array_get returning "" for both an unset element and one set to "".  Used
+  // by ${a[i]-x}/${a[i]=x}/`test -v a[i]' to decide whether the element is set.
+  bool array_elem_set(const std::string &n, const std::string &sub) const;
   // $BASH_ARGC / $BASH_ARGV views (only non-empty inside a function under
   // `shopt -s extdebug'); see bash_argc_view/bash_argv_view in shell.cpp.
   std::vector<std::string> bash_argc_view() const;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -377,7 +377,8 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
 // if the result is subject to word splitting (always, for consistency here).
 static std::string expand_brace_body(Expander &, Shell &, const std::string &, bool dq);
 static std::string apply_param_op(Expander &, Shell &, const std::string &name,
-                                  std::string val, bool set, const std::string &rest, bool dq);
+                                  std::string val, bool set, const std::string &rest, bool dq,
+                                  bool have_sub = false, const std::string &sub = std::string());
 // Build the ${a[@]@K} "key value ..." string for array NAME (defined below).
 static std::string kv_build_K(Shell &sh, const std::string &name, bool assoc);
 
@@ -1595,17 +1596,21 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
 
   bool set = false;
   std::string val;
+  std::string tsub;  // the expanded, zsh-translated subscript, for have_sub
   if (have_sub) {
     // zsh subscripts are 1-based; translate before the (0-based) array read.
     std::string esub = ex.expand_no_split(sub);
     if (!sh.array_expand_once_ok(name, esub)) { sh.arith_error = true; return std::string(); }
-    val = sh.array_get(name, sh.zsh_subscript(name, esub));
-    set = sh.is_set(name);
+    tsub = sh.zsh_subscript(name, esub);
+    val = sh.array_get(name, tsub);
+    // A defaulting/alternative operator on a single element (${a[i]-x}, ${a[i]=x},
+    // ${a[i]+x}, ${a[i]?}) keys off whether THAT element is set, not the array.
+    set = sh.array_elem_set(name, tsub);
   } else {
     val = ex.param_value(name, set, defaulting_op);
   }
   if (length) return std::to_string(val.size());
-  return apply_param_op(ex, sh, name, val, set, rest, dq);
+  return apply_param_op(ex, sh, name, val, set, rest, dq, have_sub, tsub);
 }
 
 // Apply the operator suffix `rest' (everything after the name/subscript) of a
@@ -1613,7 +1618,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
 // array expansions can apply it to each element of ${a[@]} / ${a[*]}.
 static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &name,
                                   std::string val, bool set, const std::string &rest,
-                                  bool dq) {
+                                  bool dq, bool have_sub, const std::string &sub) {
   if (rest.empty()) return val;
 
   // In a double-quoted context the alternative word is expanded in double-quote
@@ -1649,6 +1654,19 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (op == '=') {
       if (empty) {
         std::string w = expand_word(word);
+        if (have_sub) {
+          // Assign to the array element, not a scalar named `name'.  Mirror a
+          // plain a[i]=w: an integer-attributed array evaluates the RHS as
+          // arithmetic; array_set applies any -u/-l/-c case folding.  Return the
+          // stored value so the expansion reflects those transforms.
+          auto it = sh.vars.find(sh.deref(name));
+          if (it != sh.vars.end() && it->second.integer) {
+            bool ok = true;
+            w = std::to_string(eval_arith(sh, w, &ok));
+          }
+          sh.array_set(name, sub, w);
+          return sh.array_get(name, sub);
+        }
         sh.set(name, w);
         return w;
       }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -715,8 +715,23 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   Variable &v = vars[n];
   if (v.readonly) return;
   v.invisible = false;  // an assignment makes a declared-but-unset array visible
+  // `declare -u'/`-l'/`-c' fold the case of each element value on assignment,
+  // exactly as Shell::set does for scalars.
+  std::string fv = val;
+  if (v.ucase)
+    for (char &c : fv) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  else if (v.lcase)
+    for (char &c : fv) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  else if (v.capcase) {
+    bool first = true;
+    for (char &c : fv) {
+      c = static_cast<char>(first ? std::toupper(static_cast<unsigned char>(c))
+                                  : std::tolower(static_cast<unsigned char>(c)));
+      first = false;
+    }
+  }
   if (v.kind == VarKind::Assoc) {
-    assoc_put(v, sub, val);
+    assoc_put(v, sub, fv);
     return;
   }
   // A subscripted assignment to an existing scalar promotes it to an indexed
@@ -738,8 +753,8 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
       return;
     }
   }
-  v.idx[k] = val;
-  if (k == 0) v.value = val;
+  v.idx[k] = fv;
+  if (k == 0) v.value = fv;
 }
 
 bool Shell::array_unset(const std::string &n_in, const std::string &sub) {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -637,6 +637,35 @@ std::string Shell::array_get(const std::string &n_in, const std::string &sub) co
   return (k == 0) ? v.value : std::string();
 }
 
+bool Shell::array_elem_set(const std::string &n_in, const std::string &sub) const {
+  if (n_in == "BASH_ALIASES" || n_in == "BASH_CMDS") {  // string-keyed live tables
+    const auto &tbl = (n_in == "BASH_ALIASES") ? aliases : hashed;
+    return tbl.count(sub) != 0;
+  }
+  if (n_in == "BASH_ARGC" || n_in == "BASH_ARGV" || n_in == "DIRSTACK") {
+    auto v = (n_in == "BASH_ARGC") ? bash_argc_view()
+             : (n_in == "BASH_ARGV") ? bash_argv_view() : dirstack();
+    bool ok = true;
+    long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
+    if (!ok) k = 0;
+    return k >= 0 && k < static_cast<long long>(v.size());
+  }
+  std::string n = deref(n_in);
+  auto it = vars.find(n);
+  if (it == vars.end()) return false;
+  const Variable &v = it->second;
+  if (v.invisible) return false;
+  if (v.kind == VarKind::Assoc) return v.assoc.count(sub) != 0;
+  bool ok = true;
+  long long k = eval_arith(const_cast<Shell &>(*this), sub, &ok);
+  if (!ok) k = 0;
+  if (v.kind == VarKind::Indexed) {
+    if (k < 0 && !is_zsh() && !v.idx.empty()) k += v.idx.rbegin()->first + 1;
+    return v.idx.count(k) != 0;
+  }
+  return k == 0;  // a scalar's only element is itself
+}
+
 void Shell::array_set(const std::string &n_in, const std::string &sub, const std::string &val) {
   std::string n = deref(n_in);
   // GROUPS/FUNCNAME carry bash's att_noassign: an assignment is silently


### PR DESCRIPTION
## Summary
Fixes three related array-element expansion/assignment gaps (array30.sub 23 → 4; overall **array 195 → 185**, plus a bonus **assoc 86 → 84**).

## Changes (two commits)
1. **expand: array-element defaulting operators act on the element** — `${a[i]-x}`, `${a[i]+x}`, `${a[i]?}` now test whether *that element* is set (new `Shell::array_elem_set`) instead of the whole array, and `${a[i]=v}` / `${a[i]:=v}` assign the element via `array_set` (with integer-array arithmetic) rather than creating a scalar named `a`.
2. **shell: fold array element case under `declare -u/-l/-c`** — a subscripted assignment now applies the array's case attributes to the element value, matching `Shell::set` for scalars. This also fixes the plain `A[x]=foo` path.

## Deferred
`${A[@]:=foo}` (bash assigns to the literal key `@`) still errors — an obscure `[@]`-with-assignment edge case left for later (2 diffs).

## Testing
- `ctest --test-dir build` → 22/22
- `run_diff.sh` → all 238 scripts match bash
- array 195 → 185, assoc 86 → 84, no regressions

Closes #337