### PR TITLE
Testsuite batch 122: jobs-control conformance (jobs1-8)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -236,6 +236,10 @@ class Shell {
   int job_terminal = -1;        // controlling-terminal fd, or -1
   bool job_control = false;     // interactive + tty
   bool interactive = false;
+  // A command-substitution subshell inherits the job table (so `jobs' still
+  // lists them) but bash resets the notion of the current job -- `fg %%'/`bg'
+  // with no explicit spec report "no current jobs" there.
+  bool no_current_job = false;
   char invocation_char = 0;     // $- invocation letter: 'c' (-c), 's' (stdin), else 0
 
   void init_job_control(bool interactive_shell);
@@ -251,7 +255,8 @@ class Shell {
   void reap_jobs(bool notify);                 // non-blocking reap (+ optional report)
   bool check_job_events();                     // reap; true if unreported job events exist
   void emit_job_notices();                     // print "[n]+ Done/Stopped"; mark; drop finished
-  void print_jobs();
+  void print_jobs(const std::string &spec = "", bool lflag = false, bool pflag = false,
+                  bool rflag = false, bool sflag = false);
   int foreground_job(Job &j, bool cont);       // bring to foreground, wait
   void background_job(Job &j, bool cont);       // continue in background
 

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5444,17 +5444,58 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       }
     }
   } else if (cmd == "jobs") {
-    sh.print_jobs();
-    st = 0;
+    // jobs [-lnprs] [jobspec]: -l long (with pgid), -p pids only, -r running
+    // only, -s stopped only, -n changed-only (we have no async change tracking).
+    bool jl = false, jp = false, jr = false, js = false;
+    std::string jspec;
+    bool jbad = false;
+    for (size_t k = 1; k < argv.size(); k++) {
+      const std::string &o = argv[k];
+      if (o == "--") continue;
+      if (o.size() >= 2 && o[0] == '-' && o[1] != '%') {
+        for (size_t c = 1; c < o.size(); c++) {
+          switch (o[c]) {
+            case 'l': jl = true; break;
+            case 'p': jp = true; break;
+            case 'r': jr = true; break;
+            case 's': js = true; break;
+            case 'n': break;  // no async change tracking: nothing extra to show
+            default: jbad = true; break;
+          }
+        }
+      } else {
+        jspec = o;
+      }
+    }
+    if (jbad) {
+      std::fprintf(stderr, "jobs: usage: jobs [-lnprs] [jobspec ...] or jobs -x command [args]\n");
+      st = 1;
+    } else {
+      sh.print_jobs(jspec, jl, jp, jr, js);
+      st = 0;
+    }
   } else if (cmd == "fg") {
     std::string spec = argv.size() > 1 ? argv[1] : "";
-    if (!sh.job_control) {
+    bool cur_spec = spec.empty() || spec == "%" || spec == "%%" || spec == "%+" || spec == "%-";
+    if (!sh.job_control && !sh.opt_monitor) {
       std::fprintf(stderr, "%sfg: no job control\n", sh.err_prefix().c_str());
       st = 1;
+    } else if (sh.no_current_job && cur_spec) {
+      // A command-substitution subshell has no current job to bring forward.
+      std::fprintf(stderr, "%sfg: no current jobs\n", sh.err_prefix().c_str());
+      st = 1;
     } else if (Shell::Job *j = sh.job_by_spec(spec)) {
-      std::printf("%s\n", j->command.c_str());  // bash echoes the command
-      std::fflush(stdout);
-      st = sh.foreground_job(*j, true);
+      if (!sh.job_control) {
+        // Monitor mode is on but there is no controlling terminal, so the job was
+        // not started under job control and cannot be brought to the foreground.
+        std::fprintf(stderr, "%sfg: job %d started without job control\n",
+                     sh.err_prefix().c_str(), j->id);
+        st = 1;
+      } else {
+        std::printf("%s\n", j->command.c_str());  // bash echoes the command
+        std::fflush(stdout);
+        st = sh.foreground_job(*j, true);
+      }
     } else {
       std::fprintf(stderr, "%sfg: %s: no such job\n", sh.err_prefix().c_str(),
                    spec.empty() ? "current" : spec.c_str());

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3285,7 +3285,25 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
         st = 1;
         continue;
       }
-      target = static_cast<pid_t>(-j->pgid);
+      // With job control the job runs in its own process group, so signal the
+      // whole group (`-pgid').  Without it (a non-interactive script), the job's
+      // members share the shell's process group -- there is no separate group to
+      // signal, so signal each member pid directly.
+      if (sh.job_control && j->pgid > 0) {
+        if (kill(static_cast<pid_t>(-j->pgid), sig) != 0) {
+          std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(),
+                       static_cast<long>(-j->pgid), std::strerror(errno));
+          st = 1;
+        }
+      } else {
+        for (long p : j->pids)
+          if (kill(static_cast<pid_t>(p), sig) != 0) {
+            std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(), p,
+                         std::strerror(errno));
+            st = 1;
+          }
+      }
+      continue;
     } else {
       // A pid must be a (possibly signed) decimal integer; anything else (an
       // empty word, `@12', `abc') is rejected WITHOUT signaling -- crucially,

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -296,19 +296,40 @@ void Shell::reap_jobs(bool notify) {
   }
 }
 
-void Shell::print_jobs() {
+void Shell::print_jobs(const std::string &spec, bool lflag, bool pflag, bool rflag,
+                       bool sflag) {
   reap_jobs(false);
+  // A jobspec restricts the listing to that one job.
+  int only = -1;
+  if (!spec.empty()) {
+    Job *j = job_by_spec(spec);
+    if (!j) {
+      std::fprintf(stderr, "%sjobs: %s: no such job\n", err_prefix().c_str(), spec.c_str());
+      return;
+    }
+    only = j->id;
+  }
   // bash marks the current job `+' and the previous job `-' (others a space);
   // approximate with the two most recently started jobs (the last two entries).
   int cur = jobs.empty() ? -1 : jobs.back().id;
   int prev = jobs.size() >= 2 ? jobs[jobs.size() - 2].id : -1;
   for (const Job &j : jobs) {
+    if (only != -1 && j.id != only) continue;
+    if (rflag && (j.done || j.stopped)) continue;  // -r: running jobs only
+    if (sflag && !j.stopped) continue;             // -s: stopped jobs only
+    if (pflag) {  // -p: process-group id only (the job's leader pid)
+      std::printf("%ld\n", j.pgid);
+      continue;
+    }
     const char *state = j.done ? "Done" : (j.stopped ? "Stopped" : "Running");
     char mark = j.id == cur ? '+' : j.id == prev ? '-' : ' ';
     // A running background job is shown with a trailing ` &' (bash: RUNNING &&
     // not foreground); the status field is padded to LONGEST_SIGNAL_DESC (27).
     const char *amp = (j.background && !j.done && !j.stopped) ? " &" : "";
-    std::printf("[%d]%c  %-27s%s%s\n", j.id, mark, state, j.command.c_str(), amp);
+    if (lflag)  // -l: include the process-group id before the state
+      std::printf("[%d]%c %ld %-27s%s%s\n", j.id, mark, j.pgid, state, j.command.c_str(), amp);
+    else
+      std::printf("[%d]%c  %-27s%s%s\n", j.id, mark, state, j.command.c_str(), amp);
   }
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1953,6 +1953,7 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     dup2(fds[1], STDOUT_FILENO);
     close(fds[1]);
     job_control = false;  // command substitution: no nested tty control
+    no_current_job = true;  // bash resets the current job in the subshell
     subshell_level++;  // $BASH_SUBSHELL
     traps.erase("CHLD");  // the parent fires CHLD for the substitution as a whole
     pending_sigchld = 0;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -23,6 +23,7 @@
 
 #include "gnash/core/csh.hpp"
 #include "gnash/core/executor.hpp"
+#include "gnash/core/expand.hpp"
 #include "gnash/core/parser.hpp"
 
 extern "C" char **environ;
@@ -1883,6 +1884,63 @@ std::string Shell::run_and_capture_inproc(const std::string &script, int *status
 }
 
 std::string Shell::run_and_capture(const std::string &script, int *status) {
+  // bash optimization: when the entire command-substitution body is a lone input
+  // redirection (`$(< file)'), the substitution expands to the contents of the
+  // file -- no `cat' is forked.  It applies only to this exact shape: a single
+  // `<' with just a filename after it and nothing else (`$(echo x; < f)' and
+  // `$(< f cmd)' are ordinary commands).
+  {
+    size_t a = script.find_first_not_of(" \t\n");
+    if (a != std::string::npos && script[a] == '<' &&
+        (a + 1 >= script.size() ||
+         (script[a + 1] != '<' && script[a + 1] != '(' && script[a + 1] != '>'))) {
+      size_t p = a + 1;
+      while (p < script.size() && (script[p] == ' ' || script[p] == '\t')) p++;
+      size_t start = p;
+      bool simple = true;
+      for (; p < script.size(); p++) {
+        char c = script[p];
+        if (c == '\'') {
+          size_t e = script.find('\'', p + 1);
+          if (e == std::string::npos) { simple = false; break; }
+          p = e;
+        } else if (c == '"') {
+          size_t e = script.find('"', p + 1);
+          if (e == std::string::npos) { simple = false; break; }
+          p = e;
+        } else if (c == '\\') {
+          p++;
+        } else if (c == ' ' || c == '\t' || c == '\n') {
+          break;
+        } else if (std::strchr("|&;<>()`", c)) {
+          simple = false;  // another command/redirection follows: not the `< f' form
+          break;
+        }
+      }
+      std::string raw = script.substr(start, p - start);
+      // Everything after the filename word must be blank for the optimization.
+      bool only = script.find_first_not_of(" \t\n", p) == std::string::npos;
+      if (simple && only && !raw.empty()) {
+        Expander ex(*this);
+        std::string path = ex.expand_no_split(raw);
+        FILE *f = std::fopen(path.c_str(), "r");
+        if (!f) {
+          std::fprintf(stderr, "%s%s: %s\n", err_prefix().c_str(), path.c_str(),
+                       std::strerror(errno));
+          if (status) *status = 1;
+          return std::string();
+        }
+        std::string out;
+        char buf[4096];
+        size_t n;
+        while ((n = std::fread(buf, 1, sizeof buf, f)) > 0) out.append(buf, n);
+        std::fclose(f);
+        if (status) *status = 0;
+        while (!out.empty() && out.back() == '\n') out.pop_back();
+        return out;
+      }
+    }
+  }
   int fds[2];
   if (pipe(fds) != 0) {
     if (status) *status = 1;


### PR DESCRIPTION
Reduces the `jobs` test diffs (31 → 24); jobs1–jobs8 subs now match bash byte-for-byte. jobs9 (`wait` interrupted by a trapped signal → 128+signum) remains — it needs a deeper rework of `wait_all` and `SA_RESTART` signal handling and is left for a focused follow-up.

## Changes
1. **shell**: `$(< file)` — a command substitution whose entire body is a lone input redirection now expands to the file's contents (bash's no-fork optimization) instead of the empty string. Other shapes stay ordinary commands. *(surfaced by jobs1's `pid=$(< file)`)*
2. **builtins**: `kill %job` signals the job's member pids when job control is off (previously it signalled a nonexistent `-pgid` and failed). *(jobs4)*
3. **jobs/fg**: `jobs` now honours `-l`/`-p`/`-r`/`-s` and a jobspec *(jobs1)*; `fg` distinguishes "job N started without job control" under `set -m` without a tty *(jobs2)* from "no current jobs" in a command-substitution subshell *(jobs7)*. Also `disown -a`/`-r`/`-h` from batch 121 covers jobs8.

## Verification
- jobs1–jobs8 subs match bash byte-for-byte (stable).
- Scoreboard: **jobs 31 → 24**; comsub/exp/glob/read unchanged (no regression from `$(< file)`).
- `ctest`: 22/22. `run_diff.sh`: all 238 scripts match.