### PR TITLE
nameref: targetless/element/attribute conformance (nameref 117→100)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2444,9 +2444,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
                        name.c_str());
           return 1;
         }
-        rv.value = tgt;
-        rv.invisible = false;  // a nameref given a target is now visible
-                               // (`typeset -n r; typeset -n r=P' -> `-n r="P"')
+        // A `declare -n' naming an existing array is rejected below ("reference
+        // variable cannot be an array"); leave the array untouched -- don't store
+        // the target or clear its invisible flag -- so a rejected retarget of a
+        // declared-but-empty array still prints `declare -a array', not `=()'.
+        if (rv.kind != VarKind::Indexed && rv.kind != VarKind::Assoc) {
+          rv.value = tgt;
+          rv.invisible = false;  // a nameref given a target is now visible
+                                 // (`typeset -n r; typeset -n r=P' -> `-n r="P"')
+        }
       } else {
         val = pre_val;  // expanded above, in the enclosing scope, before localizing
         // Honor a pre-existing integer attribute too (e.g. `readonly x+=7' on a

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2320,26 +2320,40 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // A subscripted name implies an indexed array even without `-a'
     // (`declare -r c[100]' creates an empty readonly array c).
     else if (subscript0) sh.make_array(name, false);
+    // Pre-assignment attributes (-i and the case folds, applied so a compound
+    // array literal's elements honor them) attach to the variable that actually
+    // receives the value.  For an existing nameref name that is the reference's
+    // TARGET (`local -n ref=var; local -i ref=(...)') -- bash applies -i to var
+    // and leaves ref a plain `-n' reference -- so resolve through the nameref.
+    std::string attr_name = name;
+    {
+      auto nv2 = sh.vars.find(name);
+      if (nv2 != sh.vars.end() && nv2->second.nameref && !nv2->second.value.empty()) {
+        std::string d = sh.deref(name);
+        size_t lb = d.find('[');
+        attr_name = (lb == std::string::npos) ? d : d.substr(0, lb);
+      }
+    }
     // bash applies declared attributes before the assignment, so a `declare -i'
     // array/associative literal (`declare -ai a=(1+1 2*3)') evaluates each
     // element arithmetically.  apply_array_assign reads the integer attribute
     // from the variable, so set it now rather than after the assignment (the
     // scalar path already honors the -i flag directly).
     if (integer && eq != std::string::npos && !name.empty() && !nameref)
-      sh.vars[name].integer = true;
+      sh.vars[attr_name].integer = true;
     // `declare +i NAME=value' removes the integer attribute BEFORE the
     // assignment, so an array/scalar value is stored verbatim rather than
     // arithmetically evaluated (`declare +i arr=(hello world)').
-    if (rm_integer && eq != std::string::npos && !name.empty() && sh.vars.count(name))
-      sh.vars[name].integer = false;
+    if (rm_integer && eq != std::string::npos && !name.empty() && sh.vars.count(attr_name))
+      sh.vars[attr_name].integer = false;
     // The case-fold attributes (`-l'/`-u'/`-c') likewise apply to array literal
     // elements, so set them before the assignment: array_set reads them from the
     // variable (`declare -al a=(ONE TWO)' -> [0]=one).  The scalar path folds the
     // value directly below, so this only matters for the compound-array path.
     if (eq != std::string::npos && !name.empty() && !nameref) {
-      if (lcase) sh.vars[name].lcase = true;
-      else if (ucase) sh.vars[name].ucase = true;
-      else if (capcase) sh.vars[name].capcase = true;
+      if (lcase) sh.vars[attr_name].lcase = true;
+      else if (ucase) sh.vars[attr_name].ucase = true;
+      else if (capcase) sh.vars[attr_name].capcase = true;
     }
     if (eq != std::string::npos) {
       std::string val = a.substr(eq + 1);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2608,6 +2608,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // cannot be converted to a nameref, but `declare -rn foo=bar' on a fresh
     // var, or re-declaring an existing nameref, is fine.
     bool was_readonly = v.readonly;
+    // Whether v was already a nameref BEFORE this command: adding `-n' to a
+    // variable that was not one strips its integer/case attributes, but
+    // re-declaring an existing nameref (`declare -n b=a[0]; declare -ni b')
+    // leaves them, so the strip below is gated on this.
+    bool was_nameref = v.nameref;
     // A localvar_inherit'd local already holds the enclosing value, so it stays
     // visible; only a genuinely empty fresh scalar is marked declared-but-unset.
     if (fresh_var && !inherited_local && eq == std::string::npos && v.kind == VarKind::Scalar)
@@ -2652,6 +2657,13 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       ret = 1;
     } else if (nameref) {
       v.nameref = true;
+      // A nameref cannot also carry the integer or case-fold attributes: NEWLY
+      // adding `-n' to a variable that has them strips them (bash declare.def
+      // unsets att_integer|att_uppercase|att_lowercase|att_capcase), so
+      // `declare -i ivar; declare -n ivar=foo' prints `declare -n ivar="foo"'.
+      // Re-declaring an existing nameref (`declare -n b=a[0]; declare -ni b')
+      // leaves them, so only strip when the reference is being introduced.
+      if (!was_nameref) v.integer = v.ucase = v.lcase = v.capcase = false;
     }
     // `+X' removes attributes.  Applied after the assignment so `typeset +n
     // foo=other' writes through the still-active nameref to its target before

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -574,8 +574,12 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
     }
   }
   // An integer-attributed array (`declare -i') evaluates each element value as
-  // an arithmetic expression, and `+=' adds rather than string-appends.
-  auto vit = sh.vars.find(a.name);
+  // an arithmetic expression, and `+=' adds rather than string-appends.  The
+  // attribute lives on the target the assignment lands on, so resolve through a
+  // nameref (`declare -ai var; declare -n ref=var; ref[1]=' evaluates on var).
+  std::string dtgt = sh.deref(a.name);
+  size_t dlb = dtgt.find('[');
+  auto vit = sh.vars.find(dlb == std::string::npos ? dtgt : dtgt.substr(0, dlb));
   bool integer = vit != sh.vars.end() && vit->second.integer;
   if (a.sub) {
     // A compound value `(...)' cannot be assigned to a single element in bash

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -543,6 +543,15 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   // rejects the resolved target as an invalid identifier rather than creating a
   // variable literally named `a[0]'.
   if (a.sub) {
+    // A targetless nameref (`declare -n ref') resolves to the empty name, so
+    // `ref[0]=x' has nothing to subscript: bash rejects it as `': not a valid
+    // identifier' and leaves ref an unset reference.
+    auto nit = sh.vars.find(a.name);
+    if (nit != sh.vars.end() && nit->second.nameref && nit->second.value.empty()) {
+      std::fprintf(stderr, "%s`': not a valid identifier\n", sh.err_prefix().c_str());
+      sh.last_status = 1;
+      return;
+    }
     std::string dn = sh.deref(a.name);
     if (dn.find('[') != std::string::npos) {
       std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh.err_prefix().c_str(),

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1955,6 +1955,17 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       } else {
         target = sh.get(iname);
       }
+      // The indirection variable's value is the name to expand; if it is empty
+      // (INAME unset or set to the empty string) there is no name to reference,
+      // so bash reports `INAME: invalid indirect expansion' and aborts the
+      // command.  This fires even with a defaulting operator (`${!x-word}'): the
+      // operator applies to the INDIRECTED parameter, not to the missing name.
+      if (target.empty()) {
+        std::fprintf(stderr, "%s%s: invalid indirect expansion\n", sh.err_prefix().c_str(),
+                     iname.c_str());
+        sh.arith_error = true;
+        return std::string();
+      }
       if (length) return std::to_string(mb_charlen(expand_brace_body(ex, sh, target + b.substr(q), dq)));
       return expand_brace_body(ex, sh, target + b.substr(q), dq);
     }


### PR DESCRIPTION
Third cleanup pass over the `nameref` suite. Five independent fixes; scoreboard **117 → 100**, no regressions.

## Fixes (one commit each)

1. **Element assignment through a targetless nameref** — `declare -n ref; ref[0]=foo` now errors `` `': not a valid identifier `` and leaves ref an unset reference, instead of creating an `-an` hybrid array. (nameref12)
2. **`${!name}` with an empty target** — name unset or set to the empty string now errors `name: invalid indirect expansion` and aborts the command; previously `${!x-DEF}` re-parsed the operator text as `${-DEF}` and expanded the `$-` flags. (nameref3)
3. **`declare -n` naming an existing array is a no-op on the array** — the retarget is rejected ("cannot be an array") so the array is left untouched; a declared-but-empty array still prints `declare -a array`. (nameref22)
4. **Array-literal attributes through a nameref apply to the target** — `local -n ref=var; local -i ref=([1]=)` makes var an integer array (empty element → `0`) and leaves ref a plain `-n` reference; the element evaluation reads the integer attribute from the deref target. (nameref21)
5. **Newly adding `-n` strips integer/case attributes** — a nameref can't be integer, so `declare -i ivar; declare -n ivar=foo` prints `declare -n ivar="foo"`. Re-declaring an existing nameref keeps them (matches bash, and avoids disturbing the excluded nameref23 block). (nameref19)

## Verification

- `nameref` 117 → 100; nameref3/12/21/22 cleared or reduced to their deferred cases.
- No regressions: array/assoc/varenv/attr/builtins/arith/quotearray/exp/posixexp/func unchanged vs `main`.
- `ctest` 22/22; `run_diff.sh` all 238 scripts match bash.

## Deferred

nameref11 (exec-fd allocation, coproc line numbers); nameref14 (nameref env export); nameref15 (circular/self-reference-through-element); nameref20 (`-g`/function-local nameref-target scoping); the `declare +n -i` follows-target case (nameref19); and the user-excluded nameref23 `declare -in b=a[0]` / nameref1 `${!foo[0]}` cases.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)