### PR TITLE
fix(expand): posix-mode ${} quoting, \} unescaping, substitute-word splitting

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -76,7 +76,7 @@ const char *tok_name(Tok t);
 // Tokenize INPUT.  Always ends with a single Tok::Eof token.  Unterminated
 // quotes/spans are tolerated (consumed to end of input); the parser decides
 // whether the result is a syntax error.
-std::vector<Token> tokenize(const std::string &input);
+std::vector<Token> tokenize(const std::string &input, bool posix_mode = false);
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -34,7 +34,7 @@ struct ParseResult {
 };
 
 // Parse a complete program.
-ParseResult parse(const std::string &input);
+ParseResult parse(const std::string &input, bool posix_mode = false);
 
 // Parse with alias expansion applied first: regular aliases in command position,
 // zsh global aliases (`alias -g') anywhere, and zsh suffix aliases (`alias -s').

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -53,7 +53,7 @@ bool pat_match(const std::string &pattern, const std::string &text) {
 // -- only a `${` does -- matching bash's parse_matched_pair P_FIRSTCLOSE rule,
 // so `${IFS+a{b}` closes at the `}` after `b`.
 size_t scan_balanced(const std::string &t, size_t i, char open, char close,
-                     bool firstclose = false) {
+                     bool firstclose = false, bool squote_literal = false) {
   int depth = 0;
   bool wasdol = false;  // previous char was an unquoted `$` (LEX_WASDOL)
   // When scanning a `$( ... )' command substitution, a `)' that terminates a
@@ -91,7 +91,12 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
       wasdol = false;
       continue;
     }
-    if (c == '\'') { contaminate(); while (++i < t.size() && t[i] != '\'') {} wasdol = false; continue; }
+    if (c == '\'') {
+      // POSIX mode, inside a double-quoted ${...}: a single quote is an
+      // ordinary character (`"${IFS+'}'z}"` closes at the first `}`).
+      if (squote_literal) { wasdol = false; continue; }
+      contaminate(); while (++i < t.size() && t[i] != '\'') {} wasdol = false; continue;
+    }
     if (c == '"') {
       contaminate();
       while (++i < t.size() && t[i] != '"')
@@ -985,7 +990,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   }
   // ${...}
   if (n1 == '{') {
-    size_t end = scan_balanced(t, i + 1, '{', '}', /*firstclose=*/true);
+    size_t end = scan_balanced(t, i + 1, '{', '}', /*firstclose=*/true,
+                               /*squote_literal=*/dq && sh_.opt_posix);
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
 
@@ -1090,7 +1096,14 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
                 // Unquoted default word: a leading `~' tilde-expands (bash).
                 // In a here-document the word keeps here-document quoting
                 // (e.g. $'...' stays literal), so pass the flag through.
+                size_t m0 = mask.size();
                 process(expand_leading_tilde(sh_, word), out, mask, false, heredoc);
+                // The replacement is EXPANSION OUTPUT: its unquoted literal
+                // text IFS-splits like a parameter's value (`${IFS+foo 'b c'
+                // baz}' is three fields, the middle protected by its quotes).
+                if (!heredoc)
+                  for (size_t mk = m0; mk < mask.size(); mk++)
+                    if (mask[mk] == '2') mask[mk] = '0';
               }
               i = end + 1;
               return;
@@ -2427,7 +2440,13 @@ std::string Expander::expand_dq_word(const std::string &w_in) {
   // literal.
   std::string w;
   for (size_t k = 0; k < w_in.size(); k++) {
-    if (w_in[k] == '\\' && k + 1 < w_in.size()) { w += w_in[k]; w += w_in[k + 1]; k++; continue; }
+    if (w_in[k] == '\\' && k + 1 < w_in.size()) {
+      // `\}' escaped the ${...} closer at scan time: the word keeps a literal
+      // `}' and the backslash is consumed (`"${IFS+\}z}"' -> `}z'), unlike
+      // the ordinary double-quote escapes which process() handles below.
+      if (w_in[k + 1] == '}') { w += '}'; k++; continue; }
+      w += w_in[k]; w += w_in[k + 1]; k++; continue;
+    }
     if (w_in[k] == '$' && k + 1 < w_in.size() && w_in[k + 1] == '\'') {
       size_t j = k + 2;
       while (j < w_in.size() && w_in[j] != '\'') { if (w_in[j] == '\\' && j + 1 < w_in.size()) j++; j++; }
@@ -2873,6 +2892,12 @@ void Expander::expand_word_fields(const std::string &w) {
   splitting_ = true;  // nested $*/$@ -> separate fields, with proper masks
   process(src, o, m, false);
   splitting_ = saved;
+  // The whole replacement is EXPANSION OUTPUT: its unquoted literal text
+  // IFS-splits like a parameter's value (`${IFS+foo 'b c' baz}' is three
+  // fields), so remap literal '2' to splittable '0'; quoted '1' stays
+  // protected.
+  for (char &mc : m)
+    if (mc == '2') mc = '0';
   op_out_ = std::move(o);
   op_mask_ = std::move(m);
   op_fields_ = true;  // consumed (and cleared) by the ${...} splice in expand_dollar
@@ -2898,7 +2923,12 @@ static bool has_unquoted_splat(const std::string &w) {
 }
 
 std::string Expander::expand_op_word(const std::string &w, bool dq, bool top_level) {
-  if (top_level && splitting_ && !dq && !sh_.is_zsh() && has_unquoted_splat(w)) {
+  // An UNQUOTED substitute word is expanded and field-split like any other
+  // expansion output, with the word's own quotes protecting their content:
+  // `${IFS+foo 'b c' baz}' is three fields, the middle one `b c' (bash).
+  if (top_level && splitting_ && !dq && !sh_.is_zsh() &&
+      (has_unquoted_splat(w) ||
+       w.find_first_of(" \t\n") != std::string::npos)) {
     expand_word_fields(w);
     return std::string();  // real content is in op_out_/op_mask_ (op_fields_ set)
   }

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -101,6 +101,7 @@ struct Lexer {
     return skip_subscript(in, start);
   }
 
+  bool posix = false;  // posix-mode lexing (quote rules inside "${...}")
   explicit Lexer(const std::string &s) : in(s), n(s.size()) {}
 
   char cur() const { return in[pos]; }
@@ -225,7 +226,7 @@ struct Lexer {
     } while (pos < n && depth > 0);
     if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = ')'; }
   }
-  void scan_brace(std::string &w) {  // pos at '{'
+  void scan_brace(std::string &w, bool in_dq = false) {  // pos at '{'
     int depth = 0;
     // Inside ${...} only a nested `${` opens another level; a bare `{` is a
     // literal character.  This mirrors bash's parse_matched_pair called with
@@ -262,7 +263,11 @@ struct Lexer {
         scan_paren(w);
         wasdol = false;
       } else if (c == '\'') {
-        scan_single(w);
+        // POSIX mode: inside a DOUBLE-QUOTED ${...} a single quote is an
+        // ordinary character, not a quote (`"${IFS+'}'z}"` ends at the first
+        // `}`), matching bash's parse_matched_pair posix handling.
+        if (posix && in_dq) { w += c; pos++; }
+        else scan_single(w);
         wasdol = false;
       } else if (c == '"') {
         scan_double(w);
@@ -329,7 +334,7 @@ struct Lexer {
       } else if (c == '$' && pos + 1 < n && in[pos + 1] == '{') {
         w += '$';
         pos++;
-        scan_brace(w);
+        scan_brace(w, /*in_dq=*/true);
       } else {
         w += c;
         pos++;
@@ -657,8 +662,9 @@ struct Lexer {
 
 }  // namespace
 
-std::vector<Token> tokenize(const std::string &input) {
+std::vector<Token> tokenize(const std::string &input, bool posix_mode) {
   Lexer lx(input);
+  lx.posix = posix_mode;
   lx.run();
   return std::move(lx.out);
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1452,8 +1452,8 @@ static AliasExpansion alias_splice_text(const std::string &input,
   return ax;
 }
 
-ParseResult parse(const std::string &input) {
-  Parser p(tokenize(input));
+ParseResult parse(const std::string &input, bool posix_mode) {
+  Parser p(tokenize(input, posix_mode));
   return p.run();
 }
 
@@ -1464,7 +1464,7 @@ ParseResult parse_with_aliases(const std::string &input,
                                bool posix_mode) {
   AliasExpansion ax =
       alias_splice_text(input, aliases, global_aliases, suffix_aliases, posix_mode);
-  std::vector<Token> toks = tokenize(ax.text);
+  std::vector<Token> toks = tokenize(ax.text, posix_mode);
   if (ax.changed) {
     // Tokens report the line of the byte they start at: original bytes keep
     // their physical line, spliced bytes the invoking word's line.  The Eof

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1848,7 +1848,7 @@ int Shell::run_script_lines(const std::string &text) {
       ParseResult chk =
           aliases_active()
               ? parse_with_aliases(pending, aliases, global_aliases, suffix_aliases, opt_posix)
-              : parse(pending);
+              : parse(pending, opt_posix);
       bool was_heredoc = in_heredoc;
       in_heredoc = chk.heredoc_eof;
       in_heredoc_quoted = chk.heredoc_eof_quoted;
@@ -1890,7 +1890,7 @@ int Shell::run_string(const std::string &script) {
   ParseResult r = aliases_active()
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases,
                                            opt_posix)
-                      : parse(script);
+                      : parse(script, opt_posix);
   if (!r.ok) {
     // bash's format: `NAME: [CONTEXT: ][-c: ]line N: syntax error...' per
     // message line; "near unexpected token" joins without a colon, and the


### PR DESCRIPTION
Fixes #412.

posixexp2.tests 41 diff lines → **0 (byte-perfect)**. Four gaps, detailed in the issue: posix-aware lexing of single quotes inside double-quoted \${} (threaded through parse()/parse_with_aliases from opt_posix — previously a mis-scan aborted whole posix scripts on a phantom unterminated quote), the matching expander scan rule, backslash-brace unescaping in double-quoted \${} words, and IFS-splitting of unquoted substitute words with quote protection.

**Verification:** full-suite sweep vs yesterday shows only improvements — posixexp2 41→0, quote 15→7, posixexp 43→42 as bonuses; 47 of 83 files now byte-perfect; ctest 22/22; run_diff 240/240.