### PR TITLE
array: declare -l/-u/-c case-folds compound array element values

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2252,6 +2252,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // arithmetically evaluated (`declare +i arr=(hello world)').
     if (rm_integer && eq != std::string::npos && !name.empty() && sh.vars.count(name))
       sh.vars[name].integer = false;
+    // The case-fold attributes (`-l'/`-u'/`-c') likewise apply to array literal
+    // elements, so set them before the assignment: array_set reads them from the
+    // variable (`declare -al a=(ONE TWO)' -> [0]=one).  The scalar path folds the
+    // value directly below, so this only matters for the compound-array path.
+    if (eq != std::string::npos && !name.empty() && !nameref) {
+      if (lcase) sh.vars[name].lcase = true;
+      else if (ucase) sh.vars[name].ucase = true;
+      else if (capcase) sh.vars[name].capcase = true;
+    }
     if (eq != std::string::npos) {
       std::string val = a.substr(eq + 1);
       bool arraylit = val.size() >= 2 && val.front() == '(' && val.back() == ')';

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -894,6 +894,23 @@ void Shell::array_assign(
     v.nameref = false;
   }
   v.invisible = false;  // even `b=()' makes a declared-but-unset array visible
+  // `declare -l'/`-u'/`-c' fold the case of each ELEMENT VALUE (never a key),
+  // exactly as Shell::set / array_set do for scalar and single-element writes.
+  auto fold_val = [&v](std::string s) {
+    if (v.ucase)
+      for (char &c : s) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    else if (v.lcase)
+      for (char &c : s) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    else if (v.capcase) {
+      bool first = true;
+      for (char &c : s) {
+        c = static_cast<char>(first ? std::toupper(static_cast<unsigned char>(c))
+                                    : std::tolower(static_cast<unsigned char>(c)));
+        first = false;
+      }
+    }
+    return s;
+  };
   if (!append) {
     v.idx.clear();
     v.assoc.clear();
@@ -908,24 +925,25 @@ void Shell::array_assign(
   // to explicit `([k]=v)' pairs (which keep their subscript below).
   if (v.kind == VarKind::Assoc) {
     for (size_t x = 0; x < elems.size(); x++) {
-      if (elems[x].first) { assoc_put(v, *elems[x].first, elems[x].second); continue; }
+      if (elems[x].first) { assoc_put(v, *elems[x].first, fold_val(elems[x].second)); continue; }
       const std::string &key = elems[x].second;
-      assoc_put(v, key, (x + 1 < elems.size()) ? elems[x + 1].second : std::string());
+      assoc_put(v, key,
+                fold_val((x + 1 < elems.size()) ? elems[x + 1].second : std::string()));
       x++;  // consumed the paired value
     }
     return;
   }
   for (const auto &e : elems) {
     if (v.kind == VarKind::Assoc) {
-      if (e.first) assoc_put(v, *e.first, e.second);
+      if (e.first) assoc_put(v, *e.first, fold_val(e.second));
     } else if (e.first) {
       bool ok = true;
       long long k = eval_arith(*this, *e.first, &ok);
       if (!ok) k = 0;
-      v.idx[k] = e.second;
+      v.idx[k] = fold_val(e.second);
       next = k + 1;
     } else {
-      v.idx[next++] = e.second;
+      v.idx[next++] = fold_val(e.second);
     }
   }
   if (v.kind == VarKind::Indexed && v.idx.count(0)) v.value = v.idx[0];


### PR DESCRIPTION
## Summary
`declare -al a=(ONE TWO)` now stores lowercased elements, and `declare -Au h=([k]=val)` uppercases the value but not the key. Two parts: set the case attribute before the compound assignment (like `-i`), and fold each element value in `array_assign` (never a key).

## Testing
- `ctest` 22/22; `run_diff` all 238 match
- array 87 → **85**; assoc/attr/varenv/nameref/quotearray unchanged

Closes #356