### PR TITLE
fix(redir): keep redirect backups out of the user-reachable fd range

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -74,7 +74,12 @@ int heredoc_fd(const std::string &body) {
 }
 
 void save_fd(int fd, std::vector<SavedFd> &saved) {
-  int s = fcntl(fd, F_DUPFD_CLOEXEC, 10);
+  // Backups live well above the fd-10+ region users reach with `exec 10>&1'
+  // and the {var} allocations: a user redirect landing on a backup slot would
+  // clobber it (`{ exec 10>&1; } > file' must still restore stdout -- the
+  // backup used to sit at fd 10 and the inner exec overwrote it, leaving
+  // stdout pointing at the file forever).
+  int s = fcntl(fd, F_DUPFD_CLOEXEC, 100);
   saved.push_back({fd, s});
 }
 


### PR DESCRIPTION
Fixes #408.

One-line core fix plus comment: backup slots move from F_DUPFD(fd,10) to F_DUPFD(fd,100), out of the range `exec 10>&1`-style redirects can clobber. Full failure analysis in the issue (stdout permanently re-pointed at the block's file; self-copying cat; 1.6GB runaway).

**Verification:** redir 77 → **25** (126 at day start); vredir 0 (unchanged); ctest 22/22; run_diff 240/240; the reproducer completes instantly with bash-identical output.