### PR TITLE
Multibyte string foundation + corpus-diff harness

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -16,6 +16,7 @@
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
+#include <cwchar>
 #include <pwd.h>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -140,6 +141,45 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
     wasdol = (c == '$');
   }
   return std::string::npos;
+}
+
+// --- multibyte helpers ------------------------------------------------------
+// Character (code point) length of s under the current LC_CTYPE.  In a unibyte
+// or C locale (MB_CUR_MAX==1) this is the byte count, exactly as bash falls
+// back.  A malformed or truncated sequence counts as one character (and resets
+// the shift state), matching bash's tolerance for invalid input.
+size_t mb_charlen(const std::string &s) {
+  if (MB_CUR_MAX <= 1) return s.size();
+  size_t n = 0, i = 0;
+  std::mbstate_t st{};
+  while (i < s.size()) {
+    size_t r = std::mbrtowc(nullptr, s.data() + i, s.size() - i, &st);
+    if (r == static_cast<size_t>(-1) || r == static_cast<size_t>(-2) || r == 0) {
+      r = 1;
+      st = std::mbstate_t{};
+    }
+    i += r;
+    n++;
+  }
+  return n;
+}
+
+// Byte offset of character index c within s (clamped to s.size()), the inverse
+// of mb_charlen used to turn a character offset/length into a byte slice.
+size_t mb_byteoff(const std::string &s, size_t c) {
+  if (MB_CUR_MAX <= 1) return c < s.size() ? c : s.size();
+  size_t i = 0, k = 0;
+  std::mbstate_t st{};
+  while (i < s.size() && k < c) {
+    size_t r = std::mbrtowc(nullptr, s.data() + i, s.size() - i, &st);
+    if (r == static_cast<size_t>(-1) || r == static_cast<size_t>(-2) || r == 0) {
+      r = 1;
+      st = std::mbstate_t{};
+    }
+    i += r;
+    k++;
+  }
+  return i;
 }
 
 // Encode a Unicode code point as UTF-8 (for \u / \U), matching bash's u32cconv.
@@ -1714,7 +1754,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       auto nit = sh.vars.find(iname);
       if (q == b.size() && nit != sh.vars.end() && nit->second.nameref) {
         std::string tname = sh.deref(iname);
-        return length ? std::to_string(tname.size()) : tname;
+        return length ? std::to_string(mb_charlen(tname)) : tname;
       }
       // The value of INAME is the parameter to expand; any operator that
       // follows applies to the indirected parameter.  A `#'/digit name is a
@@ -1727,7 +1767,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       } else {
         target = sh.get(iname);
       }
-      if (length) return std::to_string(expand_brace_body(ex, sh, target + b.substr(q), dq).size());
+      if (length) return std::to_string(mb_charlen(expand_brace_body(ex, sh, target + b.substr(q), dq)));
       return expand_brace_body(ex, sh, target + b.substr(q), dq);
     }
   }
@@ -1816,7 +1856,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   } else {
     val = ex.param_value(name, set, defaulting_op);
   }
-  if (length) return std::to_string(val.size());
+  if (length) return std::to_string(mb_charlen(val));
   return apply_param_op(ex, sh, name, val, set, rest, dq, have_sub, tsub, /*top_level=*/true);
 }
 
@@ -2078,13 +2118,15 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     long long off = eval_arith(sh, colon2 == std::string::npos ? args : args.substr(0, colon2), &ok);
     long long len = -1;
     if (colon2 != std::string::npos) len = eval_arith(sh, args.substr(colon2 + 1), &ok);
-    long long n = static_cast<long long>(val.size());
+    // Offset and length are counted in characters (bash), not bytes: map them
+    // through mb_byteoff so a UTF-8 value slices on code-point boundaries.
+    long long n = static_cast<long long>(mb_charlen(val));
     if (off < 0) off += n;
     if (off < 0) off = 0;
     if (off > n) off = n;
-    std::string res = val.substr(static_cast<size_t>(off));
-    if (len >= 0 && len < static_cast<long long>(res.size()))
-      res = res.substr(0, static_cast<size_t>(len));
+    std::string res = val.substr(mb_byteoff(val, static_cast<size_t>(off)));
+    if (len >= 0 && len < static_cast<long long>(mb_charlen(res)))
+      res = res.substr(0, mb_byteoff(res, static_cast<size_t>(len)));
     return res;
   }
 

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -16,6 +16,7 @@
 // are absent, so gnash works out of the box for users with only ~/.bash* files.
 #include <cctype>
 #include <cerrno>
+#include <clocale>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -275,6 +276,10 @@ void show_shell_usage(const std::string &name) {
 }  // namespace
 
 int main(int argc, char **argv) {
+  // Adopt the environment's locale (LC_ALL/LC_CTYPE/LANG) so MB_CUR_MAX and the
+  // libc ctype/mbrtowc facilities reflect it -- bash does this at startup, and
+  // it is what makes ${#var}, substrings, etc. count characters not bytes.
+  std::setlocale(LC_ALL, "");
   Shell sh;
   shopt_seed(sh);  // seed default shopt states so $BASHOPTS is populated
   sh.import_env_functions();  // pull in any BASH_FUNC_*%% exported functions

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <set>
+#include <clocale>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -1174,6 +1175,25 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   return true;
 }
 
+static bool is_locale_var(const std::string &n) {
+  return n == "LC_ALL" || n == "LC_CTYPE" || n == "LANG";
+}
+
+// Re-apply the LC_CTYPE locale from the shell's own LC_ALL/LC_CTYPE/LANG
+// variables, in POSIX precedence order, so a runtime `export LC_ALL=en_US.UTF-8'
+// makes subsequent ${#var}/substring operations count characters.  Only the
+// LC_CTYPE category (which governs MB_CUR_MAX / mbrtowc) is changed.
+static void apply_ctype_locale(Shell &sh) {
+  auto val = [&](const char *k) -> std::string {
+    auto it = sh.vars.find(k);
+    return it != sh.vars.end() ? it->second.value : std::string();
+  };
+  std::string loc = val("LC_ALL");
+  if (loc.empty()) loc = val("LC_CTYPE");
+  if (loc.empty()) loc = val("LANG");
+  if (!loc.empty()) std::setlocale(LC_CTYPE, loc.c_str());
+}
+
 bool Shell::set(const std::string &n_in, const std::string &v,
                 const char *nameref_ctx) {
   // A nameref whose target is an array element (`declare -n r=a[2]'): write
@@ -1269,6 +1289,8 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
   // Setting POSIXLY_CORRECT (to any value) enables POSIX mode, as in bash.
   if (n == "POSIXLY_CORRECT") opt_posix = true;
+  // A locale assignment re-applies LC_CTYPE so multibyte handling follows it.
+  if (is_locale_var(n)) apply_ctype_locale(*this);
   // `declare -u' / `-l' / `-c' fold the value's case on every assignment.
   if (var.ucase)
     for (char &c : var.value) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
@@ -1301,6 +1323,7 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
   var.exported = true;
   var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
   if (n == "POSIXLY_CORRECT") opt_posix = true;
+  if (is_locale_var(n)) apply_ctype_locale(*this);
 }
 
 void Shell::export_name(const std::string &n) {

--- a/scripts/corpus-diff.sh
+++ b/scripts/corpus-diff.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Brian J. Fox
+# Licensed under GPLv2 with the GPLv2-AI Exception.
+#
+# corpus-diff.sh -- measure how close gnash is to a drop-in bash replacement by
+# running a corpus of REAL-WORLD shell scripts under both shells and reporting
+# where they diverge.
+#
+#   scripts/corpus-diff.sh [options] [ROOT ...]
+#
+# Two modes:
+#   --parse   (default) Parse-only: `SHELL -n SCRIPT'.  Never executes the
+#             script, so it is safe to run over arbitrary system scripts.
+#             Compares parse success/failure and the syntax-error diagnostics.
+#   --exec    Execute each script under both shells in an isolated temp CWD with
+#             a scrubbed environment and a timeout, then diff stdout+stderr+exit
+#             status.  Only point this at scripts you trust to be side-effect
+#             free -- see the WARNING below.  Intended for a curated corpus.
+#
+# Options:
+#   --exec              enable execute-diff (default is parse-only)
+#   --max N             cap at N scripts (default 1000)
+#   --timeout SECS      per-script timeout in --exec mode (default 10)
+#   --bash PATH         bash binary (default: from $BASH or PATH)
+#   --gnash PATH        gnash binary (default: build/core/gnash under the repo)
+#   --out DIR           write the detailed report here (default: a temp dir)
+#   -h | --help         this help
+#
+# WARNING (--exec): executing real-world scripts runs whatever they contain.
+# The harness scrubs the environment, runs in a throwaay CWD, and applies a
+# timeout, but it CANNOT sandbox filesystem or network side effects.  Only use
+# --exec on a corpus you have vetted.  Parse mode is always safe.
+#
+# Exit status: 0 if every script agreed, 1 if any diverged, 2 on usage error.
+
+set -uo pipefail
+
+MODE=parse
+MAX=1000
+TIMEOUT=10
+BASH_BIN=${BASH:-}
+GNASH_BIN=""
+OUT=""
+ROOTS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --parse)    MODE=parse; shift ;;
+    --exec)     MODE=exec; shift ;;
+    --max)      MAX=${2:?}; shift 2 ;;
+    --timeout)  TIMEOUT=${2:?}; shift 2 ;;
+    --bash)     BASH_BIN=${2:?}; shift 2 ;;
+    --gnash)    GNASH_BIN=${2:?}; shift 2 ;;
+    --out)      OUT=${2:?}; shift 2 ;;
+    -h|--help)  sed -n '4,40p' "$0"; exit 0 ;;
+    -*)         echo "unknown option: $1" >&2; exit 2 ;;
+    *)          ROOTS+=("$1"); shift ;;
+  esac
+done
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+[ -n "$BASH_BIN" ] || BASH_BIN=$(command -v bash)
+[ -n "$GNASH_BIN" ] || GNASH_BIN="$ROOT/build/core/gnash"
+[ -x "$BASH_BIN" ]  || { echo "bash not found: $BASH_BIN" >&2; exit 2; }
+[ -x "$GNASH_BIN" ] || { echo "gnash not found: $GNASH_BIN (build it first)" >&2; exit 2; }
+[ -n "$OUT" ] || OUT=$(mktemp -d "${TMPDIR:-/tmp}/corpus-diff.XXXXXX")
+mkdir -p "$OUT"
+
+# Default corpus: real scripts that ship on this machine.  Override by passing
+# ROOT dirs/files on the command line.
+if [ ${#ROOTS[@]} -eq 0 ]; then
+  for d in /opt/homebrew /usr/share /usr/libexec /etc; do
+    [ -d "$d" ] && ROOTS+=("$d")
+  done
+fi
+
+# --- collect the corpus ------------------------------------------------------
+# A file joins the corpus if it has a sh/bash shebang or a .sh/.bash extension.
+# Skip .sample git hooks and anything unreadable.
+is_shell_script() {
+  local f=$1
+  case "$f" in *.sample) return 1 ;; esac
+  case "$f" in *.sh|*.bash) return 0 ;; esac
+  read -r first < "$f" 2>/dev/null || return 1
+  case "$first" in
+    '#!'*/sh|'#!'*/sh\ *|'#!'*/bash|'#!'*/bash\ *|'#!'*env\ sh*|'#!'*env\ bash*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+echo "collecting corpus from: ${ROOTS[*]}" >&2
+CORPUS="$OUT/corpus.list"; : > "$CORPUS"
+count=0
+while IFS= read -r f; do
+  [ -f "$f" ] && [ -r "$f" ] || continue
+  is_shell_script "$f" || continue
+  printf '%s\n' "$f" >> "$CORPUS"
+  count=$((count + 1))
+  [ "$count" -ge "$MAX" ] && break
+done < <(find "${ROOTS[@]}" -type f 2>/dev/null)
+total=$(wc -l < "$CORPUS" | tr -d ' ')
+echo "collected $total scripts (mode=$MODE)" >&2
+
+# Normalize shell-specific noise so only real differences remain: the shell's
+# own path/name in diagnostics and long numbers (PIDs).  Uses `#' as the sed
+# delimiter so the binary PATH (which contains `/') substitutes cleanly.  Line
+# numbers are deliberately NOT normalized -- a differing line number on the same
+# script is a real divergence worth surfacing.
+norm() {  # norm <binary-path>
+  local base; base=$(basename "$1")
+  LC_ALL=C sed -E "s#$1#SHELL#g; s#^${base}:#SHELL:#; s#[0-9]{5,}#NUM#g"
+}
+
+run_parse() {  # run_parse <bin> <script> -> writes rc + normalized stderr
+  local bin=$1 f=$2
+  "$bin" --norc -n "$f" >/dev/null 2>"$OUT/.err"
+  local rc=$?
+  printf 'rc=%s\n' "$rc"
+  norm "$bin" < "$OUT/.err"
+}
+
+run_exec() {  # run_exec <bin> <script> -> rc + normalized stdout+stderr
+  # Isolated CWD, scrubbed env, and a perl-based timeout (macOS has no
+  # timeout(1)) that kills the whole process group after $TIMEOUT seconds.
+  local bin=$1 f=$2 work
+  work=$(mktemp -d "$OUT/.run.XXXXXX")
+  ( cd "$work" && env -i PATH="/usr/bin:/bin" HOME="$work" TERM=dumb \
+      perl -e '
+        use POSIX qw(setsid); my $secs = shift; my $pid = fork();
+        if ($pid == 0) { setsid(); exec @ARGV or exit 127; }
+        $SIG{ALRM} = sub { kill(-9, $pid); exit 124; };
+        alarm $secs; waitpid($pid, 0); alarm 0; exit($? >> 8);' \
+      "$TIMEOUT" "$bin" --norc "$f" ) >"$work/.o" 2>"$work/.e"
+  local rc=$?
+  printf 'rc=%s\n' "$rc"
+  { norm "$bin" < "$work/.o"; echo '--8<--stderr--'; norm "$bin" < "$work/.e"; }
+  rm -rf "$work"
+}
+
+# --- compare -----------------------------------------------------------------
+DIVERGED="$OUT/diverged.txt"; : > "$DIVERGED"
+SIGS="$OUT/signatures.txt"; : > "$SIGS"
+BLOCKERS="$OUT/blockers.txt"; : > "$BLOCKERS"
+agree=0; diverge=0; blockers=0; i=0
+# The exit status carries the most important signal: a script bash ACCEPTS
+# (rc=0) but gnash rejects, or vice versa, is a real drop-in blocker; a
+# difference where both agree on accept/reject is cosmetic (usually error-message
+# wording on a script that is invalid under both).
+rc_of() { printf '%s' "$1" | sed -n 's/^rc=//p' | head -1; }
+while IFS= read -r f; do
+  i=$((i + 1))
+  printf '\r  %d/%d  diverged=%d (blockers=%d)  ' "$i" "$total" "$diverge" "$blockers" >&2
+  if [ "$MODE" = parse ]; then
+    bo=$(run_parse "$BASH_BIN" "$f"); go=$(run_parse "$GNASH_BIN" "$f")
+  else
+    bo=$(run_exec "$BASH_BIN" "$f"); go=$(run_exec "$GNASH_BIN" "$f")
+  fi
+  if [ "$bo" = "$go" ]; then
+    agree=$((agree + 1))
+    continue
+  fi
+  diverge=$((diverge + 1))
+  brc=$(rc_of "$bo"); grc=$(rc_of "$go")
+  kind=cosmetic
+  if [ "$brc" = 0 ] && [ "$grc" != 0 ]; then kind=BLOCKER-gnash-rejects
+  elif [ "$brc" != 0 ] && [ "$grc" = 0 ]; then kind=BLOCKER-gnash-accepts; fi
+  {
+    echo "### [$kind] $f"
+    diff <(printf '%s\n' "$bo") <(printf '%s\n' "$go") | sed 's/^/    /'
+    echo
+  } >> "$DIVERGED"
+  case "$kind" in
+    BLOCKER-*) blockers=$((blockers + 1)); printf '%s\t%s\n' "$kind" "$f" >> "$BLOCKERS" ;;
+  esac
+  # Signature: gnash's first differing line, for frequency ranking.
+  sig=$(diff <(printf '%s\n' "$bo") <(printf '%s\n' "$go") | grep -m1 '^>' | sed 's/^> //')
+  [ -n "$sig" ] || sig="(bash-only output / exit-status differs)"
+  printf '%s\n' "$sig" >> "$SIGS"
+done < "$CORPUS"
+echo >&2
+
+# --- report ------------------------------------------------------------------
+pct=0; [ "$total" -gt 0 ] && pct=$(( agree * 100 / total ))
+{
+  echo "gnash vs bash corpus diff  (mode=$MODE)"
+  echo "  bash:  $BASH_BIN"
+  echo "  gnash: $GNASH_BIN"
+  echo "  scripts:   $total"
+  echo "  identical: $agree  (${pct}%)"
+  echo "  diverged:  $diverge  (of which $blockers accept/reject BLOCKERS)"
+  echo
+  if [ "$blockers" -gt 0 ]; then
+    echo "BLOCKERS -- one shell accepts what the other rejects (real drop-in gaps):"
+    sed 's/^/  /' "$BLOCKERS"
+    echo
+  fi
+  if [ "$diverge" -gt 0 ]; then
+    echo "top divergence signatures (gnash side, by frequency):"
+    sort "$SIGS" | uniq -c | sort -rn | head -20 | sed 's/^/  /'
+    echo
+    echo "full per-script diffs: $DIVERGED"
+  fi
+} | tee "$OUT/report.txt"
+
+# Exit non-zero only for real accept/reject blockers; cosmetic message diffs
+# (common on scripts that are invalid under both shells) do not fail the run.
+[ "$blockers" -eq 0 ]


### PR DESCRIPTION
Two pieces of groundwork toward a credible drop-in-bash claim.

## Multibyte foundation
gnash ran in the C locale globally (MB_CUR_MAX always 1), so every string op was byte-based regardless of $LANG/$LC_*.
- **shell**: `setlocale(LC_ALL,"")` at startup (as bash does), and re-apply LC_CTYPE (precedence LC_ALL > LC_CTYPE > LANG) whenever one of those is assigned/exported.
- **expand**: `mb_charlen()`/`mb_byteoff()` helpers (byte-wise when MB_CUR_MAX==1) route `${#var}` and `${var:off:len}`/`${var: -n}` through character counting. `${#café}` is now 4; substrings slice on code-point boundaries.

ASCII and C-locale behavior unchanged. intl 1836→1828 (the bulk of intl is a separate ~1770-line non-UTF-8 \U-encoding cluster). Deeper multibyte (case conversion, pattern matching, IFS splitting, LC_NUMERIC printf) is future work.

## Corpus-diff harness (scripts/corpus-diff.sh)
Runs a corpus of **real-world** scripts under both shells and reports divergences — the evidence the (curated) bash test suite can't give.
- **parse mode** (default, safe): `SHELL -n SCRIPT`, never executes.
- **exec mode** (--exec, opt-in): isolated CWD, scrubbed env, timeout; diffs stdout+stderr+exit.
- Classifies each divergence: an accept/reject mismatch is a real **BLOCKER**; same-verdict differences are cosmetic. Signatures ranked by frequency.

First run over 285 system scripts: **93% parse-identical**, 4 real blockers (gnash rejects, bash accepts) — including **config.guess** (autotools) and **nvm.sh**. Those are follow-up parser bugs.

## Verification
- Zero regressions across 13 conformance suites (all match prior baselines); ctest 22/22.
- Multibyte length/substring verified byte-for-byte vs bash under en_US.UTF-8 and C locales.

Closes #370