### PR TITLE
array: braced ${*} join, -v element-0, negative append subscript, declare error text

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2126,9 +2126,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // is the one exception: for `local' a bare `-' is the special save-options
     // operand (bash), not an identifier, so it is not rejected here.
     if (!valid_identifier(name) && !(local && a == "-")) {
-      std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
+      // bash reports the whole offending word, including any `=value'.
       std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+                   sh.err_prefix().c_str(), argv[0].c_str(), a.c_str());
       ret = 1;
       continue;
     }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -501,6 +501,12 @@ struct TestEval {
       for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
       return false;
     }
+    // A bare array name implicitly references element 0 (bash), which can be
+    // unset even when the array has other elements set.
+    if (sh.is_array(arg)) {
+      for (const std::string &k : sh.array_keys(arg)) if (k == "0") return true;
+      return false;
+    }
     return sh.is_set(arg);
   }
 
@@ -5566,6 +5572,12 @@ struct CondEval {
           if (!sh.array_expand_once_ok(nm, sub)) return false;  // diagnostic printed
           if (sub == "@" || sub == "*") return sh.array_count(nm) > 0;
           for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
+          return false;
+        }
+        // A bare array name implicitly references element 0 (bash), which can be
+        // unset even when the array has other elements set.
+        if (sh.is_array(arg)) {
+          for (const std::string &k : sh.array_keys(arg)) if (k == "0") return true;
           return false;
         }
         if (sh.is_set(arg)) return true;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -423,7 +423,13 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
   // right); an associative array takes any string as a key.
   auto tvit = sh.vars.find(sh.deref(name));
   bool assoc = tvit != sh.vars.end() && tvit->second.kind == VarKind::Assoc;
+  // A fresh `name=(...)' has already cleared the array, so negative subscripts
+  // resolve against the running max starting at -1.  An append `name+=(...)'
+  // keeps the existing elements, so a leading `[-1]=v' counts back from the
+  // current highest index (bash).
   long long maxidx = -1;
+  if (whole_append && !assoc && tvit != sh.vars.end() && !tvit->second.idx.empty())
+    maxidx = tvit->second.idx.rbegin()->first;
   // An associative array whose list already used `[key]=value' form is in
   // subscript mode: a later bare word is an error.  An all-bare list is a valid
   // flat key/value list, so only reject a bare word once a subscript was seen.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -787,7 +787,22 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             if (k) for (char c : joiner) { out += c; mask += '1'; }
             for (char c : pos[k]) { out += c; mask += '1'; }
           }
-        } else {
+        } else if (body[0] == '*' && splitting_ && sh_.ifs().empty()) {
+          bool first = true;  // empty IFS: separate fields, empties dropped
+          for (size_t k = 0; k < pos.size(); k++) {
+            if (pos[k].empty()) continue;
+            if (!first) { out += FIELD_SEP; mask += MMARK; }
+            first = false;
+            for (char c : pos[k]) { out += c; mask += '0'; }
+          }
+        } else if (body[0] == '*') {  // unquoted (non-empty IFS) / assignment: join IFS[0]
+          std::string sep = sh_.ifs();
+          std::string joiner = sep.empty() ? std::string() : std::string(1, sep[0]);
+          for (size_t k = 0; k < pos.size(); k++) {
+            if (k) for (char c : joiner) { out += c; mask += '0'; }
+            for (char c : pos[k]) { out += c; mask += '0'; }
+          }
+        } else {  // unquoted ${@}
           for (size_t k = 0; k < pos.size(); k++) {
             if (k) { out += FIELD_SEP; mask += MMARK; }
             for (char c : pos[k]) { out += c; mask += '0'; }


### PR DESCRIPTION
## Summary
Four small independent array fixes (each byte-perfects one sub):

1. **Braced `${*}`/`${@}`** now joins with IFS[0] in unquoted/no-split contexts (was losing the join char to a space). (array20)
2. **`-v arrayname`** references element 0 in both `test`/`[` and `[[ ]]` (was true whenever the array existed). (array16)
3. **Negative subscript in `name+=([-1]=v)`** resolves against the existing array's highest index. (array14)
4. **`declare` invalid-identifier** error reports the whole word including `=value`. (array2)

## Testing
- `ctest` 22/22; `run_diff` all 238 match
- array 121 → **~110** (array2/14/16/20 byte-perfect); cond/test/dbg-support/more-exp unchanged