### PR TITLE
declare: reject removing -n from a readonly nameref

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2582,7 +2582,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     }
     if (rm_exported) v.exported = false;
     if (rm_integer) v.integer = false;
-    if (rm_nameref) v.nameref = false;
+    // Removing the nameref attribute from a readonly nameref is rejected, like
+    // adding one: modifying a readonly variable's type is an error, so `declare
+    // +n' on a readonly `declare -n' reports `readonly variable' (bash).  A `+n'
+    // on a readonly NON-nameref is a harmless no-op and does not error.
+    if (rm_nameref && v.readonly && v.nameref) {
+      std::fprintf(stderr, "%s%s: %s: readonly variable\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+      ret = 1;
+    } else if (rm_nameref) {
+      v.nameref = false;
+    }
     if (rm_ucase) v.ucase = false;
     if (rm_lcase) v.lcase = false;
     if (rm_capcase) v.capcase = false;


### PR DESCRIPTION
## Problem
`declare +n` / `typeset +n` on a **readonly nameref** changes a readonly variable's type, which bash rejects with `NAME: readonly variable` — symmetric with adding `-n` to a readonly variable (batch126). gnash silently tore down the reference.

## Fix
Guard the `rm_nameref` application in `bi_declare`: when the target is both readonly and a nameref, report the readonly error and leave the attribute. A `+n` on a readonly **non-nameref** stays a harmless no-op (no error, matching bash), and a `+n` on a read-write nameref still removes the attribute.

## Verification
- `declare -rn foo=bar; declare +n foo` → `declare: foo: readonly variable` (bash); `+n` on a readonly scalar and on a read-write nameref both unchanged.
- **nameref 212 → 209** (nameref17 lines 28/76/92).
- Zero regressions (varenv/attr/assoc/array/builtins/errors/quotearray); ctest 22/22.

Closes #382