### PR TITLE
jobs: complete job-control conformance for the bash test suite

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -208,6 +208,12 @@ class Shell {
   bool in_trap = false;                       // guard against trap recursion
   void set_signal_trap(int signo, bool active);  // (de)install the shared handler
   void run_pending_traps();                   // run traps for signals received
+  // Around a blocking `wait', re-install trapped-signal handlers WITHOUT
+  // SA_RESTART so a trapped signal interrupts the wait (EINTR) rather than
+  // resuming it; end_ restores the normal (restarting) handlers.
+  void begin_interruptible_wait();
+  void end_interruptible_wait();
+  int pending_trapped_signal();               // a pending signal that has a trap, or 0
   void note_child_reaped();                   // count a reaped child for the SIGCHLD trap
   int pending_sigchld = 0;                     // children reaped, awaiting the CHLD trap
   // Run the DEBUG trap (if set) before a command, with $BASH_COMMAND set to

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -236,6 +236,7 @@ class Shell {
     int status = 0;             // exit status when done
     bool notified = false;
     bool background = false;
+    bool monitored = false;     // job control (set -m / interactive) was on at start
   };
   std::vector<Job> jobs;
   // Current (`+') and previous (`-') job ids, maintained incrementally the way

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -238,6 +238,14 @@ class Shell {
     bool background = false;
   };
   std::vector<Job> jobs;
+  // Current (`+') and previous (`-') job ids, maintained incrementally the way
+  // bash does (0 == none).  A job that stops or is newly backgrounded becomes
+  // current; the old current becomes previous.
+  int j_current = 0;
+  int j_previous = 0;
+  void set_current_job(int id);   // make ID the current job, pick a useful previous
+  void reset_current();           // recompute current/previous after a change
+  void remove_jobs_if(const std::function<bool(const Job &)> &pred);  // erase + reset_current
   long shell_pgid = 0;
   int job_terminal = -1;        // controlling-terminal fd, or -1
   bool job_control = false;     // interactive + tty

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3203,6 +3203,7 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
       char *end = nullptr;
       long n = std::strtol(spec.c_str(), &end, 10);
       if (*end != '\0') return -1;
+      if (n == 0) return 0;  // signal 0: no name, but valid (existence check)
       return trapname_from_num(static_cast<int>(n)) ? static_cast<int>(n) : -1;
     }
     std::string n = spec;
@@ -3244,20 +3245,27 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
   size_t i = 1;
   if (argv.size() > 1 && argv[1].size() > 1 && argv[1][0] == '-' && argv[1] != "--") {
     std::string opt = argv[1];
-    if (opt == "-s" || opt == "-n") {
-      // The signal is the next word: `-s TERM' / `-n 15'.
-      if (argv.size() < 3) {
+    if (opt[1] == 's' || opt[1] == 'n') {
+      // `-s sigspec' / `-n signum': the argument is either attached to the
+      // option (`-sHUP', `-n9') or the following word (`-s HUP', `-n 9').
+      std::string arg;
+      if (opt.size() > 2) {
+        arg = opt.substr(2);
+        i = 2;
+      } else if (argv.size() > 2) {
+        arg = argv[2];
+        i = 3;
+      } else {
         std::fprintf(stderr, "%skill: %s: option requires an argument\n",
                      sh.err_prefix().c_str(), opt.c_str());
         return 1;
       }
-      sig = resolve_sig(argv[2]);
+      sig = resolve_sig(arg);
       if (sig < 0) {
         std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
-                     sh.err_prefix().c_str(), argv[2].c_str());
+                     sh.err_prefix().c_str(), arg.c_str());
         return 1;
       }
-      i = 3;
     } else {
       // `-INT' / `-9' / `-SIGHUP': the spec is the option itself.
       sig = resolve_sig(opt.substr(1));

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5396,15 +5396,49 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // Wait for every named id (bash waits for all of them).  The last one's
         // pid is the -p result.
         for (size_t k = ai; k < argv.size(); k++) {
-          Shell::Job *j = sh.job_by_spec(argv[k]);
-          if (j) {
-            for (long p : j->pids) st = sh.wait_for_pid(p);
+          const std::string &spec = argv[k];
+          if (!spec.empty() && spec[0] == '%') {
+            // A `%jobspec' that names no job: bash reports it and returns 127.
+            Shell::Job *j = sh.job_by_spec(spec);
+            if (!j) {
+              std::fprintf(stderr, "%swait: %s: no such job\n",
+                           sh.err_prefix().c_str(), spec.c_str());
+              st = 127;
+              continue;
+            }
+            int wid = j->id;
             if (!j->pids.empty()) { finished_pid = j->pids.front(); found = true; }
+            for (long p : j->pids) st = sh.wait_for_pid(p);
+            // A waited-for job is consumed: bash removes it so its number frees
+            // up for reuse by the next async job.
+            sh.remove_jobs_if([wid](const Shell::Job &x) { return x.id == wid; });
           } else {
-            long pp = std::atol(argv[k].c_str());
+            // Anything not a `%jobspec' must be a decimal pid.
+            bool numeric = !spec.empty();
+            for (char c : spec)
+              if (!std::isdigit(static_cast<unsigned char>(c))) { numeric = false; break; }
+            if (!numeric) {
+              std::fprintf(stderr, "%swait: `%s': not a pid or valid job spec\n",
+                           sh.err_prefix().c_str(), spec.c_str());
+              st = 1;
+              continue;
+            }
+            long pp = std::atol(spec.c_str());
+            Shell::Job *pj = sh.job_by_spec(spec);
+            if (!pj) {
+              std::fprintf(stderr, "%swait: pid %ld is not a child of this shell\n",
+                           sh.err_prefix().c_str(), pp);
+              st = 127;
+              continue;
+            }
+            int wid = pj->id;
             st = sh.wait_for_pid(pp);
             finished_pid = pp;
             found = true;
+            // The waited-for job is consumed once it is fully done, so its
+            // number frees up for reuse (bash removes it after `wait pid').
+            sh.remove_jobs_if(
+                [wid](const Shell::Job &x) { return x.id == wid && x.done; });
           }
         }
       } else if (!have_p) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -5493,9 +5493,10 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       std::fprintf(stderr, "%sfg: no current jobs\n", sh.err_prefix().c_str());
       st = 1;
     } else if (Shell::Job *j = sh.job_by_spec(spec)) {
-      if (!sh.job_control) {
-        // Monitor mode is on but there is no controlling terminal, so the job was
-        // not started under job control and cannot be brought to the foreground.
+      if (!j->monitored) {
+        // The job was started when job control was inactive (bash's
+        // IS_JOBCONTROL(job) == 0), so it cannot be brought to the foreground
+        // even though monitor mode is on now.
         std::fprintf(stderr, "%sfg: job %d started without job control\n",
                      sh.err_prefix().c_str(), j->id);
         st = 1;

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -166,7 +166,13 @@ Shell::Job *Shell::job_by_spec(const std::string &spec) {
         if (j.id == id) return &j;
       return nullptr;
     }
-    for (auto &j : jobs)  // prefix match on command
+    if (s[0] == '?') {  // %?str: the job whose command CONTAINS str
+      std::string sub = s.substr(1);
+      for (auto &j : jobs)
+        if (!j.done && j.command.find(sub) != std::string::npos) return &j;
+      return nullptr;
+    }
+    for (auto &j : jobs)  // %str: the job whose command STARTS with str
       if (!j.done && j.command.rfind(s, 0) == 0) return &j;
     return nullptr;
   }

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -354,6 +354,8 @@ int Shell::wait_all() {
   int wst;
   while (waitpid(-1, &wst, WNOHANG) > 0) note_child_reaped();  // reap exited stragglers
   end_interruptible_wait();
+  // bash's `wait' with no operands removes every terminated job it reaped.
+  remove_jobs_if([](const Job &j) { return j.done; });
   return st;
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -72,6 +72,10 @@ Shell::Job *Shell::add_job(long pgid, const std::vector<long> &pids, const std::
   j.command = cmd;
   j.background = background;
   j.running = true;
+  // Record whether job control was active when the job started: bash's
+  // J_JOBCONTROL.  `fg'/`bg' only operate on such jobs; one started with
+  // monitor off reports "started without job control" even after `set -m'.
+  j.monitored = job_control || opt_monitor;
   jobs.push_back(j);
   // A newly-created background job becomes the current job (bash: reset_current
   // after stop_pipeline for an async job).
@@ -197,7 +201,11 @@ int wait_job(Shell::Job &j) {
 int Shell::foreground_job(Job &j, bool cont) {
   if (job_control) tcsetpgrp(job_terminal, static_cast<pid_t>(j.pgid));
   if (cont) {
-    kill(static_cast<pid_t>(-j.pgid), SIGCONT);
+    // With a job-control terminal the job has its own process group; without
+    // one (set -m in a script) its members share the shell's group, so signal
+    // the member pids directly rather than the group.
+    if (job_control) kill(static_cast<pid_t>(-j.pgid), SIGCONT);
+    else for (long p : j.pids) kill(static_cast<pid_t>(p), SIGCONT);
     j.stopped = false;
     j.running = true;
   }
@@ -211,7 +219,8 @@ int Shell::foreground_job(Job &j, bool cont) {
 
 void Shell::background_job(Job &j, bool cont) {
   if (cont) {
-    kill(static_cast<pid_t>(-j.pgid), SIGCONT);
+    if (job_control) kill(static_cast<pid_t>(-j.pgid), SIGCONT);
+    else for (long p : j.pids) kill(static_cast<pid_t>(p), SIGCONT);
     j.stopped = false;
     j.running = true;
   }

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -234,11 +234,52 @@ int Shell::wait_next(const std::vector<int> &ids, long *finished_pid, bool *foun
 
 int Shell::wait_all() {
   int st = 0;
-  for (auto &j : jobs) {
-    if (!j.done) { st = wait_job(j); if (j.done) for (size_t k = 0; k < j.pids.size(); k++) note_child_reaped(); }
+  // Block until every background job has terminated, reaping whichever child
+  // changes state first (not job-by-job in order, so one job finishing early
+  // is observed immediately).  A trapped signal interrupts the wait: bash's
+  // `wait' returns 128+signum, then the trap runs (jobs9).
+  begin_interruptible_wait();
+  for (;;) {
+    bool running = false;
+    for (const auto &j : jobs)
+      if (!j.done && !j.stopped) { running = true; break; }
+    if (!running) break;
+
+    int wst = 0;
+    pid_t pid = waitpid(-1, &wst, WUNTRACED);
+    if (pid < 0) {
+      if (errno == EINTR) {
+        if (int s = pending_trapped_signal()) { end_interruptible_wait(); return 128 + s; }
+        continue;
+      }
+      break;  // ECHILD: no children left despite a job marked running (already reaped)
+    }
+    if (pid == 0) continue;
+
+    Job *owner = nullptr;
+    for (auto &j : jobs)
+      if (std::find(j.pids.begin(), j.pids.end(), static_cast<long>(pid)) != j.pids.end()) {
+        owner = &j;
+        break;
+      }
+    if (WIFSTOPPED(wst)) {
+      if (owner) { owner->stopped = true; owner->running = false; }
+      continue;
+    }
+    note_child_reaped();
+    if (!owner) continue;  // an untracked child (command-substitution straggler)
+    int rc = WIFEXITED(wst) ? WEXITSTATUS(wst)
+                            : 128 + (WIFSIGNALED(wst) ? WTERMSIG(wst) : 0);
+    if (static_cast<long>(pid) == owner->pids.back()) {
+      owner->done = true;
+      owner->running = false;
+      owner->status = rc;
+      st = rc;
+    }
   }
   int wst;
-  while (waitpid(-1, &wst, 0) > 0) note_child_reaped();  // reap any stragglers
+  while (waitpid(-1, &wst, WNOHANG) > 0) note_child_reaped();  // reap exited stragglers
+  end_interruptible_wait();
   return st;
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -73,7 +73,72 @@ Shell::Job *Shell::add_job(long pgid, const std::vector<long> &pids, const std::
   j.background = background;
   j.running = true;
   jobs.push_back(j);
+  // A newly-created background job becomes the current job (bash: reset_current
+  // after stop_pipeline for an async job).
+  if (background) reset_current();
   return &jobs.back();
+}
+
+namespace {
+// The most recent (highest-id) live job in the wanted run state whose id is
+// below `below' (0 = no bound), mirroring bash's most_recent_job_in_state.
+int most_recent_in_state(const std::vector<Shell::Job> &jobs, int below,
+                         bool want_stopped) {
+  int best = 0;
+  for (const auto &j : jobs) {
+    if (j.done) continue;
+    if (below > 0 && j.id >= below) continue;
+    if (j.stopped == want_stopped && j.id > best) best = j.id;
+  }
+  return best;
+}
+}  // namespace
+
+// Make ID the current job and choose a useful previous job (bash set_current_job).
+void Shell::set_current_job(int id) {
+  auto find = [&](int i) -> Job * {
+    for (auto &j : jobs) if (j.id == i && !j.done) return &j;
+    return nullptr;
+  };
+  if (j_current != id) { j_previous = j_current; j_current = id; }
+  // First choice for previous: the old current job, if it is stopped.
+  Job *p = find(j_previous);
+  if (j_previous != j_current && p && p->stopped) return;
+  // Second choice: newest stopped job older than the current one.
+  Job *c = find(j_current);
+  if (c && c->stopped) {
+    int cand = most_recent_in_state(jobs, j_current, true);
+    if (cand) { j_previous = cand; return; }
+  }
+  // Otherwise the newest running job (older than current if current is running).
+  int cand = (c && !c->stopped) ? most_recent_in_state(jobs, j_current, false)
+                                : most_recent_in_state(jobs, 0, false);
+  j_previous = cand ? cand : j_current;
+}
+
+// Recompute current/previous after jobs change (bash reset_current).
+void Shell::reset_current() {
+  auto find = [&](int i) -> Job * {
+    for (auto &j : jobs) if (j.id == i && !j.done) return &j;
+    return nullptr;
+  };
+  int cand = 0;
+  Job *cur = find(j_current);
+  if (cur && cur->stopped) {
+    cand = j_current;  // a stopped current job stays current
+  } else {
+    Job *prev = find(j_previous);
+    if (prev && prev->stopped) cand = j_previous;               // first: previous, if stopped
+    if (!cand) cand = most_recent_in_state(jobs, 0, true);      // second: newest stopped
+    if (!cand) cand = most_recent_in_state(jobs, 0, false);     // third: newest running
+  }
+  if (cand) set_current_job(cand);
+  else { j_current = j_previous = 0; }
+}
+
+void Shell::remove_jobs_if(const std::function<bool(const Job &)> &pred) {
+  jobs.erase(std::remove_if(jobs.begin(), jobs.end(), pred), jobs.end());
+  reset_current();
 }
 
 Shell::Job *Shell::job_by_spec(const std::string &spec) {
@@ -85,13 +150,11 @@ Shell::Job *Shell::job_by_spec(const std::string &spec) {
   if (spec[0] == '%') {
     std::string s = spec.substr(1);
     if (s.empty() || s == "%" || s == "+" || s == "-") {
-      // current (or previous for `-')
-      std::vector<Job *> live;
+      int want = (s == "-") ? j_previous : j_current;  // current (or previous for `-')
+      if (want == 0) return nullptr;
       for (auto &j : jobs)
-        if (!j.done) live.push_back(&j);
-      if (live.empty()) return nullptr;
-      if (s == "-") return live.size() >= 2 ? live[live.size() - 2] : live.back();
-      return live.back();
+        if (j.id == want && !j.done) return &j;
+      return nullptr;
     }
     if (std::isdigit(static_cast<unsigned char>(s[0]))) {
       int id = std::atoi(s.c_str());
@@ -187,6 +250,7 @@ int Shell::wait_next(const std::vector<int> &ids, long *finished_pid, bool *foun
       if (finished_pid && !jobs[k].pids.empty()) *finished_pid = jobs[k].pids.back();
       *found = true;
       jobs.erase(jobs.begin() + k);
+      reset_current();
       return rc;
     }
   }
@@ -226,6 +290,7 @@ int Shell::wait_next(const std::vector<int> &ids, long *finished_pid, bool *foun
         *found = true;
         int r = owner->status;
         jobs.erase(jobs.begin() + (owner - &jobs[0]));
+        reset_current();
         return r;
       }
     }
@@ -288,11 +353,12 @@ int Shell::wait_all() {
 bool Shell::check_job_events() {
   int wst = 0;
   pid_t pid;
+  int last_stopped = 0;
   while ((pid = waitpid(-1, &wst, WNOHANG | WUNTRACED)) > 0) {
     for (auto &j : jobs) {
       for (long p : j.pids) {
         if (p != pid) continue;
-        if (WIFSTOPPED(wst)) { j.stopped = true; j.running = false; }
+        if (WIFSTOPPED(wst)) { j.stopped = true; j.running = false; last_stopped = j.id; }
         else {
           j.done = true;
           j.running = false;
@@ -302,6 +368,11 @@ bool Shell::check_job_events() {
     }
     if (!WIFSTOPPED(wst)) note_child_reaped();  // a background child terminated
   }
+  // A job that stopped becomes the current job.  A job that merely terminated
+  // does NOT recompute current/previous: bash's set_job_status_and_cleanup only
+  // bumps call_set_current on a stop, so current keeps pointing at a dead job
+  // (still marked `+') until the job is actually removed from the table.
+  if (last_stopped) set_current_job(last_stopped);
   for (const Job &j : jobs)
     if ((j.done || j.stopped) && !j.notified) return true;
   return false;
@@ -350,10 +421,9 @@ void Shell::print_jobs(const std::string &spec, bool lflag, bool pflag, bool rfl
     }
     only = j->id;
   }
-  // bash marks the current job `+' and the previous job `-' (others a space);
-  // approximate with the two most recently started jobs (the last two entries).
-  int cur = jobs.empty() ? -1 : jobs.back().id;
-  int prev = jobs.size() >= 2 ? jobs[jobs.size() - 2].id : -1;
+  // bash marks the current job `+' and the previous job `-' (others a space).
+  int cur = j_current;
+  int prev = j_previous;
   for (const Job &j : jobs) {
     if (only != -1 && j.id != only) continue;
     if (rflag && (j.done || j.stopped)) continue;  // -r: running jobs only
@@ -372,6 +442,10 @@ void Shell::print_jobs(const std::string &spec, bool lflag, bool pflag, bool rfl
     else
       std::printf("[%d]%c  %-27s%s%s\n", j.id, mark, state, j.command.c_str(), amp);
   }
+  // Reporting a terminated job consumes it (bash removes DEADJOB entries once
+  // listed).  Only when listing the whole table, not a single -r/-s filter view.
+  if (only == -1 && !rflag && !sflag && !pflag)
+    remove_jobs_if([](const Job &j) { return j.done; });
 }
 
 }  // namespace gnash::core

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -256,6 +256,40 @@ void Shell::set_signal_trap(int signo, bool active) {
   sigaction(signo, &sa, nullptr);
 }
 
+// Re-arm the handlers for every currently-trapped signal so a blocking wait is
+// interrupted (EINTR) instead of resumed.  `restart' selects the normal
+// SA_RESTART disposition (used to restore after the wait) vs. no-restart.
+static void rearm_trap_handlers(const std::map<std::string, std::string> &traps,
+                                bool restart) {
+  for (int sig = 1; sig < NSIG; sig++) {
+    if (sig == SIGCHLD) continue;                  // reaped synchronously, no async handler
+    const char *nm = signum_to_trapname(sig);      // skip EXIT/DEBUG/ERR/RETURN pseudo-traps
+    if (!nm) continue;
+    auto it = traps.find(nm);
+    if (it == traps.end() || it->second.empty()) continue;  // untrapped / reset
+    struct sigaction sa;
+    std::memset(&sa, 0, sizeof sa);
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = restart ? SA_RESTART : 0;
+    sa.sa_handler = trap_signal_handler;
+    sigaction(sig, &sa, nullptr);
+  }
+}
+
+void Shell::begin_interruptible_wait() { rearm_trap_handlers(traps, false); }
+void Shell::end_interruptible_wait() { rearm_trap_handlers(traps, true); }
+
+int Shell::pending_trapped_signal() {
+  for (int s = 1; s < NSIG; s++) {
+    if (!g_trap_pending[s]) continue;
+    const char *nm = signum_to_trapname(s);
+    if (!nm) continue;
+    auto it = traps.find(nm);
+    if (it != traps.end() && !it->second.empty()) return s;
+  }
+  return 0;
+}
+
 int Shell::run_debug_trap(const std::string &cmd_text) {
   auto it = traps.find("DEBUG");
   if (it == traps.end() || in_debug_trap) return 0;


### PR DESCRIPTION
Completes gnash's job-control behavior so `jobs.tests` matches bash 5.3 byte-for-byte (scoreboard: **35 → 0** byte-diffs, stable across runs).

## What changed

- **Current (`+`) / previous (`-`) job tracking** — replaces the "last two table entries" approximation with bash's incremental `set_current_job`/`reset_current` model (including `most_recent_job_in_state`). A job that merely terminates keeps `+` until it's actually removed from the table; recomputation happens on removal via a new `remove_jobs_if()` helper.
- **fg/bg on monitored jobs without a controlling terminal** — records job-control state per job at creation in a `monitored` flag (bash's `J_JOBCONTROL`). `fg` gates on the job's own flag rather than a live tty, so a job started under `set -m` in a script is foregrounded (command echoed, then waited for) even with no terminal; a job started before `set -m` still reports "started without job control". SIGCONT is sent to member pids directly when there is no process group.
- **`wait` consumes waited-for jobs + diagnostics** — `wait ID ...` removes each successfully waited-for job (and bare `wait` removes every reaped job), so job numbers free up for reuse and stale finished jobs no longer skew later `%n` references. Argument validation now matches bash's wording ("no such job" 127, "not a pid or valid job spec" 1, "pid N is not a child of this shell" 127).
- **`%?str` substring jobspec** — selects the job whose command line *contains* str, distinct from the `%str` prefix match.

## Root cause note

The largest remaining diff cluster came from `wait %job`/`wait pid` never removing completed jobs: job numbers drifted so `%1` foregrounded a stale job. Fixing job consumption plus making `fg` work under `set -m` without a tty made gnash converge on bash's behavior.

## Testing

- `jobs.tests` byte-diff: 35 → 0, stable across 3 consecutive runs.
- `trap.tests` unchanged (its 17 diffs are pre-existing, unrelated to job control).