### PR TITLE
nameref: prefix invalid-target errors with the builtin name

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -81,7 +81,12 @@ class Shell {
   std::string get_quiet(const std::string &n) const;
   bool get_if_set(const std::string &n, std::string &out) const;
   // Assign N=V; false if N is readonly (an error is printed).
-  bool set(const std::string &n, const std::string &v);
+  // nameref_ctx, when non-null, prefixes the invalid-nameref-target diagnostic
+  // with a builtin name (`printf'/`getopts'/`exec'/`((') -- bash reports e.g.
+  // `printf: `X': not a valid identifier' when the assignment flows through that
+  // builtin, versus the bare form for a plain `r=X' assignment.
+  bool set(const std::string &n, const std::string &v,
+           const char *nameref_ctx = nullptr);
   void set_exported(const std::string &n, const std::string &v);
   void export_name(const std::string &n);
   // Remove N.  A readonly variable is left in place unless FORCE is set

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -477,6 +477,7 @@ struct Ctx {
   int depth = 0;
   size_t err_pos = std::string::npos;  // offset of the error token (see Parser)
   std::string err_msg;
+  const char *cmd_name = nullptr;  // "(("/"let" -- prefixes a nameref-target error
   void note(const std::string &m, size_t p) {
     if (err_pos == std::string::npos) { err_pos = p; err_msg = m; }
     ok = false;
@@ -524,8 +525,8 @@ void ref_set(const Node *n, long long val, Ctx &ctx) {
     std::string sub = n->sub;
     if (!ctx.sh.array_expand_once_ok(n->name, sub)) { ctx.ok = false; return; }
     ctx.sh.array_set(n->name, ctx.sh.zsh_subscript(n->name, sub), std::to_string(val));
-  } else if (!ctx.sh.set(n->name, std::to_string(val)))
-    ctx.ok = false;  // assignment to a readonly variable: the expansion fails
+  } else if (!ctx.sh.set(n->name, std::to_string(val), ctx.cmd_name))
+    ctx.ok = false;  // readonly, or an invalid nameref target (`((: `0': ...')
 }
 
 long long eval_node(const Node *n, Ctx &ctx) {
@@ -613,7 +614,7 @@ long long eval_arith_msg(Shell &sh, const std::string &expr, const char *cmd_nam
   if (blank_expr(expr)) { if (ok) *ok = true; return 0; }
   if (try_int(expr, iv)) { if (ok) *ok = true; return iv; }
   Parsed p = parse_cached(expr);
-  Ctx ctx{sh, p.ok, 0, p.err_pos, p.err_msg};
+  Ctx ctx{sh, p.ok, 0, p.err_pos, p.err_msg, cmd_name};
   long long v = eval_node(p.root.get(), ctx);
   if (ok) *ok = ctx.ok;
   if (!ctx.ok && ctx.err_pos != std::string::npos && ctx.err_pos <= expr.size()) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -438,8 +438,8 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
       std::string sub = vname.substr(lb + 1, vname.size() - lb - 2);
       if (!sh.array_expand_once_ok(base, sub)) return 1;
       sh.array_set(base, sub, out);
-    } else {
-      sh.set(vname, out);
+    } else if (!sh.set(vname, out, "printf")) {
+      return 1;  // invalid nameref target: `printf: `X': not a valid identifier'
     }
   } else {
     std::fwrite(out.data(), 1, out.size(), stdout);
@@ -3121,26 +3121,31 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
   // readonly OPTARG (dropping the readonly attribute), so `${OPTARG-unset}'
   // reports it unset and a later re-declaration is not blocked.
   auto clear_optarg = [&]() { sh.unset("OPTARG", true); };
+  // Writes to the result variable carry the `getopts' name so an invalid
+  // nameref target reports `getopts: `?': not a valid identifier' (bash).  The
+  // diagnostic is printed BEFORE the store so it precedes that error, matching
+  // bash's `illegal option -- X' / `getopts: ...' ordering.
+  auto set_name = [&](const std::string &val) { return sh.set(name, val, "getopts"); };
   auto badopt = [&](char c) {
-    if (silent) { sh.set(name, "?"); sh.set("OPTARG", std::string(1, c)); }
+    if (silent) { set_name("?"); sh.set("OPTARG", std::string(1, c)); }
     else {
       clear_optarg();
-      sh.set(name, "?");
       std::fprintf(stderr, "%s: illegal option -- %c\n", sh.arg0.c_str(), c);
+      set_name("?");
     }
   };
   auto needarg = [&](char c) {
-    if (silent) { sh.set(name, ":"); sh.set("OPTARG", std::string(1, c)); }
+    if (silent) { set_name(":"); sh.set("OPTARG", std::string(1, c)); }
     else {
       clear_optarg();
-      sh.set(name, "?");
       std::fprintf(stderr, "%s: option requires an argument -- %c\n", sh.arg0.c_str(), c);
+      set_name("?");
     }
   };
 
   for (;;) {
     int ai = optind - 1;  // 0-based index into args
-    if (ai >= static_cast<int>(args.size())) { clear_optarg(); sh.set(name, "?"); return 1; }
+    if (ai >= static_cast<int>(args.size())) { clear_optarg(); set_name("?"); return 1; }
     const std::string &arg = args[static_cast<size_t>(ai)];
 
     // Start of a fresh argument.
@@ -3151,10 +3156,10 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
         s_charidx = 1;
         sh.set("OPTIND", std::to_string(optind));
         clear_optarg();
-        sh.set(name, "?");
+        set_name("?");
         return 1;
       }
-      if (arg.empty() || arg[0] != '-' || arg == "-") { clear_optarg(); sh.set(name, "?"); return 1; }
+      if (arg.empty() || arg[0] != '-' || arg == "-") { clear_optarg(); set_name("?"); return 1; }
       s_charidx = 1;
       s_curarg = arg;
     }
@@ -3187,7 +3192,7 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
         return 0;
       }
     }
-    sh.set(name, std::string(1, c));
+    set_name(std::string(1, c));
     s_optind = optind;
     sh.set("OPTIND", std::to_string(optind));
     return 0;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1174,7 +1174,8 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   return true;
 }
 
-bool Shell::set(const std::string &n_in, const std::string &v) {
+bool Shell::set(const std::string &n_in, const std::string &v,
+                const char *nameref_ctx) {
   // A nameref whose target is an array element (`declare -n r=a[2]'): write
   // through to that element.  array_set enforces the target's readonly flag.
   {
@@ -1225,10 +1226,14 @@ bool Shell::set(const std::string &n_in, const std::string &v) {
   // on such a nameref, so n still names it.  bash rejects a non-identifier here.
   {
     auto it = vars.find(n);
+    // An empty value is rejected too: setting a targetless nameref's target to
+    // "" (`declare -n r; r=""') is an invalid identifier in bash, unlike a plain
+    // scalar `x=""'.
     if (it != vars.end() && it->second.nameref && it->second.value.empty() &&
-        !v.empty() && !valid_nameref_target(v)) {
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", err_prefix().c_str(),
-                   v.c_str());
+        !valid_nameref_target(v)) {
+      bool has_ctx = nameref_ctx && nameref_ctx[0];
+      std::fprintf(stderr, "%s%s%s`%s': not a valid identifier\n", err_prefix().c_str(),
+                   has_ctx ? nameref_ctx : "", has_ctx ? ": " : "", v.c_str());
       return false;
     }
   }


### PR DESCRIPTION
## Summary
When a value that isn't a valid identifier is assigned through an unset nameref (`declare -n r`), bash prefixes the diagnostic with the builtin that triggered it — `((: `0'`, `printf: `/'`, `getopts: `?'`. gnash emitted the bare form and, for getopts, printed the nameref error before `illegal option`. It also silently accepted an empty nameref target where bash errors.

All these paths funnel through `Shell::set`.

## Commits
1. **shell: refine invalid-nameref-target diagnostics** — `Shell::set` gains an optional builtin-name context for the error, and no longer skips an empty value for a targetless nameref (so `declare -n r; r=""` and `: ${r=}` now report ``': not a valid identifier` like bash).
2. **nameref: prefix the invalid-target error with the builtin name** — thread the context from arith `((`/`let` (via the evaluator Ctx), `printf -v`, and `getopts` (which also reorders its `illegal option` diagnostic before the store to match bash).

## Verification
- **nameref 230 → 221** (−9).
- Zero regressions across nameref/builtins/arith/varenv/assoc/array/quotearray/more-exp/posixexp/exp/glob/comsub/errors; ctest 22/22.
- Normal getopts, plain arith, integer assignment, empty scalars, and nameref-with-target all verified unaffected.

Deferred: the analogous `exec {var}>` case (`exec: `10'` + `cannot assign fd to variable`) needs the command name threaded through the redirection layer — a separate follow-up.

Closes #366