### PR TITLE
nameref: validate for-loop retargets; reject declare -n on a readonly var

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2485,6 +2485,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // its current value/visibility.
     bool fresh_var = fresh_local || sh.vars.find(aname) == sh.vars.end();
     Variable &v = sh.vars[aname];
+    // Whether v was already readonly BEFORE this command applied its attributes
+    // (`-r' below sets v.readonly): a pre-existing readonly plain variable
+    // cannot be converted to a nameref, but `declare -rn foo=bar' on a fresh
+    // var, or re-declaring an existing nameref, is fine.
+    bool was_readonly = v.readonly;
     // A localvar_inherit'd local already holds the enclosing value, so it stays
     // visible; only a genuinely empty fresh scalar is marked declared-but-unset.
     if (fresh_var && !inherited_local && eq == std::string::npos && v.kind == VarKind::Scalar)
@@ -2501,7 +2506,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // (`r=/; declare -n r') -- or which names itself -- is rejected; bash leaves
     // the variable unchanged without the attribute.  (The `=val' form validated
     // its value above.)
-    if (nameref && (v.kind == VarKind::Indexed || v.kind == VarKind::Assoc)) {
+    if (nameref && was_readonly && !v.nameref) {
+      // Converting a pre-existing readonly plain variable to a nameref is
+      // rejected (`declare -r RO=x; declare -n RO' -> `declare: RO: readonly
+      // variable'); bash permits `-x' on a readonly var, but not `-n'.
+      std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
+                   argv[0].c_str(), name.c_str());
+      ret = 1;
+    } else if (nameref && (v.kind == VarKind::Indexed || v.kind == VarKind::Assoc)) {
       // An existing array/associative variable cannot be turned into a nameref;
       // bash rejects the `-n' and leaves the array (and any assignment made by
       // this same command) intact.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1775,7 +1775,14 @@ int Executor::run_for(const ForCommand *c) {
       if (vit->second.readonly)
         std::fprintf(stderr, "%s%s: readonly variable\n", sh_.err_prefix().c_str(),
                      c->var.c_str());
-      else
+      else if (!Shell::valid_nameref_target(item)) {
+        // Retargeting a nameref to a non-identifier (`for r in /') is an error,
+        // like `declare -n r=/'; bash aborts the loop rather than continuing.
+        std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
+                     item.c_str());
+        st = 1;
+        break;
+      } else
         vit->second.value = item;
     } else {
       sh_.set(c->var, item);


### PR DESCRIPTION
## Summary
Two nameref conformance gaps (tests/nameref11.sub):

1. **for-loop nameref retarget** — `for ref in WORDS` retargets a nameref loop variable to each word (as if `declare -n ref=word`), but gnash stored the word unchecked. `declare -n r; for r in /` silently retargeted r to `/` where bash reports ``/': not a valid identifier` and aborts the loop.
2. **declare -n on readonly** — `declare -r RO=x; declare -n RO` errors in bash (`declare: RO: readonly variable`); gnash silently applied `-n`.

## Fixes
- `run_for`: validate the item with `valid_nameref_target` before retargeting; on failure print the error and abort the loop (matching bash).
- `bi_declare`: reject `-n` when the variable was readonly *before* this command's attributes were applied — so combined `declare -rn foo=bar` on a fresh var and re-declaring an existing nameref still work, and `-x` on a readonly var stays allowed (as in bash). This pre-existing-state check was essential: an earlier naive version fired on `declare -rn foo=bar` and cascaded +23 diffs through nameref17.

## Verification
- **nameref 221 → 212** (−9).
- Zero regressions across 15 suites (varenv/assoc/array/builtins/errors/arith/quotearray/more-exp/posixexp/exp/glob/comsub/cond/dbg-support); ctest 22/22.

Closes #368