### PR TITLE
nameref: whole-array splat expansion + declare conformance (nameref 149→117)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -110,6 +110,12 @@ class Expander {
   void emit_zsh_subscript(const std::string &name, const std::string &sub, bool dq,
                           std::string &out, std::string &mask);
 
+  // Emit a list of array elements with `${a[@]}'/`${a[*]}' field/quote
+  // semantics (SEL is '@' or '*'), honoring the current quoting/splitting.
+  // Shared by the ${a[@]} path and namerefs/indirection to a whole-array splat.
+  void emit_array_items(const std::vector<std::string> &items, char sel, bool dq,
+                        std::string &out, std::string &mask);
+
   // zsh `${(flags)name}' expansion flags (join/split/sort/unique/case/keys).
   // Returns true and emits into out/mask when BODY begins with a `(flags)'
   // group; false (leaving out/mask untouched) otherwise, so the caller can

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2301,6 +2301,20 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         }
       }
     }
+    // `declare -a NAME[sub]=val' / `-A NAME[sub]=...' where NAME is a nameref
+    // cannot keep the reference -- a nameref has no subscript of its own -- so
+    // bash drops the nameref attribute (with a warning) and makes NAME itself the
+    // array, rather than following the reference to its target.  A bare `declare
+    // -a ref' (no subscript) still follows the nameref (handled by make_array).
+    if (subscript0 && (mk_array || mk_assoc) && !nameref && !rm_nameref) {
+      auto nv = sh.vars.find(name);
+      if (nv != sh.vars.end() && nv->second.nameref) {
+        std::fprintf(stderr, "%swarning: %s: removing nameref attribute\n",
+                     sh.err_prefix().c_str(), name.c_str());
+        nv->second.nameref = false;
+        nv->second.value.clear();  // discard the old target; NAME becomes the array
+      }
+    }
     if (mk_assoc) sh.make_array(name, true);
     else if (mk_array) sh.make_array(name, false);
     // A subscripted name implies an indexed array even without `-a'

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2344,12 +2344,18 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           (cur->second.kind == VarKind::Indexed || cur->second.kind == VarKind::Assoc);
       bool unwrap_quoted = mk_array || mk_assoc ||
           (arrayvar && (argv[0] == "declare" || argv[0] == "typeset"));
-      if (!arraylit && unwrap_quoted && val.size() >= 4 &&
+      if (!nameref && !arraylit && unwrap_quoted && val.size() >= 4 &&
           (val.front() == '\'' || val.front() == '"') && val.back() == val.front() &&
           val[1] == '(' && val[val.size() - 2] == ')') {
         apply_assignment_word(sh, name + (append ? "+=" : "=") +
                                       val.substr(1, val.size() - 2));
       } else if (arraylit || subscript) {
+        // An UNQUOTED compound (`declare -n array=(one two three)') is assigned
+        // as an array literal even under -n; the "reference variable cannot be an
+        // array" error then fires on the resulting array below (bash).  A QUOTED
+        // compound (`declare -n array='(...)'`) is instead a nameref-target value
+        // -- the unwrap above is gated on !nameref so it falls to the branch
+        // below and is rejected as an invalid target.
         apply_assignment_word(sh, a);  // NAME=(...) or NAME[i]=...
       } else if (nameref) {
         // `declare -n ref=target': store the target NAME as ref's own value.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -528,6 +528,29 @@ static bool array_ref(const std::string &body, char &lead, std::string &name, ch
   return false;
 }
 
+// True when S is a whole-array splat reference `BASE[@]' / `BASE[*]' (BASE a
+// non-empty identifier-shaped prefix); fills BASE and SEL ('@' or '*').
+static bool is_array_splat(const std::string &s, std::string &base, char &sel) {
+  size_t lb = s.find('[');
+  if (lb == std::string::npos || lb == 0 || s.size() != lb + 3 || s.back() != ']')
+    return false;
+  char c = s[lb + 1];
+  if (c != '@' && c != '*') return false;
+  base = s.substr(0, lb);
+  sel = c;
+  return true;
+}
+
+// A nameref whose target is a whole-array splat (`declare -n ref=arr[@]'):
+// expanding $ref / ${ref} yields every element like ${arr[@]}.  Returns true and
+// fills BASE and SEL ('@' or '*') when NAME is such a nameref.
+static bool nameref_array_splat(Shell &sh, const std::string &name, std::string &base,
+                                char &sel) {
+  auto it = sh.vars.find(name);
+  if (it == sh.vars.end() || !it->second.nameref) return false;
+  return is_array_splat(it->second.value, base, sel);
+}
+
 // Detect NAME[@]OP / NAME[*]OP where OP is an operator applied element-wise
 // (case-mod ^ , ; pattern removal # % ; substitution / ; transform @).  Slicing
 // (:offset) and default (:-) forms act on the array as a whole and are excluded.
@@ -804,6 +827,53 @@ void Expander::emit_zsh_subscript(const std::string &name, const std::string &su
   }
   std::string val = sh_.array_get(name, sh_.zsh_subscript(name, expand_no_split(sub)));
   for (char c : val) { out += c; mask += qm; }
+}
+
+void Expander::emit_array_items(const std::vector<std::string> &items, char sel, bool dq,
+                                std::string &out, std::string &mask) {
+  if (sel == '@' && dq) {
+    // "${a[@]}": one field per element (empties kept); absorb the quoted-null
+    // the opening quote emitted so an empty list drops the word.
+    if (!out.empty() && out.back() == QNULL && mask.back() == MMARK) {
+      out.pop_back();
+      mask.pop_back();
+    }
+    for (size_t k = 0; k < items.size(); k++) {
+      if (k) { out += FIELD_SEP; mask += MMARK; }
+      out += QNULL; mask += MMARK;
+      for (char c : items[k]) { out += c; mask += '1'; }
+    }
+  } else if (sel == '*' && dq) {
+    std::string is = sh_.ifs();
+    std::string j = mb_first_char(is);
+    for (size_t k = 0; k < items.size(); k++) {
+      if (k) for (char c : j) { out += c; mask += '1'; }
+      for (char c : items[k]) { out += c; mask += '1'; }
+    }
+  } else if (sel == '*' && splitting_ && sh_.ifs().empty()) {
+    bool first = true;
+    for (size_t k = 0; k < items.size(); k++) {
+      if (items[k].empty()) continue;
+      if (!first) { out += FIELD_SEP; mask += MMARK; }
+      first = false;
+      for (char c : items[k]) { out += c; mask += '0'; }
+    }
+  } else if (sel == '*') {
+    std::string is = sh_.ifs();
+    std::string j = mb_first_char(is);
+    for (size_t k = 0; k < items.size(); k++) {
+      if (k) for (char c : j) { out += c; mask += '0'; }
+      for (char c : items[k]) { out += c; mask += '0'; }
+    }
+  } else {
+    bool first = true;
+    for (size_t k = 0; k < items.size(); k++) {
+      if (splitting_ && items[k].empty()) continue;
+      if (!first) { out += FIELD_SEP; mask += MMARK; }
+      first = false;
+      for (char c : items[k]) { out += c; mask += '0'; }
+    }
+  }
 }
 
 void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::string &out,
@@ -1118,6 +1188,26 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             i = end + 1;
             return;
           }
+        }
+      }
+      // `${ref}' where ref is a nameref to a whole-array splat (`arr[@]') expands
+      // like `${arr[@]}'; likewise `${!indir}' where indir's VALUE is such a
+      // splat.  Rewrite the body to the target so the array path below preserves
+      // the field structure (a plain string return would flatten it).  A body
+      // carrying any operator won't match the bare-name lookup, so this only
+      // fires for `${ref}' / `${!indir}'.
+      {
+        std::string nrbase;
+        char nrsel;
+        if (nameref_array_splat(sh_, body, nrbase, nrsel)) {
+          body = nrbase + '[' + nrsel + ']';
+        } else if (body.size() > 1 && body[0] == '!') {
+          // ${!indir}: a non-nameref plain variable whose value is `arr[@]'.
+          // (A nameref indir is special-cased to its target NAME elsewhere.)
+          auto it = sh_.vars.find(body.substr(1));
+          if (it != sh_.vars.end() && !it->second.nameref &&
+              is_array_splat(it->second.value, nrbase, nrsel))
+            body = it->second.value;
         }
       }
       char lead, sel;
@@ -1646,6 +1736,16 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       }
     }
     return;
+  }
+  // A bare `$ref' where ref is a nameref to a whole-array splat (`arr[@]'/
+  // `arr[*]') expands to every element, like $arr[@] would.
+  {
+    std::string nrbase;
+    char nrsel;
+    if (nameref_array_splat(sh_, name, nrbase, nrsel)) {
+      emit_array_items(sh_.array_values(nrbase), nrsel, dq, out, mask);
+      return;
+    }
   }
   bool set = false;
   std::string v = param_value(name, set);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1190,6 +1190,14 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   {
     std::string base, sub;
     if (nameref_elt(n_in, base, sub)) {
+      // A scalar assignment through a nameref to a whole-array splat
+      // (`declare -n r=a[@]; r=5') has no single element to target: bash rejects
+      // the `@'/`*' subscript as a bad array subscript and assigns nothing.
+      if (sub == "@" || sub == "*") {
+        std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", err_prefix().c_str(),
+                     base.c_str(), sub.c_str());
+        return false;
+      }
       auto it = vars.find(base);
       if (it != vars.end() && it->second.readonly) {
         std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),


### PR DESCRIPTION
Second cleanup pass over the `nameref` suite. Four independent fixes; scoreboard **149 → 117**, plus **quotearray 104 → 96**.

## Fixes (one commit each)

1. **A nameref/indirection to a whole-array splat yields all elements.** `declare -n ref=arr[@]` (or `indir=arr[@]`) — expanding `$ref`, `${ref}`, `${!indir}` now produces every element with `${arr[@]}` field/quote semantics (`"$ref"` splits per element) instead of collapsing to element 0. Adds an `is_array_splat` detector and an `emit_array_items` helper factored from the existing `${a[@]}` emit.

2. **A quoted compound value on `declare -n` is a nameref target, not an array.** `declare -a array=(zero); declare -n array='(one two three)'` now rejects the value as an invalid target and leaves array unchanged (the quoted-compound unwrap is gated on `!nameref`). An unquoted `declare -n array=(...)` still assigns then errors "cannot be an array", as bash does.

3. **`declare -a NAME[sub]=val` on a nameref drops the reference.** It warns `removing nameref attribute` and makes NAME itself the array, instead of following the reference to its target. A bare `declare -a ref` (no subscript) still follows the nameref.

4. **Writing through a nameref to `X[@]`/`X[*]` is a bad subscript.** `declare -n r=a[@]; r=5` now errors `a[@]: bad array subscript` and stores nothing, rather than writing element 0.

## Verification

- `nameref` 149 → 117; `quotearray` 104 → 96; the whole-array recho block and the var[@]/xref clusters in nameref15/18/22 cleared.
- No regressions: array/assoc/varenv/attr/builtins/arith byte-diffs unchanged vs `main`.
- `ctest` 22/22; `run_diff.sh` all 238 scripts match bash.

## Deferred (intricate/interlocking, long flagged fragile)

nameref11 (exec-fd allocation, coproc line numbers, per-builtin invalid-target prefixes); circular/chained nameref attribute-removal and self-reference-through-element (nameref15); nameref environment export (nameref14); `-g`/function-local nameref-target scoping (nameref20); `-ni ref=var` fresh-creation rejection (nameref19/21/23); `declare -r` element→array conversion (nameref12).

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)