### PR TITLE
glob: match patterns by character under a multibyte locale

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2396,16 +2396,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         } else if (append) {
           val = sh.get(name) + val;
         }
-        if (lcase) for (char &c : val) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        else if (ucase) for (char &c : val) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-        else if (capcase) {
-          bool cfirst = true;
-          for (char &c : val) {
-            c = static_cast<char>(cfirst ? std::toupper(static_cast<unsigned char>(c))
-                                         : std::tolower(static_cast<unsigned char>(c)));
-            cfirst = false;
-          }
-        }
+        // Character-aware fold (multibyte-safe), matching Shell::set's attribute.
+        if (lcase) val = mb_lower(val);
+        else if (ucase) val = mb_upper(val);
+        else if (capcase) val = mb_capitalize(val);
         // Retargeting an existing empty nameref via `declare r=val' validates
         // the value like a plain assignment, but the diagnostic carries the
         // builtin name (Shell::set would print it bare).

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2017,25 +2017,32 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
   if (rest[0] == '#' || rest[0] == '%') {
     bool longest = rest.size() > 1 && rest[1] == rest[0];
     std::string pat = ex.expand_pattern(rest.substr(longest ? 2 : 1));
-    if (rest[0] == '#') {  // prefix removal
+    // Try only CHARACTER-boundary split points, so `${x%?}' removes one whole
+    // multibyte character rather than a single trailing byte (which would leave
+    // a broken sequence).  cb lists the byte offsets of every boundary, 0..size.
+    std::vector<size_t> cb;
+    for (size_t i = 0;; ) {
+      cb.push_back(i);
+      if (i >= val.size()) break;
+      size_t len = 1;
+      mb_decode(val, i, len);
+      i += len;
+    }
+    if (rest[0] == '#') {  // prefix removal (shortest = first, longest = last)
       if (longest) {
-        for (size_t k = val.size(); k + 1 > 0; k--) {
-          if (pat_match(pat, val.substr(0, k))) return val.substr(k);
-          if (k == 0) break;
-        }
+        for (size_t j = cb.size(); j-- > 0; )
+          if (pat_match(pat, val.substr(0, cb[j]))) return val.substr(cb[j]);
       } else {
-        for (size_t k = 0; k <= val.size(); k++)
+        for (size_t k : cb)
           if (pat_match(pat, val.substr(0, k))) return val.substr(k);
       }
-    } else {  // suffix removal
+    } else {  // suffix removal (longest = first split, shortest = last split)
       if (longest) {
-        for (size_t k = 0; k <= val.size(); k++)
+        for (size_t k : cb)
           if (pat_match(pat, val.substr(k))) return val.substr(0, k);
       } else {
-        for (size_t k = val.size(); k + 1 > 0; k--) {
-          if (pat_match(pat, val.substr(k))) return val.substr(0, k);
-          if (k == 0) break;
-        }
+        for (size_t j = cb.size(); j-- > 0; )
+          if (pat_match(pat, val.substr(cb[j]))) return val.substr(0, cb[j]);
       }
     }
     return val;

--- a/libglob/src/smatch.cpp
+++ b/libglob/src/smatch.cpp
@@ -14,6 +14,8 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <cwchar>
+#include <cwctype>
 
 #include "strmatch.h"
 
@@ -28,6 +30,34 @@ extern "C" void strmatch_set_interrupt(int state) { interrupt_state = state ? 1 
 namespace {
 
 using UC = unsigned char;
+
+// Byte width of the character at s (s < se) under the current locale; 1 in a
+// unibyte/C locale or on an invalid/truncated sequence, so scanning never
+// stalls.
+inline size_t mb_clen(const UC *s, const UC *se) {
+  if (MB_CUR_MAX <= 1 || s >= se) return 1;
+  std::mbstate_t st{};
+  size_t r = std::mbrtowc(nullptr, reinterpret_cast<const char *>(s),
+                          static_cast<size_t>(se - s), &st);
+  if (r == 0 || r == static_cast<size_t>(-1) || r == static_cast<size_t>(-2)) return 1;
+  return r;
+}
+
+// Decode the character at s (s < se) to a wide code point, setting len to its
+// byte width (>=1); falls back to the raw byte in a unibyte locale / on error.
+inline std::wint_t mb_cp(const UC *s, const UC *se, size_t &len) {
+  if (MB_CUR_MAX <= 1 || s >= se) { len = 1; return s < se ? *s : 0; }
+  wchar_t wc = 0;
+  std::mbstate_t st{};
+  size_t r = std::mbrtowc(&wc, reinterpret_cast<const char *>(s),
+                          static_cast<size_t>(se - s), &st);
+  if (r == 0 || r == static_cast<size_t>(-1) || r == static_cast<size_t>(-2)) {
+    len = 1;
+    return *s;
+  }
+  len = r;
+  return static_cast<std::wint_t>(wc);
+}
 
 struct SmEnds {
   UC *pattern;
@@ -70,22 +100,24 @@ int collsym(const UC *p, int len) {
 }
 
 // POSIX [:class:] test.  Returns 1/0, or -1 for an unknown class.
-int is_cclass(int c, const char *name) {
+// c is a wide code point so a bracket class ([[:alpha:]]) matches a multibyte
+// character; the wide iswctype functions honor the locale for the whole range.
+int is_cclass(std::wint_t c, const char *name) {
   struct {
     const char *name;
-    int (*fn)(int);
-  } tbl[] = {{"alpha", std::isalpha}, {"digit", std::isdigit},
-             {"alnum", std::isalnum}, {"space", std::isspace},
-             {"upper", std::isupper}, {"lower", std::islower},
-             {"punct", std::ispunct}, {"cntrl", std::iscntrl},
-             {"print", std::isprint}, {"graph", std::isgraph},
-             {"blank", std::isblank}, {"xdigit", std::isxdigit},
-             {"ascii", [](int ch) { return static_cast<int>(ch >= 0 && ch <= 0x7f); }},
-             {"word", [](int ch) { return static_cast<int>(std::isalnum(ch) || ch == '_'); }},
+    int (*fn)(std::wint_t);
+  } tbl[] = {{"alpha", std::iswalpha}, {"digit", std::iswdigit},
+             {"alnum", std::iswalnum}, {"space", std::iswspace},
+             {"upper", std::iswupper}, {"lower", std::iswlower},
+             {"punct", std::iswpunct}, {"cntrl", std::iswcntrl},
+             {"print", std::iswprint}, {"graph", std::iswgraph},
+             {"blank", std::iswblank}, {"xdigit", std::iswxdigit},
+             {"ascii", [](std::wint_t ch) { return static_cast<int>(ch <= 0x7f); }},
+             {"word", [](std::wint_t ch) { return static_cast<int>(std::iswalnum(ch) || ch == L'_'); }},
              {nullptr, nullptr}};
   for (int i = 0; tbl[i].name; i++)
     if (std::strcmp(tbl[i].name, name) == 0)
-      return tbl[i].fn(static_cast<unsigned char>(c)) ? 1 : 0;
+      return tbl[i].fn(c) ? 1 : 0;
   return -1;
 }
 
@@ -115,7 +147,7 @@ int extmatch(int xc, UC *s, UC *se, UC *p, UC *pe, int flags);
 
 // Match a bracket expression at P (P points just past `[`); returns the
 // position after the expression on success, or NULL.
-UC *brackmatch(UC *p, UC test_in, int flags) {
+UC *brackmatch(UC *p, UC test_in, std::wint_t test_cp, int flags) {
   UC cstart, cend, c;
   int is_not, forcecoll, isrange;
   int pc;
@@ -157,7 +189,7 @@ UC *brackmatch(UC *p, UC test_in, int flags) {
         std::memcpy(ccname, p + 1, static_cast<size_t>(len));
         ccname[len] = '\0';
         dequote_pathname(reinterpret_cast<UC *>(ccname));
-        pc = is_cclass(orig_test, ccname);
+        pc = is_cclass(test_cp, ccname);
         if (pc == -1) pc = 0;
         std::free(ccname);
       }
@@ -365,6 +397,7 @@ int extmatch(int xc, UC *s, UC *se, UC *p, UC *pe, int flags) {
 int gmatch(UC *string, UC *se, UC *pattern, UC *pe, SmEnds *ends, int flags) {
   UC *p, *n;
   int c, sc;
+  size_t nadv;  // bytes to advance over the matched string character
 
   if (string == nullptr || pattern == nullptr) return FNM_NOMATCH;
   p = pattern;
@@ -374,6 +407,7 @@ int gmatch(UC *string, UC *se, UC *pattern, UC *pe, SmEnds *ends, int flags) {
     c = *p++;
     c = fold(c, flags);
     sc = n < se ? *n : '\0';
+    nadv = 1;  // a `?'/`['/multibyte literal steps over a whole character below
 
     if (interrupt_state || terminating_signal) return FNM_NOMATCH;
 
@@ -394,6 +428,7 @@ int gmatch(UC *string, UC *se, UC *pattern, UC *pe, SmEnds *ends, int flags) {
             ((n == string && sdot_or_dotdot(n)) ||
              ((flags & FNM_PATHNAME) && n > string && n[-1] == '/' && sdot_or_dotdot(n))))
           return FNM_NOMATCH;
+        nadv = mb_clen(n, se);  // `?' matches one whole character
         break;
 
       case '\\':
@@ -431,7 +466,7 @@ int gmatch(UC *string, UC *se, UC *pattern, UC *pe, SmEnds *ends, int flags) {
             p = newn ? newn : pe;
           } else if (c == '?') {
             if (sc == '\0') return FNM_NOMATCH;
-            n++;
+            n += mb_clen(n, se);  // `?' consumes one whole character
             sc = n < se ? *n : '\0';
           }
           if ((flags & FNM_EXTMATCH) && c == '*' && *p == '(') {
@@ -511,15 +546,20 @@ int gmatch(UC *string, UC *se, UC *pattern, UC *pe, SmEnds *ends, int flags) {
             ((n == string && sdot_or_dotdot(n)) ||
              ((flags & FNM_PATHNAME) && n > string && n[-1] == '/' && sdot_or_dotdot(n))))
           return FNM_NOMATCH;
-        p = brackmatch(p, static_cast<UC>(sc), flags);
-        if (p == nullptr) return FNM_NOMATCH;
+        {
+          size_t clen = 1;
+          std::wint_t cp = mb_cp(n, se, clen);
+          p = brackmatch(p, static_cast<UC>(sc), cp, flags);
+          if (p == nullptr) return FNM_NOMATCH;
+          nadv = clen;  // the bracket matched one whole character
+        }
         break;
       }
 
       default:
         if (static_cast<UC>(c) != fold(sc, flags)) return FNM_NOMATCH;
     }
-    ++n;
+    n += nadv;
   }
 
   if (n == se) return 0;

--- a/scripts/probes/multibyte.sh
+++ b/scripts/probes/multibyte.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Multibyte (UTF-8) string handling: length, substrings, case, patterns.
+export LC_ALL=en_US.UTF-8
+x=café
+echo "len=${#x} up=${x^^} low=${x,,} sub=${x:1:2} last=${x: -1}"
+echo "strip=${x%?} head=${x#?} ext=${x%.*}"
+[[ $x == c??é ]] && echo "match-q ok"
+[[ é == ? ]] && echo "one-char ok"
+[[ é == [[:alpha:]] ]] && echo "class ok"
+case résumé in r?sum?) echo "case ok" ;; *) echo "case BAD" ;; esac
+declare -u U=münchen; declare -l L=BJÖRK; echo "$U $L"


### PR DESCRIPTION
Continues the deeper-multibyte work (after ${#}/substring in #371 and case-conversion in #378) — the pattern matcher.

## Problem
The `strmatch` engine and the `${var#pat}`/`${var%pat}` removals scanned the subject **byte by byte**, so under UTF-8:
- `?` matched one *byte*: `[[ é == ? ]]` failed; `${x%?}` on `café` left a broken `caf\xC3`; `case résumé in r?sum?)` didn't match.
- a bracket **class** tested only the first byte: `[[ é == [[:alpha:]] ]]` failed.

## Fix
- **smatch.cpp**: `?` and `[...]` step over a whole character (`mb_clen`); a bracket class matches the decoded code point via the wide `iswctype` functions (`is_cclass` takes a `wint_t`). Literals and `*` were already byte-correct; unibyte/C locale unchanged.
- **expand.cpp**: the `#`/`%` removals try only character-boundary split points, so shortest/longest matches land on a whole character.
- **builtins.cpp**: `declare -l L=BJÖRK` (inline) folded per byte — now uses the mb helpers (the standalone path was fixed in #378; the multibyte probe here caught the inline gap).

## Verification
- `[[ é == ? ]]`, `${x%?}`→`caf`, `case r?sum?`, `[[ é == [[:alpha:]] ]]`, `[[ É == [[:upper:]] ]]`, `????` globbing, inline declare folds — all match bash.
- New `scripts/probes/multibyte.sh` is byte-identical to bash (exec-mode) and guards these fixes.
- **Zero regressions** across 22 conformance suites (glob/globstar/case/cond/more-exp/quote/quotearray/nameref/varenv/assoc/array/builtins/attr/...); ctest 22/22.

Remaining deeper-multibyte: IFS splitting, `read -n/-N`, printf `%c`/width.