### PR TITLE
parser: fix grouped [[ =~ ]] regex; add corpus-fetch for a broad corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/bash-tests/
 
 # Agent tooling run state (machine-specific, not part of the sources)
 .agent-state/
+/corpus/

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -902,7 +902,12 @@ struct Parser {
         count_parens(rx);
         advance();
         while (!err && !is(Tok::Eof)) {
-          if (pd == 0 && (at_cond_end() || cur().preceded_by_blank)) break;
+          // At paren depth 0 the regex ends at a blank, the closing `]]', or a
+          // `)' -- the last being a conditional group close (`[[ ( X =~ RE ) ]]'),
+          // not regex content, exactly as bash treats a bare `)' there.
+          if (pd == 0 && (at_cond_end() || cur().preceded_by_blank ||
+                          cur().type == Tok::Rparen))
+            break;
           if (cur().preceded_by_blank) rx += ' ';  // blank inside (...) is regex
           std::string src = tok_source(cur());
           rx += src;

--- a/scripts/corpus-fetch.sh
+++ b/scripts/corpus-fetch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Brian J. Fox
+# Licensed under GPLv2 with the GPLv2-AI Exception.
+#
+# corpus-fetch.sh -- assemble a large real-world shell-script corpus by shallow-
+# cloning a curated set of shell-heavy projects, for use with corpus-diff.sh:
+#
+#   scripts/corpus-fetch.sh [DEST]        # default DEST: ./corpus (gitignored)
+#   scripts/corpus-diff.sh --parse DEST
+#
+# Each repo is cloned --depth 1 (fast, no history) and skipped if already
+# present.  These are chosen for a high density of portable /bin/sh and
+# /bin/bash scripts -- build glue, completions, test harnesses, version
+# managers -- i.e. exactly the code a bash replacement must parse and run.
+set -uo pipefail
+
+DEST=${1:-"$(cd "$(dirname "$0")/.." && pwd)/corpus"}
+mkdir -p "$DEST"
+
+# name<TAB>url  (shallow-cloned into DEST/name)
+REPOS='
+git	https://github.com/git/git
+bats-core	https://github.com/bats-core/bats-core
+bash-completion	https://github.com/scop/bash-completion
+shellcheck	https://github.com/koalaman/shellcheck
+nvm	https://github.com/nvm-sh/nvm
+rbenv	https://github.com/rbenv/rbenv
+pyenv	https://github.com/pyenv/pyenv
+autoconf	https://github.com/autotools-mirror/autoconf
+gnulib	https://github.com/coreutils/gnulib
+dotbot	https://github.com/anishathalye/dotbot
+tldr	https://github.com/tldr-pages/tldr
+docker-install	https://github.com/docker/docker-install
+'
+
+echo "corpus destination: $DEST" >&2
+printf '%s\n' "$REPOS" | while IFS=$'\t' read -r name url; do
+  [ -n "${name:-}" ] || continue
+  if [ -d "$DEST/$name/.git" ]; then
+    echo "  have  $name" >&2
+    continue
+  fi
+  echo "  clone $name ($url)" >&2
+  git clone --depth 1 --quiet "$url" "$DEST/$name" 2>/dev/null \
+    && echo "        ok" >&2 \
+    || echo "        FAILED (skipped)" >&2
+done
+
+# Count what the corpus scanner will actually pick up.
+n=$(find "$DEST" -type f \( -name '*.sh' -o -name '*.bash' \) 2>/dev/null | wc -l | tr -d ' ')
+echo "corpus ready: $DEST  (~$n *.sh/*.bash files, plus shebang scripts)" >&2


### PR DESCRIPTION
## Broadening the corpus
`scripts/corpus-fetch.sh` shallow-clones a curated set of shell-heavy projects (git, bats, bash-completion, shellcheck, nvm/rbenv/pyenv, autoconf, gnulib, …) into a gitignored `./corpus`. Running `corpus-diff.sh` over the result — **~2962 real scripts** — gives **98% parse-identical** and, importantly, **zero `gnash-rejects` blockers**: gnash parses every real-world script bash accepts. (The 21 remaining blockers are all `gnash-accepts`: gnash parses `?(...)` extglob without `shopt -s extglob`, where bash's `-n` is stricter — low-harm, since those scripts enable extglob at runtime.)

## The bug it found
The broadened corpus surfaced a latent bug in the `=~` regex reassembly: a `)` that closes an enclosing conditional group — `[[ ! ( "$t" =~ ^(latest|stable)$ ) && … ]]` (shellcheck's `.multi_arch_docker`) — was glued into the regex (no preceding blank), driving paren depth negative and swallowing the command (`syntax error: expected `)' in conditional`).

Fix: at paren depth 0 a `)` ends the regex (bash rejects a bare `)` there too), like a blank or `]]`. The regex's own balanced parens are unaffected.

## Verification
- `.multi_arch_docker` and `xcrun` both parse; `[[ x =~ a)b ]]` matches bash (rc=2); grouped `[[ ( x =~ ^(a|b)$ ) ]]` works; `BASH_REMATCH` groups intact.
- Zero conformance regressions (cond/nameref/errors/builtins/varenv), ctest 22/22.