### PR TITLE
fix(builtins): umask who-copy perms, posix source resolution, command shield

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -461,8 +461,14 @@ class Shell {
   // status merely propagated from a command the builtin ran (`eval false'), and
   // bash exempts a few error kinds (`trap' bad signal, `shift', `break'/
   // `continue'), whose paths deliberately do not call it.
+  // Set while a builtin runs via `command NAME', which strips the POSIX
+  // special-builtin exit-on-error property (`command . nofile' continues).
+  bool posix_builtin_shield = false;
   void posix_special_builtin_error(int status = 1) {
-    if (opt_posix && !interactive) { exiting = true; exit_status = status; }
+    if (opt_posix && !interactive && !posix_builtin_shield) {
+      exiting = true;
+      exit_status = status;
+    }
   }
 
   // --- helpers -----------------------------------------------------------

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3122,10 +3122,17 @@ static bool umask_symbolic(const std::string &s, mode_t &allowed, char &errch, b
       i++;
       if (op != '+' && op != '-' && op != '=') { errch = op; erropr = true; return false; }
       int perms = 0;
-      while (i < s.size() && std::strchr("rwxXst", s[i])) {
+      while (i < s.size() && std::strchr("rwxXstugo", s[i])) {
         if (s[i] == 'r') perms |= 0444;
         else if (s[i] == 'w') perms |= 0222;
         else if (s[i] == 'x' || s[i] == 'X') perms |= 0111;
+        else if (s[i] == 'u' || s[i] == 'g' || s[i] == 'o') {
+          // A who letter as a permission copies that class's CURRENT allowed
+          // bits (`umask g+u' grants group what user has, `o=u' mirrors it).
+          int shift = s[i] == 'u' ? 6 : s[i] == 'g' ? 3 : 0;
+          int b = (allowed >> shift) & 7;
+          perms |= (b << 6) | (b << 3) | b;
+        }
         // s/t (setuid/sticky) live outside the 0777 umask -- consume, ignore.
         i++;
       }
@@ -5438,6 +5445,18 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         st = 1;
         giveup = true;
         sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
+      }
+    } else if (sh.opt_posix) {
+      // POSIX `.'/source: search $PATH only -- NO current-directory fallback
+      // even when the file exists there.  A miss is `.: NAME: file not found'
+      // and (unshielded) fatal for a non-interactive posix shell.
+      const char *penv = std::getenv("PATH");
+      if (!search(penv ? penv : "")) {
+        std::fprintf(stderr, "%s%s: %s: file not found\n", sh.err_prefix().c_str(),
+                     cmd.c_str(), fname.c_str());
+        st = 1;
+        giveup = true;
+        sh.posix_special_builtin_error(st);
       }
     } else if (sh.shopt_opts["sourcepath"] && access(fname.c_str(), R_OK) != 0) {
       const char *penv = std::getenv("PATH");

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1482,7 +1482,14 @@ int Executor::run_simple(const SimpleCommand *c) {
     // In posix mode, assignments preceding a function call persist.
     if (sh_.opt_posix) restore.clear();
     undo_temp();
-  } else if ((apply_temp(), run_builtin(sh_, argv, &status))) {
+  } else if ((apply_temp(), [&] {
+               // `command' strips the POSIX special-builtin exit property: a
+               // failing `command . nofile' does not end a posix-mode shell.
+               sh_.posix_builtin_shield = skip_functions;
+               bool b = run_builtin(sh_, argv, &status);
+               sh_.posix_builtin_shield = false;
+               return b;
+             }())) {
     // A preceding `VAR=val builtin' applies to the builtin (e.g. IFS=, read),
     // then is restored.  It keeps effect permanently when the builtin makes the
     // variable readonly or exported: `export'/`readonly' always do, `declare'/


### PR DESCRIPTION
Fixes #410.

See issue for details; all three behaviors verified against bash 5.3.15 (probe matrix for default/posix x command/bare source-not-found included in the session).

**Verification:** builtins 106 → **87**; posix2 stays 0; ctest 22/22; run_diff 240/240.