### PR TITLE
declare: nameref to array element no longer creates a literal base[sub] variable

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2514,8 +2514,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // binding (fresh_local); at global scope the var is fresh if it did not
     // already exist.  Arrays set this in make_array; an existing variable keeps
     // its current value/visibility.
-    bool fresh_var = fresh_local || sh.vars.find(aname) == sh.vars.end();
-    Variable &v = sh.vars[aname];
+    // A nameref whose target is an array element (`declare -n ref=a[0]') derefs
+    // to `a[0]'.  bash has no variable named `a[0]' (`declare -p a[0]' reports
+    // "not found"); attributes attach to the base array `a', and the element
+    // value was already written through the subscript-aware Shell::set above.
+    // Bind `v' to the base so attribute application never creates a literal
+    // `a[0]' variable.
+    std::string vkey = aname;
+    if (size_t lb = aname.find('['); lb != std::string::npos) vkey = aname.substr(0, lb);
+    bool fresh_var = fresh_local || sh.vars.find(vkey) == sh.vars.end();
+    Variable &v = sh.vars[vkey];
     // Whether v was already readonly BEFORE this command applied its attributes
     // (`-r' below sets v.readonly): a pre-existing readonly plain variable
     // cannot be converted to a nameref, but `declare -rn foo=bar' on a fresh

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2045,6 +2045,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         auto it = sh.vars.find(argv[i]);
         if (it == sh.vars.end() ||
             (local_p && !cur_locals.count(argv[i]))) {
+          // `declare -p A B C' prints each name's declaration (stdout) or
+          // "not found" (stderr) in argument order.  stdout is block-buffered
+          // under a pipe while stderr is not, so flush any already-printed
+          // declarations first to keep the interleaving bash produces.
+          std::fflush(stdout);
           std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
                        argv[0].c_str(), argv[i].c_str());
           st = 1;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -878,6 +878,11 @@ int Shell::array_count(const std::string &n_in) const {
 
 void Shell::make_array(const std::string &n_in, bool assoc) {
   std::string n = deref(n_in);
+  // A nameref whose target is an array element (`declare -n ref=a[0]; declare -A
+  // ref') derefs to `a[0]'.  There is no variable named `a[0]'; bash applies the
+  // array attribute to the base array `a' (`declare -A a'), so strip the
+  // subscript here rather than creating a literal `a[0]' variable.
+  if (size_t lb = n.find('['); lb != std::string::npos) n = n.substr(0, lb);
   bool fresh = !vars.count(n);
   Variable &v = vars[n];
   if (fresh) v.invisible = true;  // `declare -a b' with no value: declared, unset


### PR DESCRIPTION
## Summary

Finishes the `bi_declare` nameref-to-array-element work. A nameref whose target
is an array element (`declare -n ref=a[0]`) derefs to the literal string `a[0]`.
bash has no variable named `a[0]` — `declare -p a[0]` reports "not found" — and
routes array attributes to the base array `a` while writing the element value
through the subscript.

gnash was using the resolved `a[0]` as a variable *name*, creating a spurious
variable literally named `a[0]`, which then made `declare -p a[0]` "find" it and
also contaminated later statements.

## Changes (two commits)

1. **Route nameref-to-array-element attributes to the base array.**
   `make_array` (`declare -A ref` / `declare -a ref`) and the attribute tail of
   `bi_declare` now strip the subscript and operate on the base array, never
   creating a `base[sub]` variable. The element value is already stored by the
   subscript-aware `Shell::set`. This also removes a cross-statement leak where a
   later `typeset ref=4` wrote through the stale `a[0]` literal instead of
   creating the base array.

2. **Flush stdout before "not found" in `declare -p NAME…`.**
   `declare -p ref XXX[0]` interleaves found (stdout) and missing (stderr) names
   in argument order; under a pipe stdout is block-buffered, so the errors jumped
   ahead. Flush stdout first to match bash's ordering.

## Verification

- `tests/nameref18.sub`: all `declare -p` element diffs (lines 23/38/43/59/63/67)
  and the stdout/stderr ordering diffs are gone. Scoreboard **nameref 208 → 190**.
- No regressions: array/assoc/varenv/attr/builtins/errors/quotearray byte-diffs
  unchanged vs `main`.
- `ctest` 22/22; `run_diff.sh` all 238 scripts match bash.

Remaining `nameref18.sub` diffs are unrelated to `bi_declare`: a coproc
line-number attribution (line 51 vs 49) and nameref-to-`arr[@]` *expansion*.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)