### PR TITLE
parser: keep whitespace inside (...) in a [[ =~ ]] regex

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -886,10 +886,27 @@ struct Parser {
           fail("expected operand after operator");
           return;
         }
+        // Whitespace normally ends the regex, but not while inside an unclosed
+        // `(...)' group: bash keeps `(a b)' (and nested `(a (b c))') as one
+        // pattern, and a blank or the closing `]]' only ends the regex at paren
+        // depth 0.  Track `('/`)' across tokens; `[a b]' (depth 0 at the blank)
+        // still ends, matching bash.
+        int pd = 0;
+        auto count_parens = [&pd](const std::string &s) {
+          for (char c : s) {
+            if (c == '(') pd++;
+            else if (c == ')') pd--;
+          }
+        };
         std::string rx = tok_source(cur());
+        count_parens(rx);
         advance();
-        while (!err && !at_cond_end() && !is(Tok::Eof) && !cur().preceded_by_blank) {
-          rx += tok_source(cur());
+        while (!err && !is(Tok::Eof)) {
+          if (pd == 0 && (at_cond_end() || cur().preceded_by_blank)) break;
+          if (cur().preceded_by_blank) rx += ' ';  // blank inside (...) is regex
+          std::string src = tok_source(cur());
+          rx += src;
+          count_parens(src);
           advance();
         }
         e += " =~ ";


### PR DESCRIPTION
## Problem
Homebrew's `xcrun` shim (`[[ "$*" =~ (^| )-?-show-sdk-(path|version|build) && … ]]`) failed to parse — the last of the 4 real-world blockers from `scripts/corpus-diff.sh`.

## Cause
The `=~` right operand is reassembled from the tokens after `=~`, gluing only tokens not separated by whitespace. A blank **inside a `(...)` group** ended the regex early, leaving a stray operand → `syntax error: expected `]]'`.

## Fix
Track `(`/`)` depth while reassembling; a blank (or the closing `]]`) ends the regex **only at paren depth 0**. Verified against bash on every case: `(a b)` and nested `(a (b c))` keep the whitespace; `[a b]` and `(a b) c` still end at the blank (rc=2, as bash); even the `[)]` pathology matches.

## Verification
- **All 4 corpus blockers now fixed** — corpus shows **0 accept/reject blockers** (was 4), 94% parse-identical.
- **cond 75→73** (bonus), zero regressions across 10 suites, ctest 22/22.
- Runtime `=~` matching and `BASH_REMATCH` capture groups verified intact.

Closes the last corpus blocker from #370.