### PR TITLE
array: single-eval side-effecting subscripts + colon-tilde in compound values

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -459,7 +459,10 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
       bool plain = rb != std::string::npos && rb + 1 < e.size() && e[rb + 1] == '=';
       if (app || plain) {
         std::string sub = ex.expand_no_split(e.substr(1, rb - 1));
-        std::string val = ex.expand_no_split(e.substr(rb + (app ? 3 : 2)));
+        // The value of a `[sub]=value' element is an assignment RHS, so a `~'
+        // tilde-expands at the start and after each unquoted `:' (bash); a bare
+        // word element, handled below, only gets leading-tilde expansion.
+        std::string val = ex.expand_assignment(e.substr(rb + (app ? 3 : 2)));
         if (!assoc) {
           // bash stops the whole compound assignment at the first bad subscript
           // (the array has already been cleared, so the partial result stands).

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1744,6 +1744,18 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     std::string esub = ex.expand_no_split(sub);
     if (!sh.array_expand_once_ok(name, esub)) { sh.arith_error = true; return std::string(); }
     tsub = sh.zsh_subscript(name, esub);
+    // An arithmetic (indexed) subscript may have side effects, e.g. ${a[i++]};
+    // evaluate it exactly once here and reuse the canonical index for both the
+    // read and the element-set test below, so array_get/array_elem_set don't
+    // evaluate it (and re-run the side effect) a second time.  Associative keys
+    // are literal, so leave them untouched.
+    auto vit = sh.vars.find(sh.deref(name));
+    bool assoc_sub = vit != sh.vars.end() && vit->second.kind == VarKind::Assoc;
+    if (!assoc_sub && tsub != "@" && tsub != "*") {
+      bool aok = true;
+      long long idx = eval_arith(sh, tsub, &aok);
+      if (aok) tsub = std::to_string(idx);
+    }
     val = sh.array_get(name, tsub);
     // A defaulting/alternative operator on a single element (${a[i]-x}, ${a[i]=x},
     // ${a[i]+x}, ${a[i]?}) keys off whether THAT element is set, not the array.


### PR DESCRIPTION
## Summary
Two array-element expansion fixes.

1. **`${a[i++]}` double-evaluated its subscript** — once in `array_get`, once in the `array_elem_set` test — so a side effect fired twice (`count++` advanced by 2). Now the arithmetic subscript is evaluated once and the canonical index reused. (array10.sub)
2. **`[sub]=value` compound values only leading-tilde expanded** — they are assignment RHSs, so `~` should also expand after each unquoted `:`. Now uses `expand_assignment`; bare-word elements keep leading-tilde only. (array31.sub)

## Testing
- `ctest` 22/22; `run_diff` all 238 match
- array 137 → **121** (array10 + array31 byte-perfect); arith/assoc/nameref/quotearray/varenv unchanged

Closes #345