### PR TITLE
Testsuite batch 121: wait -n job selection

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -243,6 +243,11 @@ class Shell {
   Job *job_by_spec(const std::string &spec);  // %n / %% / %+ / %- / pid
   int wait_for_pid(long pid);                  // block, return exit status
   int wait_all();                              // wait for all jobs
+  // `wait -n': block until the next of the given jobs (by id; empty = any job)
+  // terminates.  Returns its status; sets *finished_pid to a member pid and
+  // *found.  With no matching job, sets *found=false and returns 127.  The
+  // completed job is consumed (removed from the table).
+  int wait_next(const std::vector<int> &ids, long *finished_pid, bool *found);
   void reap_jobs(bool notify);                 // non-blocking reap (+ optional report)
   bool check_job_events();                     // reap; true if unreported job events exist
   void emit_job_notices();                     // print "[n]+ Done/Stopped"; mark; drop finished

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5347,53 +5347,81 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       std::fprintf(stderr, "wait: usage: wait [-fn] [-p var] [id ...]\n");
       st = 2;
     } else {
-      // Wait for the requested ids (bash waits for all of them; `-n' stops after
-      // the first), or for every job when none were named.  Capture a pid for -p.
       long finished_pid = -1;
-      if (ai < argv.size()) {
+      bool found = false;
+      if (nflag) {
+        // `-n': return after the NEXT of the named jobs finishes (or any job
+        // when none are named).  Resolve each id to a job; an unknown `%spec'
+        // reports "no such job" but the wait proceeds with the rest.
+        std::vector<int> ids;
+        for (size_t k = ai; k < argv.size(); k++) {
+          Shell::Job *j = sh.job_by_spec(argv[k]);
+          if (j) ids.push_back(j->id);
+          else {
+            std::fprintf(stderr, "%swait: %s: no such job\n", sh.err_prefix().c_str(),
+                         argv[k].c_str());
+            st = 127;
+          }
+        }
+        // With ids named but none resolvable, there is nothing to wait for.
+        if (ai < argv.size() && ids.empty()) st = 127;
+        else st = sh.wait_next(ids, &finished_pid, &found);
+      } else if (ai < argv.size()) {
+        // Wait for every named id (bash waits for all of them).  The last one's
+        // pid is the -p result.
         for (size_t k = ai; k < argv.size(); k++) {
           Shell::Job *j = sh.job_by_spec(argv[k]);
           if (j) {
             for (long p : j->pids) st = sh.wait_for_pid(p);
-            if (!j->pids.empty()) finished_pid = j->pids.front();
+            if (!j->pids.empty()) { finished_pid = j->pids.front(); found = true; }
           } else {
             long pp = std::atol(argv[k].c_str());
             st = sh.wait_for_pid(pp);
             finished_pid = pp;
+            found = true;
           }
-          if (nflag) break;  // -n: return after the first id completes
         }
-      } else if (!nflag && !have_p) {
+      } else if (!have_p) {
         st = sh.wait_all();
       } else {
-        // Options but no ids and nothing to select: reap without blocking.  bash
-        // returns 127 ("no such job") when -n/-p find no job to wait for.
+        // `-p var' with no ids and no `-n': reap without blocking; the var is
+        // left unset (bash) when no job supplied a pid.
         sh.reap_jobs(false);
-        st = 127;
+        st = 0;
       }
-      // -p VAR: store the finished pid.  The name is validated like other
-      // builtins, and an array element subscript is arithmetic -- a bad one
-      // (e.g. under array_expand_once) raises bash's arithmetic diagnostic.
+      // -p VAR: store the finished pid, or unset VAR when no job was waited for.
+      // The name is validated like other builtins, and an array-element
+      // subscript is arithmetic (a bad one raises bash's arithmetic diagnostic).
       if (have_p) {
         auto lb = pvar.find('[');
-        if (lb != std::string::npos && !pvar.empty() && pvar.back() == ']') {
-          std::string base = pvar.substr(0, lb);
-          std::string psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
-          if (!valid_identifier(base)) {
-            std::fprintf(stderr, "%swait: `%s': not a valid identifier\n",
-                         sh.err_prefix().c_str(), pvar.c_str());
-            st = 1;
-          } else if (!sh.array_expand_once_ok(base, psub)) {
-            st = 1;  // array_expand_once_ok already printed the arithmetic error
-          } else if (finished_pid >= 0) {
-            sh.array_set(base, psub, std::to_string(finished_pid));
-          }
-        } else if (!valid_identifier(pvar)) {
+        std::string base = pvar, psub;
+        bool subscripted = lb != std::string::npos && !pvar.empty() && pvar.back() == ']';
+        if (subscripted) {
+          base = pvar.substr(0, lb);
+          psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
+        }
+        if (!valid_identifier(base)) {
           std::fprintf(stderr, "%swait: `%s': not a valid identifier\n",
                        sh.err_prefix().c_str(), pvar.c_str());
           st = 1;
-        } else if (finished_pid >= 0) {
-          sh.set(pvar, std::to_string(finished_pid));
+        } else if (found && finished_pid >= 0) {
+          if (subscripted) {
+            if (!sh.array_expand_once_ok(base, psub)) st = 1;  // arith error printed
+            else sh.array_set(base, psub, std::to_string(finished_pid));
+          } else {
+            sh.set(pvar, std::to_string(finished_pid));
+          }
+        } else if (!subscripted) {
+          // No job finished: bash unsets the -p variable.  A readonly target
+          // cannot be unset and is reported as such.
+          auto it = sh.vars.find(sh.deref(base));
+          if (it != sh.vars.end() && it->second.readonly) {
+            std::fprintf(stderr, "%swait: %s: cannot unset: readonly variable\n",
+                         sh.err_prefix().c_str(), base.c_str());
+            st = 1;
+          } else {
+            sh.unset(pvar);
+          }
         }
       }
     }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5430,11 +5430,42 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       st = 1;
     }
   } else if (cmd == "disown") {
-    Shell::Job *j = sh.job_by_spec(argv.size() > 1 ? argv[1] : "");
-    if (j) {
-      int id = j->id;
+    // disown [-h] [-ar] [jobspec ... | pid ...]: -a all jobs, -r running jobs
+    // only, -h keep the job but mark it to skip SIGHUP.  With no jobspec (and no
+    // -a/-r) it acts on the current job.  We drop disowned jobs from the table
+    // (the -h "keep but no HUP" nuance is not modelled -- we have no HUP-on-exit).
+    bool all = false, running_only = false, hold = false;
+    std::vector<std::string> specs;
+    for (size_t k = 1; k < argv.size(); k++) {
+      const std::string &o = argv[k];
+      if (o.size() >= 2 && o[0] == '-' && o != "--") {
+        for (size_t c = 1; c < o.size(); c++) {
+          if (o[c] == 'a') all = true;
+          else if (o[c] == 'r') running_only = true;
+          else if (o[c] == 'h') hold = true;
+        }
+      } else if (o == "--") {
+        continue;
+      } else {
+        specs.push_back(o);
+      }
+    }
+    std::vector<int> drop;
+    if (all || running_only) {
+      for (const auto &x : sh.jobs)
+        if (!running_only || (x.running && !x.done)) drop.push_back(x.id);
+    } else if (!specs.empty()) {
+      for (const auto &s : specs)
+        if (Shell::Job *j = sh.job_by_spec(s)) drop.push_back(j->id);
+    } else if (Shell::Job *j = sh.job_by_spec("")) {
+      drop.push_back(j->id);
+    }
+    if (!hold) {
       sh.jobs.erase(std::remove_if(sh.jobs.begin(), sh.jobs.end(),
-                                   [id](const Shell::Job &x) { return x.id == id; }),
+                                   [&](const Shell::Job &x) {
+                                     return std::find(drop.begin(), drop.end(), x.id) !=
+                                            drop.end();
+                                   }),
                     sh.jobs.end());
     }
     st = 0;

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -167,6 +167,71 @@ int Shell::wait_for_pid(long pid) {
   return rc;
 }
 
+int Shell::wait_next(const std::vector<int> &ids, long *finished_pid, bool *found) {
+  *found = false;
+  if (finished_pid) *finished_pid = -1;
+  auto is_target = [&](const Job &j) {
+    return ids.empty() || std::find(ids.begin(), ids.end(), j.id) != ids.end();
+  };
+  // No matching job at all: bash's `wait -n' returns 127 ("no such job").
+  bool any = false;
+  for (const auto &j : jobs)
+    if (is_target(j)) { any = true; break; }
+  if (!any) return 127;
+
+  // Consume an already-finished target immediately (it terminated before this
+  // `wait -n', e.g. reaped by a prior non-blocking check).
+  for (size_t k = 0; k < jobs.size(); k++) {
+    if (is_target(jobs[k]) && jobs[k].done) {
+      int rc = jobs[k].status;
+      if (finished_pid && !jobs[k].pids.empty()) *finished_pid = jobs[k].pids.back();
+      *found = true;
+      jobs.erase(jobs.begin() + k);
+      return rc;
+    }
+  }
+
+  // Otherwise block for children to change state, updating the job table, until
+  // a target job has fully terminated.  A job's status is its last member's
+  // (pipeline semantics); intermediate members are reaped as they exit.
+  for (;;) {
+    int wst = 0;
+    pid_t pid = waitpid(-1, &wst, WUNTRACED);
+    if (pid <= 0) {
+      if (errno == EINTR) continue;
+      return 127;  // no more children to wait for
+    }
+    Job *owner = nullptr;
+    for (auto &j : jobs) {
+      for (long p : j.pids)
+        if (p == pid) { owner = &j; break; }
+      if (owner) break;
+    }
+    if (WIFSTOPPED(wst)) {
+      if (owner) { owner->stopped = true; owner->running = false; }
+      continue;
+    }
+    note_child_reaped();  // a background child terminated -> pending SIGCHLD trap
+    if (!owner) continue;  // an untracked child (e.g. a command-substitution straggler)
+    int rc = WIFEXITED(wst) ? WEXITSTATUS(wst)
+                            : 128 + (WIFSIGNALED(wst) ? WTERMSIG(wst) : 0);
+    // The job is done once its final member exits; that member's status is the
+    // job's exit status.
+    if (pid == owner->pids.back()) {
+      owner->done = true;
+      owner->running = false;
+      owner->status = rc;
+      if (is_target(*owner)) {
+        if (finished_pid) *finished_pid = owner->pids.back();
+        *found = true;
+        int r = owner->status;
+        jobs.erase(jobs.begin() + (owner - &jobs[0]));
+        return r;
+      }
+    }
+  }
+}
+
 int Shell::wait_all() {
   int st = 0;
   for (auto &j : jobs) {


### PR DESCRIPTION
Implements full `wait -n` job-selection — the job-control feature deferred from batch 120.

## Changes
1. **jobs**: add `Shell::wait_next`, which blocks until the next of a set of jobs (by id, or any job when the set is empty) terminates, returns that job's status, reports a member pid, and consumes the finished job. Rewire `wait` to use it for `-n`: unknown `%spec` reports `no such job` but the wait continues; `-p var` stores the finished pid, and is unset (readonly → `cannot unset: readonly variable`) when no job is waited for.
2. **builtins**: `disown` now parses `-a`/`-r`/`-h` plus any number of jobspecs — previously `disown -a` resolved `-a` as a bogus pid and removed nothing, which broke job renumbering.

## Verification
- `jobs5` now matches bash byte-for-byte (stable across repeated runs); `jobs6`, `array32` unaffected.
- Scoreboard: **jobs 66 → 31**; assoc unchanged (its remaining diffs are the bracket-in-key cluster).
- `ctest`: 22/22. `run_diff.sh`: all 238 scripts match.

Not covered: the remaining `jobs` diffs (31) are unrelated job-control formatting in other jobs subs.