### PR TITLE
fix(shell,builtins): raw-word provenance for targets; direct element writes

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -488,6 +488,16 @@ class Shell {
   // Alias expansion applies: interactive or `shopt -s expand_aliases', and at
   // least one alias table is non-empty.
   bool aliases_active() const;
+  // Raw (pre-expansion) provenance for the CURRENT builtin's argv: the source
+  // word text and whether it was quoted; text is empty when a word produced
+  // multiple or zero fields.  Consumed at builtin ENTRY (read/printf apply
+  // bash's assoc_expand_once target rules, which depend on the original
+  // quoting); cleared after the builtin returns.
+  struct RawArg {
+    std::string text;
+    bool quoted = false;
+  };
+  std::vector<RawArg> raw_args;
   // bash valid_alias_name: no shell metacharacters, blanks, quoting
   // characters, `$', or `/' anywhere in the name.
   static bool valid_alias_name(const std::string &name);

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -650,7 +650,7 @@ long long eval_string(Shell &sh, const std::string &str, int depth, bool *ok) {
 // evaluated here (the numeric result re-evaluates idempotently in
 // array_get/array_set, which still apply negative-index resolution); an
 // associative key passes through untouched.
-static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out) {
+static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing = false) {
   out = n->sub;
   auto kind_of = [&]() {
     auto it = ctx.sh.vars.find(ctx.sh.deref(n->name));
@@ -724,7 +724,15 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out) {
   // diagnostic naming the SUBSCRIPT.
   if (out.empty()) {
     ctx.ok = false;
-    ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
+    if (writing) {
+      // `(( a[""]=24 ))' -- an assignment target: `a[]': not a valid
+      // identifier (with the command prefix).
+      ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
+    } else {
+      // `(( y[$none] ))' -- a read: y[]: bad array subscript (bare).
+      ctx.full_msg = n->name + "[]: bad array subscript";
+      ctx.full_msg_bare = true;
+    }
     return false;
   }
   if (out == "@" || out == "*") {
@@ -824,7 +832,7 @@ void ref_set(const Node *n, long long val, Ctx &ctx, const std::string *rsub = n
       return;
     }
     std::string rs;
-    if (!resolve_sub(n, ctx, rs)) return;
+    if (!resolve_sub(n, ctx, rs, /*writing=*/true)) return;
     ctx.sh.array_set(n->name, rs, std::to_string(val));
     return;
   }
@@ -856,7 +864,7 @@ long long eval_node(const Node *n, Ctx &ctx) {
       // not run again for the write back).
       std::string rs;
       const std::string *rp = nullptr;
-      if (n->has_sub) { if (!resolve_sub(n, ctx, rs)) return 0; rp = &rs; }
+      if (n->has_sub) { if (!resolve_sub(n, ctx, rs, /*writing=*/true)) return 0; rp = &rs; }
       long long cur = ref_get(n, ctx, rp);
       long long d = (n->k == K::PreInc || n->k == K::PostInc) ? 1 : -1;
       ref_set(n, cur + d, ctx, rp);
@@ -901,7 +909,7 @@ long long eval_node(const Node *n, Ctx &ctx) {
       // write back (`d[x++]+=2' bumps x a single time, as bash).
       std::string rs;
       const std::string *rp = nullptr;
-      if (o != "=" && n->has_sub) { if (!resolve_sub(n, ctx, rs)) return 0; rp = &rs; }
+      if (o != "=" && n->has_sub) { if (!resolve_sub(n, ctx, rs, /*writing=*/true)) return 0; rp = &rs; }
       if (o != "=") {
         long long cur = ref_get(n, ctx, rp);
         if (o == "+=") res = cur + rhs;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -311,6 +311,28 @@ bool append_formatted(std::string &out, const std::string &spec, T value) {
 // A well-formed `NAME[subscript]' element reference: the bracket span is
 // balanced, ENDS at the final character, and is non-empty -- `A[]]' and
 // `A[]' are invalid identifiers, as bash reports for read/printf/declare.
+// assoc_expand_once (synonym array_expand_once) set?
+static bool expand_once_on(Shell &sh) {
+  auto o = [&](const char *nm) {
+    auto it = sh.shopt_opts.find(nm);
+    return it != sh.shopt_opts.end() && it->second;
+  };
+  return o("assoc_expand_once") || o("array_expand_once");
+}
+
+// Under assoc_expand_once, an UNQUOTED source word of the form `NAME[...]'
+// takes bash's lenient target parsing (subscript to the LAST bracket), so
+// `read A[$k]' with k=']' stores the key `]' -- while the QUOTED form
+// `read "A[$k]"' is still rejected as `A[]]'.  Decided from the RAW word's
+// provenance (Shell::raw_args), captured before expansion.
+static bool lenient_element_target(Shell &sh, size_t argv_idx) {
+  if (!expand_once_on(sh) || argv_idx >= sh.raw_args.size()) return false;
+  const Shell::RawArg &r = sh.raw_args[argv_idx];
+  if (r.text.empty() || r.quoted) return false;
+  size_t lb = r.text.find('[');
+  return lb != std::string::npos && lb > 0 && r.text.back() == ']';
+}
+
 bool well_formed_element(const std::string &s, bool allow_empty = false) {
   size_t lb = s.find('[');
   if (lb == std::string::npos) return s.find(']') == std::string::npos;
@@ -342,11 +364,13 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
   size_t ai = 1;
   bool to_var = false;
   std::string vname;
+  size_t vname_idx = SIZE_MAX;
   while (ai < argv.size() && argv[ai].size() >= 2 && argv[ai][0] == '-') {
     if (argv[ai] == "--") { ai++; break; }
     if (argv[ai] == "-v" && ai + 1 < argv.size()) {
       to_var = true;
       vname = argv[ai + 1];
+      vname_idx = ai + 1;
       ai += 2;
       continue;
     }
@@ -450,7 +474,8 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
 
   if (to_var) {
     auto lb = vname.find('[');
-    if (lb != std::string::npos && !well_formed_element(vname)) {
+    if (lb != std::string::npos && !lenient_element_target(sh, vname_idx) &&
+        !well_formed_element(vname)) {
       std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
                    sh.err_prefix().c_str(), vname.c_str());
       return 1;
@@ -1211,7 +1236,8 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     // A malformed element reference (an unbalanced bracket from word
     // splitting, e.g. `unset a[$(echo' + `foo)]') is a SILENT no-op in bash.
     size_t lb = argv[i].find('[');
-    if (!noref && (lb != std::string::npos || argv[i].find(']') != std::string::npos) &&
+    if (!noref && !expand_once_on(sh) &&
+        (lb != std::string::npos || argv[i].find(']') != std::string::npos) &&
         !well_formed_element(argv[i], /*allow_empty=*/true)) {
       continue;
     }
@@ -1626,10 +1652,14 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   double timeout = 0.0;
   bool edit = false;                // -e: read with readline
   std::vector<std::string> names;
+  std::vector<size_t> name_idx;  // argv index of each name, for raw provenance
 
   for (size_t i = 1; i < argv.size(); i++) {
     const std::string &a = argv[i];
-    if (a == "--") { for (size_t j = i + 1; j < argv.size(); j++) names.push_back(argv[j]); break; }
+    if (a == "--") {
+      for (size_t j = i + 1; j < argv.size(); j++) { names.push_back(argv[j]); name_idx.push_back(j); }
+      break;
+    }
     if (a.size() >= 2 && a[0] == '-' && a != "-") {
       for (size_t k = 1; k < a.size(); k++) {
         char o = a[k];
@@ -1695,6 +1725,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       }
     } else {
       names.push_back(a);
+      name_idx.push_back(i);
     }
   }
 
@@ -1741,12 +1772,15 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       return 1;
     }
   }
-  for (const std::string &nm : names)
+  for (size_t ni = 0; ni < names.size(); ni++) {
+    const std::string &nm = names[ni];
+    if (lenient_element_target(sh, ni < name_idx.size() ? name_idx[ni] : SIZE_MAX)) continue;
     if (!valid_read_target(nm)) {
       std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                    nm.c_str());
       return 1;
     }
+  }
 
   // $TMOUT is the default timeout, but only when reading from a terminal.
   if (!have_t && isatty(fd)) {
@@ -2214,6 +2248,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   int ret = 0;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
+    std::string a_display = a;  // error display; subscript shown expanded
     size_t nend = a.find_first_of("[=");
     std::string name = (nend == std::string::npos) ? a : a.substr(0, nend);
     size_t eq = a.find('=');
@@ -2232,12 +2267,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // subscript is `a[]: bad array subscript' with no builtin prefix (bash).
     if (subscript0 && !sh.is_zsh()) {
       std::string elem = (eq == std::string::npos) ? a : a.substr(0, append ? eq - 1 : eq);
+      // Validate the EXPANDED subscript: `declare A[$k]=X' with k=']' is the
+      // post-expansion `A[]]=X' error, even for the raw pass-through form.
+      {
+        size_t elb = elem.find('[');
+        if (elb != std::string::npos && elem.back() == ']' &&
+            elem.find_first_of("$`'\"\\", elb) != std::string::npos) {
+          Expander dex(sh);
+          std::string esub =
+              dex.expand_no_split(elem.substr(elb + 1, elem.size() - elb - 2));
+          elem = elem.substr(0, elb) + "[" + esub + "]";
+          a_display = elem + (eq == std::string::npos ? std::string() : a.substr(append ? eq - 1 : eq));
+        }
+      }
       // An empty or invalid BASE name (`declare []=asdf') is the
       // invalid-identifier error, not a subscript diagnostic.
       if (!valid_identifier(elem.substr(0, elem.find('['))) ||
           !well_formed_element(elem, /*allow_empty=*/true)) {
         std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                     argv[0].c_str(), a.c_str());
+                     argv[0].c_str(), a_display.c_str());
         ret = 1;
         continue;
       }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1125,6 +1125,7 @@ int Executor::run_simple(const SimpleCommand *c) {
   } psg{sh_, sh_.procsubs.size()};
   std::vector<std::pair<std::string, std::string>> assigns;
   std::vector<std::string> argv;
+  std::vector<Shell::RawArg> raw_prov;
   // Pre-formatted `set -x' trace lines for the assignment words, in source
   // order: a scalar assignment as NAME=<quoted-value> (or NAME+=...), an array
   // compound assignment as its verbatim source word, so xtrace matches bash even
@@ -1221,10 +1222,17 @@ int Executor::run_simple(const SimpleCommand *c) {
       // argument is an assignment word: pass it through raw so it is neither
       // word-split nor globbed and array literals survive; the builtin expands
       // and parses it itself.
-      if (!argv.empty() && is_assignment_builtin(argv[0]) && is_assignment_word_text(w.text))
+      if (!argv.empty() && is_assignment_builtin(argv[0]) && is_assignment_word_text(w.text)) {
         argv.push_back(w.text);
-      else
+        raw_prov.push_back({w.text, (w.flags & W_QUOTED) != 0});
+      } else {
+        size_t before = argv.size();
         for (const std::string &f : ex.expand_args({w})) argv.push_back(f);
+        // Provenance only survives a 1:1 word->field expansion.
+        if (argv.size() == before + 1)
+          raw_prov.push_back({w.text, (w.flags & W_QUOTED) != 0});
+        raw_prov.resize(argv.size());
+      }
     }
   }
 
@@ -1290,6 +1298,8 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
     if (describe || bad) break;  // -v/-V/invalid: dispatch to the `command' builtin
     argv.erase(argv.begin(), argv.begin() + k);  // strip `command' and its options
+    raw_prov.erase(raw_prov.begin(),
+                   raw_prov.begin() + std::min(k, raw_prov.size()));
     skip_functions = true;
     if (argv.empty()) return (sh_.last_status = 0);  // bare `command'
   }
@@ -1486,7 +1496,9 @@ int Executor::run_simple(const SimpleCommand *c) {
                // `command' strips the POSIX special-builtin exit property: a
                // failing `command . nofile' does not end a posix-mode shell.
                sh_.posix_builtin_shield = skip_functions;
+               sh_.raw_args = std::move(raw_prov);
                bool b = run_builtin(sh_, argv, &status);
+               sh_.raw_args.clear();
                sh_.posix_builtin_shield = false;
                return b;
              }())) {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1204,6 +1204,25 @@ static void apply_ctype_locale(Shell &sh) {
 
 bool Shell::set(const std::string &n_in, const std::string &v,
                 const char *nameref_ctx) {
+  // A DIRECT element reference (`A[sub]', e.g. a `read A[k]' target) writes
+  // through to the array element -- previously this silently created a shadow
+  // variable literally named "A[sub]".  The subscript spans to the LAST
+  // bracket, so a lenient assoc_expand_once target (`A[]]') keys on `]'.
+  {
+    size_t lb = n_in.find('[');
+    if (lb != std::string::npos && lb > 0 && n_in.back() == ']') {
+      std::string base = n_in.substr(0, lb);
+      std::string sub = n_in.substr(lb + 1, n_in.size() - lb - 2);
+      auto bit = vars.find(deref(base));
+      if (bit != vars.end() && bit->second.readonly) {
+        std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
+                     base.c_str());
+        return false;
+      }
+      array_set(base, sub, v);
+      return true;
+    }
+  }
   // A nameref whose target is an array element (`declare -n r=a[2]'): write
   // through to that element.  array_set enforces the target's readonly flag.
   {


### PR DESCRIPTION
Fixes #418.

Completes the assoc_expand_once quoted/unquoted split from #416 via the raw-word provenance channel (Shell::raw_args), and fixes the latent shadow-variable bug in `read A[k]` element stores. Details in the issue.

**Verification (full-suite sweep):** only improvements — quotearray 32 → **27**, array 64 → **53**, assoc 79 → **69** (both below their pre-campaign baselines); assoc18.sub byte-perfect; 47 files byte-perfect overall; ctest 22/22; run_diff 240/240.