### PR TITLE
fix(arith,builtins): quotearray remainder — display escapes, target validation

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -69,6 +69,7 @@ constexpr const char *kRecursion = "expression recursion level exceeded";
 constexpr const char *kBadOp = "arithmetic syntax error: invalid arithmetic operator";
 }  // namespace arith_err
 
+
 NodeP mk(K k) { auto n = std::make_unique<Node>(); n->k = k; return n; }
 
 // Digit value of C in the given BASE for bash's `base#digits' notation, or -1 if
@@ -186,6 +187,9 @@ struct Parser {
     last_tok = start;
     n.src = start;
     skip();
+    // A \x04 display-escape before `[' still opens a subscript (expansion
+    // output at expression level arrives escaped: `a\x04[\x04$k\x04]').
+    if (pos + 1 < s.size() && s[pos] == '\x04' && s[pos + 1] == '[') pos++;
     if (pos < s.size() && s[pos] == '[') {
       pos++;
       int bdepth = 1;
@@ -194,16 +198,30 @@ struct Parser {
       // balance, so `assoc['$k']' and `a[$(cmd)]' span correctly.
       while (pos < s.size() && bdepth > 0) {
         char c2 = s[pos];
+        if (c2 == '\x04' && pos + 1 < s.size()) {
+          // Display-escaped brackets stay structural; other escaped chars are
+          // carried (the escape is stripped again before expansion).
+          if (s[pos + 1] == '[') { bdepth++; n.sub += '['; pos += 2; continue; }
+          if (s[pos + 1] == ']') {
+            if (--bdepth == 0) { pos += 2; break; }
+            n.sub += ']';
+            pos += 2;
+            continue;
+          }
+          n.sub += c2; n.sub += s[pos + 1]; pos += 2; continue;
+        }
         if (c2 == '\\' && pos + 1 < s.size()) {
           n.sub += c2; n.sub += s[pos + 1]; pos += 2; continue;
         }
-        if (c2 == '\'') {
+        if (c2 == '\'' && s.find('\'', pos + 1) != std::string::npos) {
+          // A PAIRED quote is a span (`assoc['$k']'); a lone one is data
+          // (`a[80's]').
           n.sub += c2;
           while (++pos < s.size() && s[pos] != '\'') n.sub += s[pos];
           if (pos < s.size()) { n.sub += '\''; pos++; }
           continue;
         }
-        if (c2 == '"') {
+        if (c2 == '"' && s.find('"', pos + 1) != std::string::npos) {
           n.sub += c2;
           while (++pos < s.size() && s[pos] != '"') {
             if (s[pos] == '\\' && pos + 1 < s.size()) n.sub += s[pos++];
@@ -229,6 +247,9 @@ struct Parser {
         if (bdepth > 0) n.sub += c2;
         pos++;
       }
+      // An unterminated subscript (`b[$(echo' after word splitting) is
+      // bash's "bad array subscript", blaming the reference.
+      if (bdepth > 0) note("bad array subscript", start);
       n.has_sub = true;
     }
     return true;
@@ -669,42 +690,68 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out) {
   // does at evaluation: `assoc[$key]' keys on $key's VALUE, `assoc['$key']'
   // on the literal string $key -- and the result is never re-scanned, so a
   // `]' or `$(' in a value is inert data.
-  if (ctx.expand_subs == 1 && out.find_first_of("$`'\"\\") != std::string::npos) {
+  // Strip the preprocessor's \x04 display escapes: the escaped text is the
+  // real subscript.
+  std::string raw;
+  for (size_t k = 0; k < out.size(); k++) {
+    if (out[k] == '\x04' && k + 1 < out.size()) continue;
+    raw += out[k];
+  }
+  if (ctx.expand_subs == 1 && raw.find_first_of("$`'\"\\") != std::string::npos) {
     Expander ex(ctx.sh);
-    out = ex.expand_no_split(out);
+    out = ex.expand_no_split(raw, false, /*do_procsub=*/false);
+  } else {
+    out = raw;
   }
   out = ctx.sh.zsh_subscript(n->name, out);
-  if (!kind_of()) {
-    // An indexed (or undeclared) target: an EMPTY word-expanded subscript is
-    // bash's `a[]': not a valid identifier; otherwise double-quote CHARS are
-    // removed (arithmetic expansion treats them as removable quoting, so
-    // `a[\" \"]' indexes 0) and the result is arith-evaluated.  A malformed
-    // subscript aborts with bash's diagnostic naming the SUBSCRIPT.
-    if (out.empty()) {
+  if (kind_of()) {
+    // An associative key: the once-expanded text is the key, verbatim for the
+    // arithmetic-source mode (`(( a[\" \"]=11 ))' keys on the literal `" "');
+    // let's pre-expanded text drops its removable double-quote characters
+    // (`let 'a[" "]=11'` keys on the space).
+    if (ctx.expand_subs == 2) {
+      std::string k2;
+      for (char c : out)
+        if (c != '"') k2 += c;
+      out = k2;
+    }
+    return true;
+  }
+  // An indexed (or undeclared) target: an EMPTY word-expanded subscript is
+  // bash's `a[]': not a valid identifier; `@'/`*' is a bad array subscript;
+  // otherwise double-quote CHARS are removable arithmetic quoting and the
+  // result is arith-evaluated, a malformed one aborting with bash's
+  // diagnostic naming the SUBSCRIPT.
+  if (out.empty()) {
+    ctx.ok = false;
+    ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
+    return false;
+  }
+  if (out == "@" || out == "*") {
+    ctx.ok = false;
+    ctx.full_msg = n->name + "[" + out + "]: bad array subscript";
+    ctx.full_msg_bare = true;
+    return false;
+  }
+  std::string ev;
+  for (char c : out)
+    if (c != '"') ev += c;
+  if (blank_expr(ev)) { out = "0"; return true; }
+  long long k;
+  if (!try_int(ev, k)) {
+    Parsed p = parse_cached(ev);
+    Ctx sc{ctx.sh, p.ok, ctx.depth + 1, p.err_pos, p.err_msg, ctx.cmd_name, {}, false, ctx.expand_subs};
+    k = eval_node(p.root.get(), sc);
+    if (!sc.ok) {
       ctx.ok = false;
-      ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
+      ctx.full_msg = !sc.full_msg.empty()
+                         ? sc.full_msg
+                         : format_arith_err(ev, sc.err_msg, sc.err_pos);
+      ctx.full_msg_bare = true;
       return false;
     }
-    std::string ev;
-    for (char c : out)
-      if (c != '"') ev += c;
-    if (blank_expr(ev)) { out = "0"; return true; }
-    long long k;
-    if (!try_int(ev, k)) {
-      Parsed p = parse_cached(ev);
-      Ctx sc{ctx.sh, p.ok, ctx.depth + 1, p.err_pos, p.err_msg, ctx.cmd_name, {}, false, ctx.expand_subs};
-      k = eval_node(p.root.get(), sc);
-      if (!sc.ok) {
-        ctx.ok = false;
-        ctx.full_msg = !sc.full_msg.empty()
-                           ? sc.full_msg
-                           : format_arith_err(ev, sc.err_msg, sc.err_pos);
-        ctx.full_msg_bare = true;
-        return false;
-      }
-    }
-    out = std::to_string(k);
   }
+  out = std::to_string(k);
   return true;
 }
 
@@ -890,19 +937,37 @@ long long eval_arith_msg(Shell &sh, const std::string &expr, const char *cmd_nam
   if (blank_expr(expr)) { if (ok) *ok = true; return 0; }
   if (try_int(expr, iv)) { if (ok) *ok = true; return iv; }
   Parsed p = parse_cached(expr);
+  bool parse_failed = !p.ok;
   Ctx ctx{sh, p.ok, 0, p.err_pos, p.err_msg, cmd_name, {}, false, expand_subs};
   long long v = eval_node(p.root.get(), ctx);
   if (ok) *ok = ctx.ok;
+  // A PARSE error outranks an evaluation-side diagnostic (`let 'a[x],b[$(e'
+  // reports the bad subscript found at parse, not the doomed evaluation).
+  if (parse_failed) ctx.full_msg.clear();
   std::string prefix = (cmd_name && cmd_name[0]) ? std::string(cmd_name) + ": " : "";
+  // \x04 display-escape markers in expansion output: the (( )) command's
+  // diagnostics render them as backslashes (`'assoc[x\],b\[\$(...)]++'`);
+  // $(( )) diagnostics drop them (`$( echo >&2 foo ) : ...`), as bash.
+  auto rendere = [&](std::string t) {
+    std::string r;
+    for (char c : t) {
+      if (c == '\x04') {
+        if (cmd_name && cmd_name[0]) r += '\\';
+        continue;
+      }
+      r += c;
+    }
+    return r;
+  };
   if (!ctx.ok && !ctx.full_msg.empty()) {
     // A nested value-evaluation failure carries its own fully formatted
     // diagnostic naming the VALUE as the expression; a subscript failure
     // prints bare (no `((: ' prefix), as bash's array layer does.
     std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(),
-                 ctx.full_msg_bare ? "" : prefix.c_str(), ctx.full_msg.c_str());
+                 ctx.full_msg_bare ? "" : prefix.c_str(), rendere(ctx.full_msg).c_str());
   } else if (!ctx.ok && ctx.err_pos != std::string::npos && ctx.err_pos <= expr.size()) {
     std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(), prefix.c_str(),
-                 format_arith_err(expr, ctx.err_msg, ctx.err_pos).c_str());
+                 rendere(format_arith_err(expr, ctx.err_msg, ctx.err_pos)).c_str());
   }
   return v;
 }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -308,6 +308,22 @@ bool append_formatted(std::string &out, const std::string &spec, T value) {
   return true;
 }
 
+// A well-formed `NAME[subscript]' element reference: the bracket span is
+// balanced, ENDS at the final character, and is non-empty -- `A[]]' and
+// `A[]' are invalid identifiers, as bash reports for read/printf/declare.
+bool well_formed_element(const std::string &s, bool allow_empty = false) {
+  size_t lb = s.find('[');
+  if (lb == std::string::npos) return s.find(']') == std::string::npos;
+  if (s.back() != ']') return false;
+  int d = 0;
+  size_t i = lb;
+  for (; i < s.size(); i++) {
+    if (s[i] == '[') d++;
+    else if (s[i] == ']' && --d == 0) break;
+  }
+  return d == 0 && i == s.size() - 1 && (allow_empty || i > lb + 1);
+}
+
 // Apply Shell::array_expand_once_ok to a full `name[sub]' target (e.g. a `read'
 // variable), rewriting the subscript to its resolved index; false (diagnostic
 // printed) on rejection.
@@ -434,9 +450,22 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
 
   if (to_var) {
     auto lb = vname.find('[');
+    if (lb != std::string::npos && !well_formed_element(vname)) {
+      std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), vname.c_str());
+      return 1;
+    }
     if (lb != std::string::npos && !vname.empty() && vname.back() == ']') {
       std::string base = vname.substr(0, lb);
       std::string sub = vname.substr(lb + 1, vname.size() - lb - 2);
+      // `printf -v array[@]' is a bad array subscript for an INDEXED array.
+      auto pvit = sh.vars.find(sh.deref(base));
+      bool pv_assoc = pvit != sh.vars.end() && pvit->second.kind == VarKind::Assoc;
+      if (!pv_assoc && (sub == "@" || sub == "*")) {
+        std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
+                     vname.c_str());
+        return 1;
+      }
       if (!sh.array_expand_once_ok(base, sub)) return 1;
       sh.array_set(base, sub, out);
     } else if (!sh.set(vname, out, "printf")) {
@@ -498,7 +527,11 @@ struct TestEval {
       std::string nm = arg.substr(0, br);
       std::string sub = arg.substr(br + 1, arg.size() - br - 2);
       if (!sh.array_expand_once_ok(nm, sub)) { ok = false; return false; }
-      if (sub == "@" || sub == "*") return sh.array_count(nm) > 0;
+      // For an INDEXED array `@'/`*' means "any element set"; an ASSOCIATIVE
+      // array treats them as ordinary literal keys (bash).
+      auto vit = sh.vars.find(sh.deref(nm));
+      bool assoc = vit != sh.vars.end() && vit->second.kind == VarKind::Assoc;
+      if (!assoc && (sub == "@" || sub == "*")) return sh.array_count(nm) > 0;
       for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
       return false;
     }
@@ -1175,13 +1208,31 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       ret = 1;
       continue;
     }
+    // A malformed element reference (an unbalanced bracket from word
+    // splitting, e.g. `unset a[$(echo' + `foo)]') is a SILENT no-op in bash.
+    size_t lb = argv[i].find('[');
+    if (!noref && (lb != std::string::npos || argv[i].find(']') != std::string::npos) &&
+        !well_formed_element(argv[i], /*allow_empty=*/true)) {
+      continue;
+    }
     // `unset name[sub]' removes a single array element (or the whole array for
     // a `@'/`*' subscript), not a variable literally named "name[sub]".
-    size_t lb = argv[i].find('[');
     if (!noref && lb != std::string::npos && !argv[i].empty() &&
         argv[i].back() == ']') {
       std::string base = argv[i].substr(0, lb);
       std::string sub = argv[i].substr(lb + 1, argv[i].size() - lb - 2);
+      // Under BASH_COMPAT <= 51, `unset array[@]' removes the whole VARIABLE
+      // (later bash clears the elements but keeps the array).
+      if (sub == "@" || sub == "*") {
+        auto cvit = sh.vars.find(sh.deref(base));
+        bool c_assoc = cvit != sh.vars.end() && cvit->second.kind == VarKind::Assoc;
+        std::string compat = sh.get("BASH_COMPAT");
+        long cv = compat.empty() ? 99 : std::strtol(compat.c_str(), nullptr, 10);
+        if (!c_assoc && cv > 0 && cv <= 51) {
+          sh.unset(base, false, false);
+          continue;
+        }
+      }
       std::string bd = sh.deref(base);
       auto bit = sh.vars.find(bd);
       // Unset of an element only evaluates the subscript when the array exists;
@@ -1663,7 +1714,11 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) return false;
     return true;
   };
-  if (!arrayname.empty() && !valid_read_name(arrayname)) {
+  auto valid_read_target = [&](const std::string &s2) {
+    if (!valid_read_name(s2)) return false;
+    return well_formed_element(s2);  // `A[]]' is not a valid identifier
+  };
+  if (!arrayname.empty() && !valid_read_target(arrayname)) {
     std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                  arrayname.c_str());
     return 1;
@@ -1687,7 +1742,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     }
   }
   for (const std::string &nm : names)
-    if (!valid_read_name(nm)) {
+    if (!valid_read_target(nm)) {
       std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                    nm.c_str());
       return 1;
@@ -2172,6 +2227,27 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     bool arraylit0 = eq != std::string::npos && a.size() > eq + 2 &&
                      a[eq + 1] == '(' && a.back() == ')';
     bool subscript0 = nend != std::string::npos && a[nend] == '[';
+    // A malformed element reference: `declare A[]]=X' is rejected with the
+    // WHOLE argument (`declare: \`A[]]=X': not a valid identifier'); an EMPTY
+    // subscript is `a[]: bad array subscript' with no builtin prefix (bash).
+    if (subscript0 && !sh.is_zsh()) {
+      std::string elem = (eq == std::string::npos) ? a : a.substr(0, append ? eq - 1 : eq);
+      // An empty or invalid BASE name (`declare []=asdf') is the
+      // invalid-identifier error, not a subscript diagnostic.
+      if (!valid_identifier(elem.substr(0, elem.find('['))) ||
+          !well_formed_element(elem, /*allow_empty=*/true)) {
+        std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
+                     argv[0].c_str(), a.c_str());
+        ret = 1;
+        continue;
+      }
+      if (!well_formed_element(elem)) {  // balanced but empty: a[]
+        std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
+                     elem.c_str());
+        ret = 1;
+        continue;
+      }
+    }
     // `readonly'/`export' cannot target a single array element (`readonly a[5]')
     // -- bash reports it as an invalid identifier; declare/typeset/local can.
     // (zsh's array/readonly rules differ, so leave that personality alone.)
@@ -6026,7 +6102,9 @@ struct CondEval {
 
   std::string expand(const std::string &s) {
     Expander ex(sh);
-    return ex.expand_no_split(s);
+    // No process substitution inside [[: `index[7<(4+2)]' is an arithmetic
+    // comparison, not `<(cmd)' (bash).
+    return ex.expand_no_split(s, false, /*do_procsub=*/false);
   }
   // A `=='/`!=' right-hand side is a pattern: quoted/backslash-escaped glob
   // metacharacters must match literally (bash quotes them before matching), so

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2391,6 +2391,28 @@ void Expander::process_dq(const std::string &text, size_t &i, std::string &out,
 // double-quote characters are removed but single quotes stay ORDINARY
 // characters, so `$(( "1+1" ))' is 2 while `$(( 'foo' ))' is the arithmetic
 // syntax error bash reports (expr.c never sees quoting).
+// Mark characters of arithmetic-expansion OUTPUT that are special to the
+// arithmetic scanner with a \x04 display-escape byte: the scanner treats the
+// pair structurally-neutral or strips it, and error messages render it as a
+// backslash (`((: 'assoc[x\],b\[\$(echo uname >&2)]++' : ...`, as bash).
+static void arith_escape(std::string &out, std::string &mask, size_t from) {
+  std::string o, m;
+  o.reserve(out.size() - from + 8);
+  for (size_t k = from; k < out.size(); k++) {
+    char c = out[k];
+    if (c == '[' || c == ']' || c == '$' || c == '\\' || c == '`') {
+      o += '\x04';
+      m += k < mask.size() ? mask[k] : '1';
+    }
+    o += c;
+    m += k < mask.size() ? mask[k] : '1';
+  }
+  out.resize(from);
+  mask.resize(from < mask.size() ? from : mask.size());
+  out += o;
+  mask += m;
+}
+
 std::string Expander::expand_arith(const std::string &text) {
   std::string out, mask;
   size_t i = 0;
@@ -2400,8 +2422,18 @@ std::string Expander::expand_arith(const std::string &text) {
     // expands it exactly once itself (bash expands subscripts at evaluation,
     // so `(( assoc[$key]++ ))' with `]'/`$(' in $key's VALUE keys on the
     // literal value and never re-scans or executes it).
+    bool sub_ctx = false;
     if (c == '[' && !out.empty() &&
         (std::isalnum(static_cast<unsigned char>(out.back())) || out.back() == '_')) {
+      // Walk back over the name: a quote directly before it (`'assoc[$k]++'`)
+      // means this is quoted DATA, not an array reference -- expand normally
+      // so the error text shows the expansion, escaped.
+      size_t nb = out.size();
+      while (nb > 0 && (std::isalnum(static_cast<unsigned char>(out[nb - 1])) || out[nb - 1] == '_'))
+        nb--;
+      sub_ctx = nb == 0 || (out[nb - 1] != '\'' && out[nb - 1] != '"');
+    }
+    if (sub_ctx) {
       int bd = 0;
       size_t j = i;
       for (; j < text.size(); j++) {
@@ -2430,7 +2462,12 @@ std::string Expander::expand_arith(const std::string &text) {
       i += 2;
       continue;
     }
-    if (c == '$') { expand_dollar(text, i, true, out, mask); continue; }
+    if (c == '$') {
+      size_t o0 = out.size();
+      expand_dollar(text, i, true, out, mask);
+      arith_escape(out, mask, o0);
+      continue;
+    }
     if (c == '`') {
       size_t j = i + 1;
       std::string inner;
@@ -2446,7 +2483,9 @@ std::string Expander::expand_arith(const std::string &text) {
       int st = 0;
       std::string res = sh_.run_and_capture(inner, &st);
       sh_.note_cmdsub(st);
+      size_t o0 = out.size();
       for (char ch : res) { out += ch; mask += '1'; }
+      arith_escape(out, mask, o0);
       i = (j < text.size()) ? j + 1 : j;
       continue;
     }


### PR DESCRIPTION
Fixes #416.

Continuation of #414 — see the issue for the decoded behavior list. Highlights: the \\x04 display-escape system for arithmetic expansion output (rendered by (( )) diagnostics, dropped by \$(( ))), read/printf/declare element-target validation (`A[]]`, `a[]`, empty base names), literal unset subscripts with silent malformed words and BASH_COMPAT<=51 whole-array unset, literal @/* -v keys on associative arrays, no procsub inside [[, paired-vs-lone quote subscript scanning, unterminated-subscript diagnostics, and parse-error precedence.

**Verification (full-suite sweep):** quotearray 54 → **32** (95 at day start), builtins 87 → **85** (bonus), arith holds 7, array 61 → 62, assoc 72 → 79 — the assoc/array upticks are the documented assoc_expand_once word-expansion tradeoff (assoc18 unquoted targets need expander-level shopt work; the quoted forms in array27/quotearray2, which are the larger set, now match). 47 files byte-perfect; ctest 22/22; run_diff 240/240.