### PR TITLE
shell: skip comments when testing for a single-quoted line continuation

### DIFF
--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1689,13 +1689,27 @@ static OpenCtx open_context(const std::string &t) {
 // top level) keeps the backslash literal; only backticks force the splice.
 static bool squote_backslash_literal(const std::string &t) {
   bool squote = false, dquote = false, btick = false;
+  char prev = '\n';  // start of input behaves like just after a newline
   for (size_t i = 0; i < t.size(); i++) {
     char c = t[i];
-    if (squote) { if (c == '\'') squote = false; continue; }
-    if (c == '\\') { if (i + 1 < t.size()) i++; continue; }
+    if (squote) { if (c == '\'') squote = false; prev = c; continue; }
+    // Outside quotes, an unquoted `#' that begins a word starts a comment
+    // running to end of line; a `'' (or `"') inside it is a literal comment
+    // character, NOT a quote (else `# it's x' would look like an open quote and
+    // suppress a genuine line continuation further down -- e.g. config.guess).
+    // Only a `#' after a blank or at the start of a line begins a comment; one
+    // stuck to a preceding word (`)#x', `$(cmd)#x') is part of that word.
+    if (!dquote && !btick && c == '#' &&
+        (prev == ' ' || prev == '\t' || prev == '\n')) {
+      while (i < t.size() && t[i] != '\n') i++;
+      prev = '\n';
+      continue;  // the for-loop's ++i steps past the newline
+    }
+    if (c == '\\') { if (i + 1 < t.size()) i++; prev = 'x'; continue; }
     if (c == '\'' && !dquote) squote = true;
     else if (c == '"') dquote = !dquote;
     else if (c == '`') btick = !btick;
+    prev = c;
   }
   return squote && !btick;
 }


### PR DESCRIPTION
## Problem
`config.guess` (in nearly every autotools build) and `nvm.sh` failed to parse under gnash — real drop-in blockers surfaced by `scripts/corpus-diff.sh`.

## Root cause
`run_script_lines` accumulates physical lines into a command and uses `squote_backslash_literal` to decide whether a trailing `\` is a genuine line continuation or a literal byte inside a single-quoted string. That scan tracked quotes but **did not skip `#` comments**, so an apostrophe in a comment (`# it's likely …`) opened a phantom single-quote that never closed. A real `\<newline>` continuation further down was then treated as quoted, the backslash survived as a word, and the parse desynced (`syntax error: expected `fi'`).

Isolated to an 11-line minimal repro (needs: a comment-apostrophe arm + an `if` containing a `(subshell) \`-continuation in another arm).

## Fix
Skip an unquoted word-initial `#` comment while scanning. Narrowed to `#` preceded by a blank/newline so a `#` glued to a preceding word (`$(cmd)#x`) is not mistaken for a comment.

## Verification
- Fixes 3 of 4 corpus parse blockers (config.guess x2, nvm.sh); corpus parse-identical **93%→94%**. (`xcrun` is a separate, unrelated bug.)
- **Zero conformance regressions** across 14 suites; ctest 22/22. (Verified my change produces byte-identical output on the timing-flaky dbg-support test.)

Closes the config.guess blocker from #370.