### PR TITLE
executor: reject subscripting a nameref-to-array-element

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -538,6 +538,19 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
       return;
     }
   }
+  // A nameref whose target is itself an array element (`declare -n ref=a[0]')
+  // cannot be subscripted further -- `ref[foo]=x' would mean `a[0][foo]'.  bash
+  // rejects the resolved target as an invalid identifier rather than creating a
+  // variable literally named `a[0]'.
+  if (a.sub) {
+    std::string dn = sh.deref(a.name);
+    if (dn.find('[') != std::string::npos) {
+      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh.err_prefix().c_str(),
+                   dn.c_str());
+      sh.last_status = 1;
+      return;
+    }
+  }
   // An empty subscript (`b[]=x') is always a bad array subscript.  The special
   // `*'/`@' selectors are bad for an indexed array but are ordinary literal keys
   // for an associative one (`a[@]=x' stores under the key "@").


### PR DESCRIPTION
Part of the namerefs-to-array-elements cluster (nameref18).

## Fix
`ref[foo]=x` where `ref` is `declare -n ref=a[0]` means `a[0][foo]` — subscripting an element. gnash resolved `ref` to `a[0]` and created a variable literally named `a[0]`; bash rejects the resolved target (``a[0]': not a valid identifier`). `apply_array_assign` now errors when a subscripted assignment's deref'd name still contains `[`. Subscripting a nameref to a whole array (`declare -n ref=arr; ref[2]=x`) is unaffected.

## Verification
- nameref 209 → 208; zero regressions across array/assoc/varenv/attr/builtins/errors/quotearray; ctest 22/22.

## Honest note on "finishing" nameref18
The remaining diffs share one root cause I fully traced: `declare -A ref` / `declare ref=` (ref→a[0]) create a spurious literal `a[0]` variable via bi_declare's `vars[aname]` path, which then makes `declare -p a[0]` find it instead of reporting "not found". A targeted handler that short-circuited that path regressed **other** nameref-to-element cases (+16) because the shared post-store attribute logic is needed. Finishing it cleanly requires threading subscripted-target resolution *through* bi_declare (attribute→base array, value→element) rather than a blanket skip — a careful, larger change deferred to its own pass.

Closes the subscript-on-element-nameref piece.