### PR TITLE
Testsuite batch 120: arith-subscript error-reporting cluster

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5314,12 +5314,88 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   } else if (cmd == "times") {
     st = 0;
   } else if (cmd == "wait") {
-    if (argv.size() > 1) {
-      Shell::Job *j = sh.job_by_spec(argv[1]);
-      if (j) { for (long p : j->pids) st = sh.wait_for_pid(p); }
-      else st = sh.wait_for_pid(std::atol(argv[1].c_str()));
+    // Options: -f (wait for termination, not just a status change), -n (return
+    // after the next job finishes) and -p VAR (store the finished job's pid in
+    // VAR).  A leading `-<digit>' is a (negative) id, not an option.
+    bool nflag = false, have_p = false, opt_err = false;
+    std::string pvar, badopt;
+    size_t ai = 1;
+    for (; ai < argv.size(); ai++) {
+      const std::string &o = argv[ai];
+      if (o == "--") { ai++; break; }
+      if (o.size() < 2 || o[0] != '-' ||
+          std::isdigit(static_cast<unsigned char>(o[1])))
+        break;
+      bool consumed_p = false;
+      for (size_t k = 1; k < o.size() && !opt_err; k++) {
+        char c = o[k];
+        if (c == 'n') nflag = true;
+        else if (c == 'f') { /* no async status tracking: -f is a no-op here */ }
+        else if (c == 'p') {
+          have_p = true;
+          if (k + 1 < o.size()) pvar = o.substr(k + 1);
+          else if (ai + 1 < argv.size()) pvar = argv[++ai];
+          consumed_p = true;
+          break;
+        } else { opt_err = true; badopt = std::string("-") + c; }
+      }
+      if (opt_err || consumed_p) { if (opt_err) break; else continue; }
+    }
+    if (opt_err) {
+      std::fprintf(stderr, "%swait: %s: invalid option\n", sh.err_prefix().c_str(),
+                   badopt.c_str());
+      std::fprintf(stderr, "wait: usage: wait [-fn] [-p var] [id ...]\n");
+      st = 2;
     } else {
-      st = sh.wait_all();
+      // Wait for the requested ids (bash waits for all of them; `-n' stops after
+      // the first), or for every job when none were named.  Capture a pid for -p.
+      long finished_pid = -1;
+      if (ai < argv.size()) {
+        for (size_t k = ai; k < argv.size(); k++) {
+          Shell::Job *j = sh.job_by_spec(argv[k]);
+          if (j) {
+            for (long p : j->pids) st = sh.wait_for_pid(p);
+            if (!j->pids.empty()) finished_pid = j->pids.front();
+          } else {
+            long pp = std::atol(argv[k].c_str());
+            st = sh.wait_for_pid(pp);
+            finished_pid = pp;
+          }
+          if (nflag) break;  // -n: return after the first id completes
+        }
+      } else if (!nflag && !have_p) {
+        st = sh.wait_all();
+      } else {
+        // Options but no ids and nothing to select: reap without blocking.  bash
+        // returns 127 ("no such job") when -n/-p find no job to wait for.
+        sh.reap_jobs(false);
+        st = 127;
+      }
+      // -p VAR: store the finished pid.  The name is validated like other
+      // builtins, and an array element subscript is arithmetic -- a bad one
+      // (e.g. under array_expand_once) raises bash's arithmetic diagnostic.
+      if (have_p) {
+        auto lb = pvar.find('[');
+        if (lb != std::string::npos && !pvar.empty() && pvar.back() == ']') {
+          std::string base = pvar.substr(0, lb);
+          std::string psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
+          if (!valid_identifier(base)) {
+            std::fprintf(stderr, "%swait: `%s': not a valid identifier\n",
+                         sh.err_prefix().c_str(), pvar.c_str());
+            st = 1;
+          } else if (!sh.array_expand_once_ok(base, psub)) {
+            st = 1;  // array_expand_once_ok already printed the arithmetic error
+          } else if (finished_pid >= 0) {
+            sh.array_set(base, psub, std::to_string(finished_pid));
+          }
+        } else if (!valid_identifier(pvar)) {
+          std::fprintf(stderr, "%swait: `%s': not a valid identifier\n",
+                       sh.err_prefix().c_str(), pvar.c_str());
+          st = 1;
+        } else if (finished_pid >= 0) {
+          sh.set(pvar, std::to_string(finished_pid));
+        }
+      }
     }
   } else if (cmd == "jobs") {
     sh.print_jobs();

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1383,6 +1383,12 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
     if (persist) restore.clear();
     undo_temp();
+    // A builtin that performs an internal assignment (e.g. `declare -i a[$bad]=x'
+    // under array_expand_once) can raise the arithmetic-error flag from deep in
+    // the assignment path -- past the pre-dispatch check above.  The builtin has
+    // already printed the diagnostic and set its own status, so clear the flag
+    // here; otherwise it would spuriously abort the *next* command.
+    sh_.arith_error = false;
   } else {
     undo_temp();  // not a builtin after all: the external path sets its own env
     // A command name without `/' that has been hashed (`hash -p', BASH_CMDS)

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1786,21 +1786,28 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   std::string val;
   std::string tsub;  // the expanded, zsh-translated subscript, for have_sub
   if (have_sub) {
-    // zsh subscripts are 1-based; translate before the (0-based) array read.
-    std::string esub = ex.expand_no_split(sub);
+    auto vit = sh.vars.find(sh.deref(name));
+    bool assoc_sub = vit != sh.vars.end() && vit->second.kind == VarKind::Assoc;
+    // An indexed/scalar subscript is an arithmetic expression, which bash expands
+    // in a double-quoted context (Q_DOUBLE_QUOTES): single quotes stay literal and
+    // a bare `~' is not tilde-expanded, so `${a[' ']}' / `${b[~]}' reach the
+    // evaluator as `' '` / `~' and raise a syntax error rather than reading index 0.
+    // Associative keys keep the plain expansion (their quoting rules differ).
+    std::string esub = assoc_sub ? ex.expand_no_split(sub) : ex.expand_dq_word(sub);
     if (!sh.array_expand_once_ok(name, esub)) { sh.arith_error = true; return std::string(); }
+    // zsh subscripts are 1-based; translate before the (0-based) array read.
     tsub = sh.zsh_subscript(name, esub);
     // An arithmetic (indexed) subscript may have side effects, e.g. ${a[i++]};
     // evaluate it exactly once here and reuse the canonical index for both the
     // read and the element-set test below, so array_get/array_elem_set don't
-    // evaluate it (and re-run the side effect) a second time.  Associative keys
-    // are literal, so leave them untouched.
-    auto vit = sh.vars.find(sh.deref(name));
-    bool assoc_sub = vit != sh.vars.end() && vit->second.kind == VarKind::Assoc;
+    // evaluate it (and re-run the side effect) a second time.  A syntax error in
+    // the subscript prints bash's arithmetic diagnostic and aborts the command.
+    // Associative keys are literal, so leave them untouched.
     if (!assoc_sub && tsub != "@" && tsub != "*") {
       bool aok = true;
-      long long idx = eval_arith(sh, tsub, &aok);
-      if (aok) tsub = std::to_string(idx);
+      long long idx = eval_arith_msg(sh, tsub, "", &aok);
+      if (!aok) { sh.arith_error = true; return std::string(); }
+      tsub = std::to_string(idx);
     }
     val = sh.array_get(name, tsub);
     // A defaulting/alternative operator on a single element (${a[i]-x}, ${a[i]=x},


### PR DESCRIPTION
Completes the arith-subscript error-reporting cluster (array17/25/32).

## Changes
1. **expand**: indexed/scalar array subscripts are arithmetic expressions that bash expands in a double-quoted context (`Q_DOUBLE_QUOTES`) — single quotes stay literal and a bare `~` is not tilde-expanded. gnash stripped quotes / expanded `~` and silently read index 0 on failure. Now expands with `expand_dq_word` and evaluates with `eval_arith_msg`, so `${a[' ']}` and `${b[~]}` raise bash's `arithmetic syntax error` and abort the command. *(array17, array25)*
2. **executor**: `declare -i a[$bad]=x` raised `arith_error` deep inside the builtin, past the pre-dispatch check, leaking to abort the *next* command. Clear the flag after a builtin completes. *(array32's missing `declare -ai a`)*
3. **builtins**: `wait` now parses `-f`/`-n`/`-p var`, assigns the finished pid to the `-p` variable, and validates that target (invalid identifier, and an array-element subscript is arithmetic so a bad one errors). *(array32's `wait -n -p a[$bad]`, plus jobs/assoc gains)*

## Verification
- `array17`, `array25`, `array32` now match bash byte-for-byte.
- Scoreboard: **array 85→75, jobs 67→66, assoc 82→80, arith 168→164**; quotearray/nameref unchanged. No regressions (`intl`'s high count is pre-existing locale divergence — it uses no arrays/wait).
- `ctest --test-dir build`: 22/22.
- `run_diff.sh`: all 238 scripts match bash.