### PR TITLE
fix(alias): conform alias expansion to bash via textual splicing

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -50,6 +50,8 @@ struct Token {
   Tok type = Tok::Eof;
   std::string text;             // for Word / IoNumber
   int line = 1;                 // 1-based source line where the token starts
+  std::size_t start = 0;        // byte offset of the token in the input
+  std::size_t end = 0;          // one past the token's last byte
   bool preceded_by_blank = true;  // whitespace separated this from the previous token
   bool quoted = false;          // word contained quoting
   bool glued = false;           // Lparen immediately followed by `(' (for `((')

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -42,7 +42,8 @@ ParseResult parse(const std::string &input);
 ParseResult parse_with_aliases(const std::string &input,
                                const std::map<std::string, std::string> &aliases,
                                const std::map<std::string, std::string> &global_aliases = {},
-                               const std::map<std::string, std::string> &suffix_aliases = {});
+                               const std::map<std::string, std::string> &suffix_aliases = {},
+                               bool posix_mode = false);
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -471,6 +471,16 @@ class Shell {
 
   // Parse and execute a script; returns the final exit status.
   int run_string(const std::string &script);
+  // Whether run_string's OWN parse of its input failed (nested runs -- eval,
+  // source, traps -- do not leak theirs).  A non-interactive line reader stops
+  // reading its input when set, as bash does after a top-level syntax error.
+  bool had_parse_error = false;
+  // Alias expansion applies: interactive or `shopt -s expand_aliases', and at
+  // least one alias table is non-empty.
+  bool aliases_active() const;
+  // bash valid_alias_name: no shell metacharacters, blanks, quoting
+  // characters, `$', or `/' anywhere in the name.
+  static bool valid_alias_name(const std::string &name);
   // Run a script buffer command-by-command (as bash reads scripts), so history
   // recording/expansion and mid-script alias definitions behave like bash.
   int run_script_lines(const std::string &text);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4254,7 +4254,16 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
         st = 1;
       }
     } else {
-      table[a.substr(0, eq)] = a.substr(eq + 1);
+      std::string name = a.substr(0, eq);
+      // bash refuses names containing metacharacters, blanks, quoting
+      // characters, `$', or `/' (valid_alias_name); zsh has no such check.
+      if (!sh.is_zsh() && !Shell::valid_alias_name(name)) {
+        std::fprintf(stderr, "%salias: `%s': invalid alias name\n", sh.err_prefix().c_str(),
+                     name.c_str());
+        st = 1;
+        continue;
+      }
+      table[name] = a.substr(eq + 1);
     }
   }
   return st;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1596,6 +1596,18 @@ int Executor::run_coproc(const CoprocCommand *c) {
   // The shell keeps the other ends open on high, close-on-exec descriptors and
   // publishes them as NAME[0] (read from the coproc) / NAME[1] (write to it),
   // with NAME_PID holding the child's pid.  NAME defaults to COPROC.
+  // The parser accepts any word as the name; validate it here as bash's
+  // execute_coproc does (`coproc @ { :; }' -> `@': not a valid identifier).
+  if (!c->name.empty()) {
+    bool ok = std::isalpha(static_cast<unsigned char>(c->name[0])) || c->name[0] == '_';
+    for (char ch : c->name)
+      if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) ok = false;
+    if (!ok) {
+      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
+                   c->name.c_str());
+      return (sh_.last_status = 1);
+    }
+  }
   const std::string name = c->name.empty() ? std::string("COPROC") : c->name;
   int out_pipe[2], in_pipe[2];  // out: coproc->shell;  in: shell->coproc
   if (pipe(out_pipe) < 0) {
@@ -2027,8 +2039,9 @@ static int first_body_line(const Command *c) {
 
 int Executor::run_funcdef(const FunctionDef *c) {
   // bash rejects a function name that contained an unquoted `$' expansion
-  // (W_HASDOLLAR) -- e.g. `function sys$read' -- as not a valid identifier.
-  if (c->name.find('$') != std::string::npos) {
+  // (W_HASDOLLAR) -- e.g. `function sys$read' -- or any quoting (`'a b c' ()')
+  // as not a valid identifier; the raw word, quotes included, is echoed.
+  if (c->name.find_first_of("$'\"\\") != std::string::npos) {
     std::fprintf(stderr, "%s`%s': not a valid identifier\n",
                  sh_.err_prefix().c_str(), c->name.c_str());
     return (sh_.last_status = 1);

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -590,6 +590,8 @@ struct Lexer {
         t.type = Tok::Newline;
         t.line = tline;
         t.preceded_by_blank = blanked;
+        t.start = pos;
+        t.end = pos + 1;
         out.push_back(t);
         pos++;
         if (!pending.empty()) collect_heredocs();
@@ -606,18 +608,24 @@ struct Lexer {
       if ((c == '<' || c == '>') && !(pos + 1 < n && in[pos + 1] == '(')) is_op = true;
 
       if (is_op) {
+        std::size_t tstart = pos;
         Token t = read_operator();
         t.line = tline;
         t.preceded_by_blank = blanked;
+        t.start = tstart;
+        t.end = pos;
         bool is_heredoc = (t.type == Tok::DLess || t.type == Tok::DLessDash);
         out.push_back(t);
         if (is_heredoc) awaiting = (t.type == Tok::DLessDash) ? 1 : 0;
         continue;
       }
 
+      std::size_t wstart = pos;
       Token t = read_word();
       t.line = tline;
       t.preceded_by_blank = blanked;
+      t.start = wstart;
+      t.end = pos;
       out.push_back(t);
       if (awaiting >= 0 && t.type == Tok::Word) {
         bool q = false;
@@ -632,6 +640,8 @@ struct Lexer {
     if (!pending.empty()) collect_heredocs();
     Token eof;
     eof.type = Tok::Eof;
+    eof.start = n;
+    eof.end = n;
     // bash parses input with a guaranteed trailing newline, so EOF falls on the
     // line after the last content -- add one when the input has no final newline.
     eof.line = line_for(n) + ((n > 0 && in[n - 1] != '\n') ? 1 : 0);

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -442,7 +442,9 @@ int main(int argc, char **argv) {
     }
     sh.init_job_control(false);
     read_startup_files(sh, startup_prefix, login, false, sopts);
-    sh.run_string(cmd);
+    // bash parses a -c string command-by-command (parse_and_execute), so an
+    // alias defined on one line is in effect for the lines after it.
+    sh.run_script_lines(cmd);
   } else if (!force_stdin && idx < args.size()) {
     // A directory named as a script: bash reports it with the script name as
     // the error prefix (not argv0) and exits 126.

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -486,8 +486,10 @@ struct Parser {
       return nullptr;
     }
 
-    // name () { ... }
-    if (cur().type == Tok::Word && !cur().quoted && is_funcname(cur().text) &&
+    // name () { ... } -- a QUOTED word is still parsed as a function
+    // definition (bash's grammar takes any WORD here); its invalid name is
+    // reported at execution, and the reader keeps going.
+    if (cur().type == Tok::Word && (cur().quoted || is_funcname(cur().text)) &&
         peek(1).type == Tok::Lparen && peek(2).type == Tok::Rparen)
       return parse_funcdef_paren();
 
@@ -995,8 +997,11 @@ struct Parser {
     advance();  // coproc
     auto n = std::make_unique<CoprocCommand>();
     n->line = coproc_line;
+    // Any word followed by a compound command is taken as the coproc NAME
+    // (bash's grammar: COPROC WORD shell_command); an invalid name is
+    // reported at execution, not as a syntax error (`coproc @ { :; }').
     bool name_then_cmd =
-        cur().type == Tok::Word && !cur().quoted && is_name(cur().text) &&
+        cur().type == Tok::Word && !cur().quoted &&
         (peek(1).type == Tok::Lparen ||
          (peek(1).type == Tok::Word && !peek(1).quoted && is_compound_kw(peek(1).text)));
     if (name_then_cmd) {
@@ -1197,116 +1202,251 @@ static bool is_assignment_word(const std::string &w) {
   return i < w.size() && w[i] == '=';
 }
 
-// Expand aliases in command position on a token stream (in place).  An
-// unquoted word in command position that names an alias is replaced by the
-// alias body's tokens; a body ending in blank makes the following word eligible
-// too, and a word is not re-expanded within its own expansion.
-static void expand_alias_tokens(std::vector<Token> &toks,
-                                const std::map<std::string, std::string> &aliases,
-                                const std::map<std::string, std::string> &global_aliases,
-                                const std::map<std::string, std::string> &suffix_aliases) {
-  if (aliases.empty() && global_aliases.empty() && suffix_aliases.empty()) return;
+// Alias expansion is a TEXTUAL substitution performed on the input before it
+// is parsed, mirroring bash's lexer-level push_string mechanics (parse.y
+// alias_expand_token / shell_getc END_ALIAS): the body is spliced into the
+// character stream in place of the alias word, so an unbalanced quote in a
+// body continues into the following text, a trailing backslash escapes the
+// next input character, and a `#' comments out the rest of the line.
+
+// bash returns one virtual space when the expansion is exhausted so the
+// following character cannot glue onto the body's last word (`alias
+// foo='echo 0'; foo>&2' must not become an fd-0 redirect) -- EXCEPT when the
+// body ends in a blank/newline/metacharacter, in an unquoted backslash, or
+// inside a quoted string or comment (parse.y shell_getc, END_ALIAS return).
+static bool alias_wants_sentinel(const std::string &body) {
+  if (body.empty()) return false;
+  char last = body.back();
+  static const std::string meta = "()<>;&| \t\n";
+  if (meta.find(last) != std::string::npos) return false;
+  bool ub = false;      // trailing run of backslashes has odd parity
+  char q = 0;           // open quote at end of body: ' or "
+  bool comment = false; // body ends inside a `#' comment
+  bool esc = false;     // next char is escaped (quote-state scan)
+  char prev = 0;
+  for (char c : body) {
+    ub = !ub && c == '\\';  // bash's unquoted_backslash: a bare parity toggle
+    if (comment) { if (c == '\n') comment = false; prev = c; continue; }
+    if (esc) { esc = false; prev = c; continue; }
+    if (q == '\'') { if (c == '\'') q = 0; prev = c; continue; }
+    if (q == '"') {
+      if (c == '\\') esc = true;
+      else if (c == '"') q = 0;
+      prev = c; continue;
+    }
+    if (c == '\\') { esc = true; prev = c; continue; }
+    if (c == '\'' || c == '"') { q = c; prev = c; continue; }
+    if (c == '#' && (prev == 0 || prev == ' ' || prev == '\t' || prev == '\n' ||
+                     meta.find(prev) != std::string::npos))
+      comment = true;
+    prev = c;
+  }
+  return !ub && q == 0 && !comment;
+}
+
+// The result of textual alias expansion: the expanded input plus a per-byte
+// map of the line each byte should REPORT.  Bytes spliced in from an alias
+// body all report the line of the invoking word (bash does not advance
+// $LINENO across an alias body); original bytes keep their physical line.
+struct AliasExpansion {
+  std::string text;
+  std::vector<int> linemap;
+  bool changed = false;
+};
+
+// One splice region: while a token starts inside the region, the alias NAME
+// that produced it stays "being expanded" there and cannot expand again
+// (bash's AL_BEINGEXPANDED).  A region whose alias value ended in a blank
+// makes the next word after it eligible for expansion (bash's PST_ALEXPNEXT
+// set on pop_string).
+struct AliasZone {
+  std::size_t start, end;
+  std::string name;
+  bool ends_blank;
+};
+
+static AliasExpansion alias_splice_text(const std::string &input,
+                                        const std::map<std::string, std::string> &aliases,
+                                        const std::map<std::string, std::string> &global_aliases,
+                                        const std::map<std::string, std::string> &suffix_aliases,
+                                        bool posix_mode) {
+  AliasExpansion ax;
+  ax.text = input;
+  ax.linemap.resize(input.size());
+  {
+    int ln = 1;
+    for (std::size_t b = 0; b < input.size(); b++) {
+      ax.linemap[b] = ln;
+      if (input[b] == '\n') ln++;
+    }
+  }
+  if (aliases.empty() && global_aliases.empty() && suffix_aliases.empty()) return ax;
+
   static const std::set<std::string> kw = {
       "if", "then", "else", "elif", "do", "done", "{", "}", "while", "until",
       "for", "case", "select", "fi", "esac", "!", "time", "function"};
-  bool cmd_pos = true, next_also = false;
-  // After `for'/`select'/`case' the next word is a variable name (or the value
-  // being matched), not a command word, so it must NOT be alias-expanded -- e.g.
-  // `for j in ...; do' with `alias j=...' must keep `j' literal, as bash does.
-  bool name_next = false;
-  std::set<std::string> active;
+
+  std::vector<AliasZone> zones;
+
+  // A word directly after a region whose alias value ended in a blank (only
+  // blanks between) is eligible for expansion even outside command position.
+  auto follows_blank_zone = [&](const Token &t) {
+    for (const AliasZone &z : zones) {
+      if (!z.ends_blank || z.end > t.start) continue;
+      bool blanks = true;
+      for (std::size_t b = z.end; b < t.start && blanks; b++)
+        blanks = ax.text[b] == ' ' || ax.text[b] == '\t';
+      if (blanks) return true;
+    }
+    return false;
+  };
+  auto zone_blocked = [&](const Token &t) {
+    for (const AliasZone &z : zones)
+      if (z.name == t.text && t.start >= z.start && t.start < z.end) return true;
+    return false;
+  };
+  // Replace [start,end) of the working text with an alias NAME's replacement
+  // string REP, keeping the line map and existing zones consistent.
+  auto splice = [&](std::size_t start, std::size_t end, const std::string &rep,
+                    const std::string &name, bool ends_blank) {
+    long delta = static_cast<long>(rep.size()) - static_cast<long>(end - start);
+    int inv_line = start < ax.linemap.size() ? ax.linemap[start]
+                   : (ax.linemap.empty() ? 1 : ax.linemap.back());
+    ax.text = ax.text.substr(0, start) + rep + ax.text.substr(end);
+    ax.linemap.erase(ax.linemap.begin() + static_cast<long>(start),
+                     ax.linemap.begin() + static_cast<long>(end));
+    ax.linemap.insert(ax.linemap.begin() + static_cast<long>(start), rep.size(), inv_line);
+    for (AliasZone &z : zones) {
+      if (z.end <= start) continue;
+      if (z.start >= end) { z.start += delta; z.end += delta; continue; }
+      z.end += delta;  // the zone encloses the replaced span
+    }
+    zones.push_back({start, start + rep.size(), name, ends_blank});
+    ax.changed = true;
+  };
+
+  bool progress = true;
   int guard = 0;
-  for (size_t i = 0; i < toks.size() && guard < 10000;) {
-    Tok ty = toks[i].type;
-    if (ty == Tok::Newline || ty == Tok::Semi || ty == Tok::Amp || ty == Tok::Pipe ||
-        ty == Tok::AndAnd || ty == Tok::OrOr || ty == Tok::Lparen || ty == Tok::SemiSemi ||
-        ty == Tok::PipeAnd || ty == Tok::SemiAnd || ty == Tok::SemiSemiAnd) {
-      cmd_pos = true; next_also = false; name_next = false; active.clear(); i++; continue;
-    }
-    // A leading redirection (with an optional fd number and its target word)
-    // belongs to the command prefix and does not end command position, so an
-    // alias in the command word after `< file cmd' still expands.
-    if (ty == Tok::IoNumber) { i++; continue; }
-    if (is_redir_op(ty)) {
-      i++;  // the operator
-      if (i < toks.size() && toks[i].type == Tok::Word) i++;  // its target word
-      continue;  // cmd_pos unchanged
-    }
-    if (ty != Tok::Word) { i++; continue; }
-    const std::string text = toks[i].text;
-    bool quoted = toks[i].quoted;
-    if (!quoted && kw.count(text)) {
-      cmd_pos = true; next_also = false;
-      name_next = (text == "for" || text == "select" || text == "case");
-      i++; continue;
-    }
-    // The variable name after for/select/case: never an alias, and it is not a
-    // command word, so what follows it (the `in'/`do'/list) is not either.
-    if (name_next) { name_next = false; cmd_pos = false; i++; continue; }
-    // zsh global aliases (`alias -g') expand in ANY word position.
-    if (!quoted && global_aliases.count(text) && !active.count(text)) {
-      active.insert(text);
-      guard++;
-      std::vector<Token> rep = tokenize(global_aliases.at(text));
-      if (!rep.empty() && rep.back().type == Tok::Eof) rep.pop_back();
-      toks.erase(toks.begin() + static_cast<long>(i));
-      toks.insert(toks.begin() + static_cast<long>(i), rep.begin(), rep.end());
-      continue;  // reprocess from i: the body may contain operators (| > ...)
-    }
-    // zsh suffix aliases (`alias -s ext=cmd'): a bare `file.ext' in command
-    // position, whose `ext' has a suffix alias and which is not itself an alias,
-    // runs `cmd file.ext'.
-    if ((cmd_pos || next_also) && !quoted && !suffix_aliases.empty() && !aliases.count(text)) {
-      size_t dot = text.rfind('.');
-      if (dot != std::string::npos && dot + 1 < text.size()) {
-        auto sit = suffix_aliases.find(text.substr(dot + 1));
-        if (sit != suffix_aliases.end()) {
-          guard++;
-          std::vector<Token> cmd = tokenize(sit->second);
-          if (!cmd.empty() && cmd.back().type == Tok::Eof) cmd.pop_back();
-          toks.insert(toks.begin() + static_cast<long>(i), cmd.begin(), cmd.end());
-          continue;  // reprocess from i: the inserted command is now cmd_pos
+  while (progress && guard++ < 1000) {
+    progress = false;
+    std::vector<Token> toks = tokenize(ax.text);
+
+    bool cmd_pos = true;
+    // After `for'/`select' the next word is a variable name, not a command
+    // word, so it must NOT be alias-expanded (`for j in ...' with `alias
+    // j=...' keeps `j' literal, as bash does).
+    bool name_next = false;
+    // Nested `case' contexts: 0 = expecting the subject word, 1 = expecting
+    // `in', 2 = in pattern position (no expansion -- patterns are not command
+    // words), 3 = in a clause body.
+    std::vector<int> case_state;
+
+    for (std::size_t i = 0; i < toks.size() && !progress; i++) {
+      const Token &t = toks[i];
+      Tok ty = t.type;
+      if (ty == Tok::SemiSemi || ty == Tok::SemiAnd || ty == Tok::SemiSemiAnd) {
+        if (!case_state.empty()) case_state.back() = 2;
+        cmd_pos = true; name_next = false;
+        continue;
+      }
+      if (ty == Tok::Rparen) {
+        if (!case_state.empty() && case_state.back() == 2) {
+          case_state.back() = 3;
+          cmd_pos = true; name_next = false;
+        }
+        continue;
+      }
+      if (ty == Tok::Newline || ty == Tok::Semi || ty == Tok::Amp || ty == Tok::Pipe ||
+          ty == Tok::AndAnd || ty == Tok::OrOr || ty == Tok::Lparen || ty == Tok::PipeAnd) {
+        // Inside case pattern position a newline does not start a command.
+        if (case_state.empty() || case_state.back() != 2) { cmd_pos = true; name_next = false; }
+        continue;
+      }
+      if (ty == Tok::IoNumber) continue;
+      if (is_redir_op(ty)) {
+        // The operator's target word: not a command word (skip it below), but
+        // still eligible when it directly follows a blank-ending expansion
+        // (bash checks PST_ALEXPNEXT for every token read) -- `alias c='< ';
+        // ... c file' expands a `file' alias.  A leading redirection does not
+        // end command position.
+        if (i + 1 < toks.size() && toks[i + 1].type == Tok::Word) {
+          const Token &w = toks[i + 1];
+          if (!w.quoted && follows_blank_zone(w) && aliases.count(w.text) && !zone_blocked(w)) {
+            const std::string &val = aliases.at(w.text);
+            bool ends_blank = !val.empty() && (val.back() == ' ' || val.back() == '\t');
+            splice(w.start, w.end, val + (alias_wants_sentinel(val) ? " " : ""), w.text, ends_blank);
+            progress = true;
+            continue;
+          }
+          i++;  // skip the target word
+        }
+        continue;  // cmd_pos unchanged
+      }
+      if (ty != Tok::Word) continue;
+
+      // case machinery: subject and patterns are never expanded.
+      if (!case_state.empty() && case_state.back() == 0) { case_state.back() = 1; continue; }
+      if (!case_state.empty() && case_state.back() == 1) {
+        if (!t.quoted && t.text == "in") case_state.back() = 2;
+        continue;
+      }
+      if (!case_state.empty() && case_state.back() == 2) {
+        if (!t.quoted && t.text == "esac") { case_state.pop_back(); cmd_pos = false; }
+        continue;
+      }
+
+      if (name_next) { name_next = false; cmd_pos = false; continue; }
+
+      bool eligible = !t.quoted && (cmd_pos || follows_blank_zone(t));
+
+      // Posix.2 does not allow reserved words to be aliased: recognize them
+      // before attempting alias expansion.  In default mode the alias check
+      // comes first, so an eligible aliased reserved word expands (bash
+      // parse.y read_token order).
+      bool is_kw = !t.quoted && kw.count(t.text) && cmd_pos;
+      if (!(posix_mode && is_kw) && eligible && aliases.count(t.text) && !zone_blocked(t)) {
+        const std::string &val = aliases.at(t.text);
+        bool ends_blank = !val.empty() && (val.back() == ' ' || val.back() == '\t');
+        splice(t.start, t.end, val + (alias_wants_sentinel(val) ? " " : ""), t.text, ends_blank);
+        progress = true;
+        continue;
+      }
+      // zsh global aliases (`alias -g') expand in ANY word position.
+      if (!t.quoted && global_aliases.count(t.text) && !zone_blocked(t)) {
+        const std::string &val = global_aliases.at(t.text);
+        splice(t.start, t.end, val, t.text, false);
+        progress = true;
+        continue;
+      }
+      // zsh suffix aliases (`alias -s ext=cmd'): a bare `file.ext' in command
+      // position, whose `ext' has a suffix alias and which is not itself an
+      // alias, runs `cmd file.ext' (the inserted command word takes over
+      // command position, so this does not re-fire).
+      if (eligible && !suffix_aliases.empty() && !aliases.count(t.text)) {
+        std::size_t dot = t.text.rfind('.');
+        if (dot != std::string::npos && dot + 1 < t.text.size()) {
+          auto sit = suffix_aliases.find(t.text.substr(dot + 1));
+          if (sit != suffix_aliases.end()) {
+            splice(t.start, t.start, sit->second + " ", t.text, false);
+            progress = true;
+            continue;
+          }
         }
       }
-    }
-    if ((cmd_pos || next_also) && !quoted && aliases.count(text) && !active.count(text)) {
-      const std::string &val = aliases.at(text);
-      active.insert(text);
-      // Alias expansion is a textual substitution: the replacement tokens all
-      // report the line where the alias was invoked, even when the body itself
-      // contains newlines (bash does not advance $LINENO across an alias body).
-      int inv_line = toks[i].line;
-      bool trailing = !val.empty() && (val.back() == ' ' || val.back() == '\t');
-      std::vector<Token> rep = tokenize(val);
-      if (!rep.empty() && rep.back().type == Tok::Eof) rep.pop_back();
-      for (Token &t : rep) t.line = inv_line;
-      toks.erase(toks.begin() + static_cast<long>(i));
-      toks.insert(toks.begin() + static_cast<long>(i), rep.begin(), rep.end());
-      guard++;
-      // If the body ends in a blank, the word that followed the alias is also
-      // eligible for expansion (bash chains this while each body ends blank).
-      size_t np = i + rep.size();
-      while (trailing && np < toks.size() && toks[np].type == Tok::Word && !toks[np].quoted &&
-             aliases.count(toks[np].text) && !active.count(toks[np].text) && guard < 10000) {
-        const std::string &v2 = aliases.at(toks[np].text);
-        active.insert(toks[np].text);
-        trailing = !v2.empty() && (v2.back() == ' ' || v2.back() == '\t');
-        int np_line = toks[np].line;
-        std::vector<Token> r2 = tokenize(v2);
-        if (!r2.empty() && r2.back().type == Tok::Eof) r2.pop_back();
-        for (Token &t : r2) t.line = np_line;
-        toks.erase(toks.begin() + static_cast<long>(np));
-        toks.insert(toks.begin() + static_cast<long>(np), r2.begin(), r2.end());
-        guard++;
-        np += r2.size();
+
+      if (is_kw) {
+        cmd_pos = true;
+        name_next = (t.text == "for" || t.text == "select");
+        if (t.text == "case") case_state.push_back(0);
+        else if (t.text == "esac" && !case_state.empty()) { case_state.pop_back(); cmd_pos = false; }
+        continue;
       }
-      next_also = false;
-      continue;  // reprocess from i (its command word may itself be an alias)
+      // A prefix assignment keeps command position for the following word.
+      if (cmd_pos && !t.quoted && is_assignment_word(t.text)) continue;
+      cmd_pos = false;
     }
-    // A prefix assignment keeps command position for the following command word.
-    if (cmd_pos && !quoted && is_assignment_word(text)) { i++; continue; }
-    cmd_pos = false; next_also = false; i++;
   }
+  return ax;
 }
 
 ParseResult parse(const std::string &input) {
@@ -1317,9 +1457,21 @@ ParseResult parse(const std::string &input) {
 ParseResult parse_with_aliases(const std::string &input,
                                const std::map<std::string, std::string> &aliases,
                                const std::map<std::string, std::string> &global_aliases,
-                               const std::map<std::string, std::string> &suffix_aliases) {
-  std::vector<Token> toks = tokenize(input);
-  expand_alias_tokens(toks, aliases, global_aliases, suffix_aliases);
+                               const std::map<std::string, std::string> &suffix_aliases,
+                               bool posix_mode) {
+  AliasExpansion ax =
+      alias_splice_text(input, aliases, global_aliases, suffix_aliases, posix_mode);
+  std::vector<Token> toks = tokenize(ax.text);
+  if (ax.changed) {
+    // Tokens report the line of the byte they start at: original bytes keep
+    // their physical line, spliced bytes the invoking word's line.  The Eof
+    // token falls on the line after the last content (bash parses input with
+    // a trailing newline).
+    for (Token &t : toks) {
+      if (t.start < ax.linemap.size()) t.line = ax.linemap[t.start];
+      else if (!ax.linemap.empty()) t.line = ax.linemap.back() + 1;
+    }
+  }
   Parser p(std::move(toks));
   return p.run();
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -716,6 +716,16 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   // discarded (and does not fail).  Only in the bash family -- zsh has no such
   // dynamic variables, so an assignment there is ordinary.
   if ((n == "GROUPS" || n == "FUNCNAME") && !is_zsh()) return;
+  // BASH_ALIASES is the live alias table: BASH_ALIASES[name]=value defines an
+  // alias, after the same name validation the alias builtin performs.
+  if (n == "BASH_ALIASES" && !is_zsh()) {
+    if (!valid_alias_name(sub)) {
+      std::fprintf(stderr, "%s`%s': invalid alias name\n", err_prefix().c_str(), sub.c_str());
+      return;
+    }
+    aliases[sub] = val;
+    return;
+  }
   // BASH_CMDS is the live command hash: BASH_CMDS[name]=value adds a hash
   // entry.  A `/' value is rejected in a restricted shell; a value without a
   // `/' is resolved through $PATH (and must be found) before it is stored.
@@ -1831,7 +1841,14 @@ int Shell::run_script_lines(const std::string &text) {
     cont_bslash = false;
 
     if (pos < text.size()) {
-      ParseResult chk = parse(pending);
+      // Completeness must be judged on the alias-expanded text: an alias can
+      // open a construct the raw line doesn't show (`alias al=' '; al for x
+      // in v' needs the do/done lines) or carry an open quote into the
+      // following text.
+      ParseResult chk =
+          aliases_active()
+              ? parse_with_aliases(pending, aliases, global_aliases, suffix_aliases, opt_posix)
+              : parse(pending);
       bool was_heredoc = in_heredoc;
       in_heredoc = chk.heredoc_eof;
       in_heredoc_quoted = chk.heredoc_eof_quoted;
@@ -1842,20 +1859,37 @@ int Shell::run_script_lines(const std::string &text) {
       in_heredoc = false;
     }
     flush();
+    // A non-interactive shell stops reading input after a syntax error (bash
+    // exits with status 2; the -c and script readers both abort here).
+    if (had_parse_error && !interactive) return st;
   }
   if (!exiting) flush();  // whatever remains (an incomplete tail still errors)
   return st;
 }
 
-int Shell::run_string(const std::string &script) {
-  if (is_csh()) return run_csh(*this, script);  // csh is a different language
-  // Aliases are expanded only when interactive or `shopt -s expand_aliases'.
-  bool expand_al = interactive;
+bool Shell::valid_alias_name(const std::string &name) {
+  if (name.empty()) return false;
+  for (char c : name)
+    if (std::strchr(" \t\n;|&()<>'\"`\\$/", static_cast<unsigned char>(c))) return false;
+  return true;
+}
+
+bool Shell::aliases_active() const {
+  // Aliases are expanded only when interactive or `shopt -s expand_aliases';
+  // posix mode enables alias expansion even in non-interactive shells.
+  bool expand_al = interactive || opt_posix;
   auto eit = shopt_opts.find("expand_aliases");
   if (eit != shopt_opts.end() && eit->second) expand_al = true;
-  bool have_aliases = !aliases.empty() || !global_aliases.empty() || !suffix_aliases.empty();
-  ParseResult r = (expand_al && have_aliases)
-                      ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases)
+  return expand_al &&
+         (!aliases.empty() || !global_aliases.empty() || !suffix_aliases.empty());
+}
+
+int Shell::run_string(const std::string &script) {
+  if (is_csh()) return run_csh(*this, script);  // csh is a different language
+  had_parse_error = false;
+  ParseResult r = aliases_active()
+                      ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases,
+                                           opt_posix)
                       : parse(script);
   if (!r.ok) {
     // bash's format: `NAME: [CONTEXT: ][-c: ]line N: syntax error...' per
@@ -1895,7 +1929,8 @@ int Shell::run_string(const std::string &script) {
       }
     }
     // A compound-assignment syntax error (`a=(x & y)') is reported by bash with
-    // status 1, not the usual 2.
+    // status 1, not the usual 2 -- and does not stop a non-interactive reader.
+    had_parse_error = !r.assign_error;
     last_status = r.assign_error ? 1 : 2;
     return last_status;
   }
@@ -1917,6 +1952,11 @@ int Shell::run_string(const std::string &script) {
   last_status = st;
   run_pending_traps();  // deliver signals received during the final command
   last_status = st;
+  // had_parse_error reports THIS string's parse only: a syntax error inside a
+  // nested run (eval, source, a trap body) does not abort the caller's reader
+  // -- bash keeps going after `eval "do"' but stops its own input after a
+  // top-level syntax error.
+  had_parse_error = false;
   return st;
 }
 


### PR DESCRIPTION
Fixes #400.

**What:** rewrites alias expansion from token-level replacement to the textual splice bash's lexer performs (parse.y `alias_expand_token` / `push_string` / the `shell_getc` end-of-alias space), and integrates it with the line readers. `alias.tests` goes from 96 scoreboard diff lines to **byte-perfect 0**.

**The engine** (`core/src/parser.cpp` `alias_splice_text`, on new lexer token byte offsets): the alias body is spliced into the input text at the invoking word, so an unbalanced quote in a body continues into the following text (`alias foo="echo 'Error:"` + `foo bar'` → `Error: bar`), a trailing unquoted backslash escapes the next input character (`a|cat` → `<|cat>`), and a `#` body comments out the rest of the line. Splice regions model `AL_BEINGEXPANDED` (no self-recursion inside one's own expansion) and `PST_ALEXPNEXT` (a value ending in a blank makes the next word eligible, chained and re-checked per replacement — `foo bar` with `foo='echo '`, `bar=baz`, `baz=quux` prints `quux`). A virtual space closes an expansion under bash's exact `shell_getc` END_ALIAS conditions. Case patterns and for/select variables are never expanded; in default mode the alias check precedes reserved-word recognition, in posix mode reserved words win (verified against bash 5.3.15). A per-byte line map keeps `$LINENO` and error lines on the invoking word.

**Integration:**
- `run_script_lines` judges command completeness on the alias-expanded text, and a non-interactive reader stops after a top-level syntax error as bash does (status 2) — excluding compound-assignment errors (status 1, reader continues) and errors inside eval/source/trap bodies.
- `-c` strings run through the incremental reader, so an alias defined on one line is visible on the next.
- Posix mode enables alias expansion non-interactively.
- A quoted function name (`'a b c' ()`) and a non-identifier coproc name (`coproc @ { :; }`) now parse and are rejected at execution, matching bash's grammar/execute split.
- Alias names are validated (`valid_alias_name`) in the `alias` builtin and `BASH_ALIASES[...]` assignment — which now actually defines an alias instead of writing a shadow variable.

**Verification:**
- Full bash-testsuite sweep vs bash 5.3.15 — changed files only, all improved, zero regressions:
  alias 96→**0**, heredoc 95→57, comsub 35→22, comsub2 27→23, comsub-eof 22→21, test 125→113, func 39→35, nameref 95→88.
- `ctest --test-dir build`: 22/22.
- `tests/harness/run_diff.sh`: all 240 scripts match bash.
