### PR TITLE
nameref: coproc line number + self-reference-through-element (nameref 100→96)

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -991,8 +991,10 @@ struct Parser {
   }
 
   CommandPtr parse_coproc() {
+    int coproc_line = cur().line;  // $LINENO / error line of the coproc command
     advance();  // coproc
     auto n = std::make_unique<CoprocCommand>();
+    n->line = coproc_line;
     bool name_then_cmd =
         cur().type == Tok::Word && !cur().quoted && is_name(cur().text) &&
         (peek(1).type == Tok::Lparen ||

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1190,6 +1190,25 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   {
     std::string base, sub;
     if (nameref_elt(n_in, base, sub)) {
+      // A nameref whose OWN value names an element of itself (`local -n a=a[0];
+      // a=X') is circular; after the declaration's circular-reference warnings
+      // bash rejects the write as `a[0]: not a valid identifier' and assigns
+      // nothing.  Test the immediate value, not the resolved base: an indirect
+      // chain (`a->b; b=a[1]; a=foo') is handled elsewhere by removing a's
+      // nameref attribute, not by this error.
+      {
+        auto nv = vars.find(n_in);
+        if (nv != vars.end() && nv->second.nameref) {
+          const std::string &ov = nv->second.value;
+          size_t lb = ov.find('[');
+          if (lb != std::string::npos && lb > 0 && ov.back() == ']' &&
+              ov.compare(0, lb, n_in) == 0) {
+            std::fprintf(stderr, "%s`%s[%s]': not a valid identifier\n",
+                         err_prefix().c_str(), base.c_str(), sub.c_str());
+            return false;
+          }
+        }
+      }
       // A scalar assignment through a nameref to a whole-array splat
       // (`declare -n r=a[@]; r=5') has no single element to target: bash rejects
       // the `@'/`*' subscript as a bad array subscript and assigns nothing.


### PR DESCRIPTION
Fourth cleanup pass over the `nameref` suite. Two focused fixes; scoreboard **100 → 96**, no regressions.

## Fixes (one commit each)

1. **Record the line of a coproc command.** `CoprocCommand` never set its source line, so an error from the coproc's name/body was blamed on the previous command. `coproc ref { :; }` (ref resolving to an invalid identifier) was reported on line 49 instead of 51. Now captures the `coproc` keyword's line like the other compound commands. (nameref18 — byte-perfect)

2. **Writing through a nameref that references its own element is an error.** `local -n a=a[0]; a=X` now rejects the write as `` `a[0]': not a valid identifier `` (after the declaration's circular-reference warnings) instead of silently doing nothing. Tests the nameref's immediate value, so an indirect chain (`a->b; b=a[1]; a=foo`) is left to the attribute-removal path. (nameref15)

## Verification

- `nameref` 100 → 96; nameref18 byte-perfect.
- No regressions: array/assoc/varenv/attr/builtins/arith and coproc/dbg-support unchanged vs `main`.
- `ctest` 22/22; `run_diff.sh` all 238 scripts match bash.

## Deferred

nameref11 (exec-fd allocation, coproc-name invalid-target prefixes); nameref14 (nameref env export); nameref15 chain attribute-removal + unset-element cascade; nameref20 (`-g`/function-local nameref-target scoping); and the previously-excluded nameref23 / nameref1 cases.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)