### PR TITLE
nameref: do not arith-evaluate a targetless nameref's referent

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2364,7 +2364,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // Honor a pre-existing integer attribute too (e.g. `readonly x+=7' on a
         // variable already declared `-i'), not just an `-i' on this command.
         auto exv = sh.vars.find(name);
-        bool eff_integer = integer || (exv != sh.vars.end() && exv->second.integer);
+        // A value assigned to a targetless nameref becomes its referent NAME,
+        // not a number: skip the integer arithmetic eval even under -i so the
+        // raw target (`7*6') reaches the nameref-target check below and is
+        // quoted verbatim, matching bash (`declare -i foo=7*6' on `declare -n
+        // foo').
+        bool targetless_nameref = exv != sh.vars.end() && exv->second.nameref &&
+                                  exv->second.value.empty();
+        bool eff_integer = !targetless_nameref &&
+                           (integer || (exv != sh.vars.end() && exv->second.integer));
         if (eff_integer) {
           bool ok = true;
           long long rhs = eval_arith(sh, val, &ok);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1043,7 +1043,12 @@ int Executor::run_simple(const SimpleCommand *c) {
         apply_array_assign(sh_, ex, a);  // array element / literal: applied now
       } else {
         auto vit = sh_.vars.find(a.name);
-        bool integer = vit != sh_.vars.end() && vit->second.integer;
+        // A value assigned to a targetless nameref becomes its referent NAME,
+        // not a number, so it must not be arithmetic-evaluated even when the
+        // nameref carries -i: bash keeps `7*6' raw so the invalid-identifier
+        // diagnostic (Shell::set) quotes it verbatim rather than `42'.
+        bool integer = vit != sh_.vars.end() && vit->second.integer &&
+                       !(vit->second.nameref && vit->second.value.empty());
         // A plain `name=value' / `name+=value' where name is already an array
         // targets element 0 (bash), so read/write that element rather than the
         // scalar field.


### PR DESCRIPTION
Assigning to a nameref that has no target yet stores the value as the nameref's referent **name**, not as data. When such a nameref also carried the integer attribute (`declare -n foo; declare -i foo=7*6` or a later `foo=7*6`), both assignment paths arithmetic-evaluated the RHS first, so the invalid-identifier diagnostic reported the computed `42` instead of the raw `7*6` bash quotes — and the referent check ran against the wrong string.

## Fix
Skip the integer arithmetic evaluation when the target is a targetless nameref (a nameref with an empty value) in both assignment paths:
- `bi_declare`'s scalar branch (`declare -i foo=7*6`) — gate `eff_integer` on the target not being a targetless nameref.
- the executor's plain-assignment loop (`foo=7*6`) — likewise gate the integer flag.

The raw value now reaches the nameref-target validity check and is quoted verbatim, matching bash.

## Testsuite
- nameref 234 -> 230
- No regressions: varenv/assoc/array/builtins unchanged, ctest 22/22.

Closes #362