### PR TITLE
array: unset assoc[@]/[*] literal key + declare +i pre-assignment clear

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2224,6 +2224,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // scalar path already honors the -i flag directly).
     if (integer && eq != std::string::npos && !name.empty() && !nameref)
       sh.vars[name].integer = true;
+    // `declare +i NAME=value' removes the integer attribute BEFORE the
+    // assignment, so an array/scalar value is stored verbatim rather than
+    // arithmetically evaluated (`declare +i arr=(hello world)').
+    if (rm_integer && eq != std::string::npos && !name.empty() && sh.vars.count(name))
+      sh.vars[name].integer = false;
     if (eq != std::string::npos) {
       std::string val = a.substr(eq + 1);
       bool arraylit = val.size() >= 2 && val.front() == '(' && val.back() == ')';

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -763,9 +763,11 @@ bool Shell::array_unset(const std::string &n_in, const std::string &sub) {
   if (it == vars.end()) return true;  // element of a missing array: no-op
   Variable &v = it->second;
   if (v.readonly) return true;
-  // `unset a[@]' / `unset a[*]' clears every element but leaves the (now empty)
-  // array in place -- bash still reports `declare -a a=()' afterward.
-  if (sub == "@" || sub == "*") {
+  // For an INDEXED array, `unset a[@]' / `unset a[*]' clears every element but
+  // leaves the (now empty) array in place.  For an ASSOCIATIVE array, `@'/`*'
+  // are ordinary literal keys (bash does not treat them as "all elements"), so
+  // fall through and erase just that key.
+  if ((sub == "@" || sub == "*") && v.kind != VarKind::Assoc) {
     v.idx.clear();
     v.assoc.clear();
     v.assoc_seq.clear();


### PR DESCRIPTION
## Summary
Two array attribute/unset fixes:
1. **`unset A[@]`/`A[*]` on an associative array** erases only the literal key `@`/`*` instead of clearing the whole array (indexed arrays still clear all). (array21)
2. **`declare +i NAME=value`** clears the integer attribute *before* the assignment, so the value is stored verbatim rather than arithmetically evaluated. (array15)

## Testing
- `ctest` 22/22; `run_diff` all 238 match
- array 102 → **98** (array15 byte-perfect); assoc/varenv/nameref/attr unchanged

Closes #350