### PR TITLE
posix: exit a non-interactive shell on a special-builtin error

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -450,6 +450,16 @@ class Shell {
   bool exiting = false;
   int exit_status = 0;
 
+  // POSIX 2.8.1: an error in a special built-in makes a non-interactive shell
+  // exit.  A special builtin's OWN-error path calls this (with the failure
+  // status) so the shell unwinds like errexit does.  It is NOT called for a
+  // status merely propagated from a command the builtin ran (`eval false'), and
+  // bash exempts a few error kinds (`trap' bad signal, `shift', `break'/
+  // `continue'), whose paths deliberately do not call it.
+  void posix_special_builtin_error(int status = 1) {
+    if (opt_posix && !interactive) { exiting = true; exit_status = status; }
+  }
+
   // --- helpers -----------------------------------------------------------
   std::string ifs() const;  // IFS value, or default " \t\n"
   std::vector<std::string> environ_block() const;  // NAME=value for exported

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1114,6 +1114,8 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
   return st;
 }
 
+static bool valid_identifier(const std::string &s);
+
 int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   bool fflag = false;  // `-f': functions
   bool vflag = false;  // `-v' given explicitly: variables only, no function fallback
@@ -1131,6 +1133,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       else {
         std::fprintf(stderr, "%sunset: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
         std::fprintf(stderr, "unset: usage: unset [-f] [-v] [-n] [name ...]\n");
+        sh.posix_special_builtin_error(2);
         return 2;
       }
     }
@@ -1138,6 +1141,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   if (fflag && vflag) {
     std::fprintf(stderr, "%sunset: cannot simultaneously unset a function and a variable\n",
                  sh.err_prefix().c_str());
+    sh.posix_special_builtin_error(2);
     return 2;
   }
   bool funcs = fflag;
@@ -1192,6 +1196,14 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       }
       continue;
     }
+    // A plain operand (no `[subscript]', handled above) must be a valid
+    // identifier: `unset -v a-b' -> `a-b': not a valid identifier (bash).
+    if (!valid_identifier(argv[i])) {
+      std::fprintf(stderr, "%sunset: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), argv[i].c_str());
+      ret = 1;
+      continue;
+    }
     // A readonly variable cannot be unset.  Resolve through a nameref (unless
     // -n) so the target that is actually readonly is the one reported.
     std::string tgt = noref ? argv[i] : sh.deref(argv[i]);
@@ -1207,6 +1219,9 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     if (!vflag && it == sh.vars.end() && sh.functions.count(tgt)) sh.functions.erase(tgt);
     else sh.unset(argv[i], false, noref);
   }
+  // POSIX: unset is a special builtin, so any error above exits a
+  // non-interactive posix shell (`readonly a=a; unset a' aborts).
+  if (ret != 0) sh.posix_special_builtin_error(ret);
   return ret;
 }
 
@@ -5125,6 +5140,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       std::fprintf(stderr, "%sreturn: can only `return' from a function or sourced script\n",
                    sh.err_prefix().c_str());
       st = 1;
+      sh.posix_special_builtin_error(st);  // special builtin: fatal in posix
     } else {
       sh.returning = true;
       sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
@@ -5249,6 +5265,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
                      cmd.c_str(), fname.c_str());
         st = 1;
         giveup = true;
+        sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
       }
     } else if (sh.shopt_opts["sourcepath"] && access(fname.c_str(), R_OK) != 0) {
       const char *penv = std::getenv("PATH");
@@ -5289,6 +5306,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(),
                      fname.c_str(), std::strerror(errno));
         st = 1;
+        sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
       }
     }
   } else if (cmd == "local") {

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -228,7 +228,8 @@ void apply_set_o(Shell &sh, const std::string &name, bool set) {
   else if (name == "noglob") sh.opt_noglob = set;
   else if (name == "verbose") sh.opt_verbose = set;
   else if (name == "noexec") sh.opt_noexec = set;
-  // Other -o names (pipefail, posix, vi, emacs, ...) are accepted and ignored.
+  else if (name == "posix") sh.opt_posix = set;
+  // Other -o names (pipefail, vi, emacs, ...) are accepted and ignored.
 }
 
 // Configure the shell's personality (which other shell it behaves as) and the
@@ -327,7 +328,8 @@ int main(int argc, char **argv) {
       if (lo == "login") login = true;
       else if (lo == "norc") sopts.norc = true;
       else if (lo == "noprofile") sopts.noprofile = true;
-      else if (lo == "posix" || lo == "noediting" || lo == "pretty-print" ||
+      else if (lo == "posix") sh.opt_posix = true;
+      else if (lo == "noediting" || lo == "pretty-print" ||
                lo == "dump-strings" || lo == "dump-po-strings" || lo == "verbose" ||
                lo == "debug" || lo == "debugger" || lo == "restricted") {
         /* accepted (some not yet acted on), but recognized so they do not fall


### PR DESCRIPTION
## Summary
POSIX 2.8.1 requires that an error in a special built-in cause a **non-interactive shell to exit**. gnash printed the diagnostic but kept running, so `${THIS_SH} -o posix -c 'readonly a=a; unset -v a; echo X'` printed the trailing `X` where bash aborts. This showed up in `errors.tests` as spurious `after return`/`after unset 1`/`after unset 2`/`after source` lines.

## Two commits
1. **shell: honor `-o posix` / `--posix` at startup** — these were parsed but discarded, so posix mode only worked via runtime `set -o posix`. The suite uses `${THIS_SH} -o posix -c ...`, so no posix behavior took effect there. Prerequisite for the fix.
2. **posix: exit a non-interactive shell on a special-builtin error** — new `Shell::posix_special_builtin_error()` sets the same exiting/exit_status the errexit path uses, called only from a special builtin's *own-error* path. bash's exceptions (`trap` bad-signal, `shift`, `break`/`continue`, and propagated statuses like `eval false`) are preserved. Wired into `unset` (all error paths + a new `unset -v a-b` → `not a valid identifier` diagnostic), `source`/`.` (file-not-found), and `return` (outside a function/sourced script).

## Verification
- **errors 19 → 15**, **builtins 107 → 106** (bonus).
- Behavior matrix matches bash: fatal for unset/source/return/readonly-assign; non-fatal for trap/shift/break/continue/eval-false; non-posix unaffected.
- **Zero regressions** across all 11 `-o posix` files (array/builtins/comsub2/ifs/jobs/posixexp/posixexp2/redir/tilde/tilde2 unchanged). ctest 22/22.

Closes #364