### PR TITLE
fix(shell,executor,builtins): variable-scoping conformance cluster

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -163,6 +163,10 @@ class Shell {
   std::vector<std::vector<std::pair<std::string, std::optional<Variable>>>> local_stack;
   // Per-scope saved getopt state, set when that scope localizes OPTIND.
   std::vector<std::optional<std::tuple<size_t, std::string, int>>> getopt_scope_saves;
+  // Pre-temp-env bindings and names whose temp layer was consumed by a
+  // `local'/`declare' during the command (see executor apply_temp/undo_temp).
+  std::map<std::string, std::optional<Variable>> temp_prior;
+  std::set<std::string> temp_consumed;
   // Names currently bound by a `VAR=val cmd' temporary environment.  make_local
   // inherits such a variable's value/attributes when a called function localizes
   // it (`v=t f; f(){ local v; }' -> the local is `v=t', exported), matching bash.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -37,6 +37,11 @@
 
 namespace gnash::core {
 
+// Shared with the executor: parse a `( ... )' compound value into elements.
+std::vector<std::pair<std::optional<std::string>, std::string>>
+parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer,
+                  bool whole_append, const std::string &parenval);
+
 namespace {
 
 std::string join(const std::vector<std::string> &v, size_t from) {
@@ -1553,6 +1558,12 @@ std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
       {"xtrace", sh.opt_xtrace}};
 }
 
+// External wrapper for `local -' restore (Shell::pop_scope lives in
+// shell.cpp, outside this file's anonymous namespace).
+bool apply_set_o_option(Shell &sh, const std::string &o, bool on) {
+  return set_o_option(sh, o, on);
+}
+
 namespace {  // reopen the anonymous namespace for the remaining file-local helpers
 
 int bi_set(Shell &sh, const std::vector<std::string> &argv) {
@@ -2105,6 +2116,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           for (const auto &pr : sh.local_stack.back()) {
             if (std::find(seen.begin(), seen.end(), pr.first) != seen.end()) continue;
             seen.push_back(pr.first);
+            if (pr.first == "-") { std::printf("local -\n"); continue; }
             auto it = sh.vars.find(pr.first);
             if (it != sh.vars.end()) declare_print_var(pr.first, it->second, argv[0], sh.opt_posix);
           }
@@ -2248,7 +2260,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   int ret = 0;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
+    // `local -': snapshot the set -o option states into the function frame
+    // (entry named "-"); Shell::pop_scope restores them at return.
+    if (local && a == "-" && !sh.local_stack.empty()) {
+      auto &frame = sh.local_stack.back();
+      bool have = false;
+      for (auto &e : frame)
+        if (e.first == "-") { have = true; break; }
+      if (!have) {
+        Variable v;
+        v.value = "\x01SETOPTS:";
+        for (const auto &o : set_option_states(sh))
+          v.value += o.first + "=" + (o.second ? "1" : "0") + ";";
+        frame.emplace_back("-", std::optional<Variable>(v));
+      }
+      continue;
+    }
     std::string a_display = a;  // error display; subscript shown expanded
+    std::vector<std::pair<std::optional<std::string>, std::string>> pre_elems;
+    bool have_pre_elems = false;
     size_t nend = a.find_first_of("[=");
     std::string name = (nend == std::string::npos) ? a : a.substr(0, nend);
     size_t eq = a.find('=');
@@ -2388,6 +2418,19 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         for (auto &e : sh.local_stack.back())
           if (e.first == name) { fresh_local = false; break; }  // a re-declaration
       }
+      // A compound value on a LOCAL expands in the ENCLOSING scope before the
+      // variable is localized, so `local -a arr=( "${arr[@]}" )' copies the
+      // caller's array (bash), exactly like the scalar `local x=${x}' timing.
+      if (arraylit0 && eq != std::string::npos &&
+          (a.find(name, eq) != std::string::npos ||
+           a.find("${!", eq) != std::string::npos)) {
+        // Only when the value references the name being localized -- other
+        // values expand identically in either scope, and the normal path
+        // preserves subtleties (e.g. CTLESC data bytes, array29.sub).
+        Expander pex(sh);
+        pre_elems = parse_array_elems(sh, pex, name, integer, append, a.substr(eq + 1));
+        have_pre_elems = true;
+      }
       if (sh.make_local(name, force_inherit)) inherited_local = true;
     }
     // An array cannot be switched between indexed and associative in place; bash
@@ -2501,6 +2544,16 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           val[1] == '(' && val[val.size() - 2] == ')') {
         apply_assignment_word(sh, name + (append ? "+=" : "=") +
                                       val.substr(1, val.size() - 2));
+      } else if (have_pre_elems && arraylit && !nameref) {
+        // The elements were expanded in the enclosing scope before make_local.
+        auto avk = sh.vars.find(name);
+        bool as_assoc = avk != sh.vars.end() && avk->second.kind == VarKind::Assoc;
+        if (integer)
+          for (auto &e : pre_elems) {
+            bool iok = true;
+            e.second = std::to_string(eval_arith(sh, e.second, &iok));
+          }
+        sh.array_assign(name, pre_elems, append, as_assoc);
       } else if (arraylit || subscript) {
         // An UNQUOTED compound (`declare -n array=(one two three)') is assigned
         // as an array literal even under -n; the "reference variable cannot be an

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -496,6 +496,8 @@ bool parse_assign(const std::string &w, Assign &a) {
   return true;
 }
 
+}  // namespace (parse_array_elems is shared with bi_declare)
+
 std::vector<std::pair<std::optional<std::string>, std::string>>
 parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer,
                   bool whole_append, const std::string &parenval) {
@@ -608,6 +610,8 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
   }
   return out;
 }
+
+namespace {
 
 void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   // Assigning to any part of a readonly array is an error (bash names the array,
@@ -1124,6 +1128,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     ~ProcsubGuard() { s.reap_procsubs(base); }
   } psg{sh_, sh_.procsubs.size()};
   std::vector<std::pair<std::string, std::string>> assigns;
+  std::vector<Assign> pending_elem;  // subscripted prefix assigns, decided below
   std::vector<std::string> argv;
   std::vector<Shell::RawArg> raw_prov;
   // Pre-formatted `set -x' trace lines for the assignment words, in source
@@ -1145,12 +1150,17 @@ int Executor::run_simple(const SimpleCommand *c) {
     if (assign_here) {
       Assign a;
       parse_assign(w.text, a);
-      if (a.sub || a.is_array) {
+      if (a.sub) {
+        // A SUBSCRIPTED prefix assignment is only valid when no command word
+        // follows; decided after the loop (`var[0]=X f' is rejected, bare
+        // `var[0]=X' assigns).
+        pending_elem.push_back(a);
+      } else if (a.is_array) {
         // NOTE: an array/element assignment is not xtrace'd here -- bash prints it
         // via its compound-assignment word-list deparser (each element expanded
         // then re-quoted, e.g. source `$'\t'' -> `'<tab>''), which gnash does not
         // reproduce; tracing the verbatim source word would not match.  Deferred.
-        apply_array_assign(sh_, ex, a);  // array element / literal: applied now
+        apply_array_assign(sh_, ex, a);  // array literal: applied now
       } else {
         auto vit = sh_.vars.find(a.name);
         // A value assigned to a targetless nameref becomes its referent NAME,
@@ -1233,6 +1243,20 @@ int Executor::run_simple(const SimpleCommand *c) {
           raw_prov.push_back({w.text, (w.flags & W_QUOTED) != 0});
         raw_prov.resize(argv.size());
       }
+    }
+  }
+
+  // Subscripted assignments in a temporary environment are invalid: with a
+  // command word present bash rejects each (`var[0]=X f' prints `var[0]':
+  // not a valid identifier) and runs the command without them; with no
+  // command word they are ordinary element assignments.
+  for (const Assign &a : pending_elem) {
+    if (!argv.empty()) {
+      std::string disp = a.name + "[" + (a.sub ? *a.sub : std::string()) + "]";
+      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
+                   disp.c_str());
+    } else {
+      apply_array_assign(sh_, ex, a);
     }
   }
 
@@ -1370,6 +1394,11 @@ int Executor::run_simple(const SimpleCommand *c) {
       auto it = sh_.vars.find(a.first);
       restore.push_back({a.first,
                          it == sh_.vars.end() ? std::nullopt : std::optional<Variable>(it->second)});
+      // Record the pre-temp binding: a `local'/`declare' created during the
+      // command CONSUMES the temp layer (make_local), taking this as its
+      // frame-restore point so `v=t declare -x v' in a function leaves the
+      // caller's v untouched while the local keeps t until return.
+      sh_.temp_prior[a.first] = restore.back().second;
       if (it != sh_.vars.end() && it->second.nameref) {
         // A temporary assignment to a nameref shadows it with a plain binding
         // for the duration of the command; it does not write through to the
@@ -1387,11 +1416,16 @@ int Executor::run_simple(const SimpleCommand *c) {
   };
   auto undo_temp = [&]() {
     for (auto it = restore.rbegin(); it != restore.rend(); ++it) {
+      if (sh_.temp_consumed.count(it->first)) continue;  // localized: frame owns it
       if (it->second) sh_.vars[it->first] = *it->second;
       else sh_.vars.erase(it->first);
     }
     restore.clear();
-    for (const auto &a : assigns) sh_.temp_env_active.erase(a.first);
+    for (const auto &a : assigns) {
+      sh_.temp_env_active.erase(a.first);
+      sh_.temp_prior.erase(a.first);
+      sh_.temp_consumed.erase(a.first);
+    }
   };
 
   int status = 0;
@@ -1489,8 +1523,9 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.call_stack.pop_back();
     sh_.positional = saved_pos;
     if (sh_.returning) { sh_.returning = false; status = sh_.exit_status; }
-    // In posix mode, assignments preceding a function call persist.
-    if (sh_.opt_posix) restore.clear();
+    // Assignments preceding a function call are UNDONE at return, in posix
+    // mode too: bash no longer propagates `var=two func' to the caller, even
+    // when the function export/readonly-marks the temporary (varenv12.sub).
     undo_temp();
   } else if ((apply_temp(), [&] {
                // `command' strips the POSIX special-builtin exit property: a
@@ -1511,7 +1546,11 @@ int Executor::run_simple(const SimpleCommand *c) {
     // mode all the POSIX special builtins persist too.
     builtin = true;
     bool persist = argv[0] == "export" || argv[0] == "readonly";
-    if (!persist && (argv[0] == "declare" || argv[0] == "typeset")) {
+    if (!persist && !sh_.in_function() &&
+        (argv[0] == "declare" || argv[0] == "typeset")) {
+      // Inside a function, `v=t declare -x v' needs no promotion: declare
+      // creates a LOCAL that inherits the temp-env value, and it unwinds at
+      // return leaving the caller's binding untouched (varenv12.sub).
       for (size_t k = 1; k < argv.size() && argv[k].size() > 1 && argv[k][0] == '-'; k++)
         if (argv[k].find('x') != std::string::npos ||
             argv[k].find('r') != std::string::npos) { persist = true; break; }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -31,6 +31,8 @@ extern "C" char **environ;
 
 namespace gnash::core {
 
+bool apply_set_o_option(Shell &sh, const std::string &o, bool on);
+
 namespace { const char *signum_to_trapname(int sig); }
 
 Shell::Shell() {
@@ -1073,6 +1075,20 @@ void Shell::pop_scope() {
   if (local_stack.empty()) return;
   auto &scope = local_stack.back();
   for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
+    // `local -': the entry holds a set -o option snapshot, not a variable.
+    if (it->first == "-" && it->second &&
+        it->second->value.compare(0, 9, "\x01SETOPTS:") == 0) {
+      const std::string &sv = it->second->value;
+      size_t p = 9;
+      while (p < sv.size()) {
+        size_t eq = sv.find('=', p), sc = sv.find(';', p);
+        if (eq == std::string::npos || sc == std::string::npos) break;
+        if (sv.compare(p, eq - p, "restricted") != 0)  // cannot be cleared
+          apply_set_o_option(*this, sv.substr(p, eq - p), sv[eq + 1] == '1');
+        p = sc + 1;
+      }
+      continue;
+    }
     if (it->second)
       vars[it->first] = *it->second;
     else
@@ -1096,7 +1112,17 @@ bool Shell::make_local(const std::string &n, bool inherit_force) {
   for (auto &e : scope)
     if (e.first == n) return false;  // already made local in this scope
   auto it = vars.find(n);
-  scope.emplace_back(n, it == vars.end() ? std::nullopt : std::optional<Variable>(it->second));
+  // Under an active temp env (`v=t declare -x v'), the new local CONSUMES the
+  // temp layer: its frame-restore point is the PRE-temp binding (so the
+  // caller's v is restored at return), and the command's temp undo skips it.
+  auto tp = temp_prior.find(n);
+  if (tp != temp_prior.end() && temp_env_active.count(n)) {
+    scope.emplace_back(n, tp->second);
+    temp_consumed.insert(n);
+    temp_prior.erase(tp);
+  } else {
+    scope.emplace_back(n, it == vars.end() ? std::nullopt : std::optional<Variable>(it->second));
+  }
   // A fresh local inherits the value and attributes of the nearest enclosing
   // variable of the same name rather than starting unset when `-I' was given or
   // `shopt -s localvar_inherit' is set (bash); a later `=value' on the local
@@ -1113,10 +1139,13 @@ bool Shell::make_local(const std::string &n, bool inherit_force) {
   if (!inherit) {
     // A local of an exported variable stays exported even without inheriting
     // its value, so the environment the function passes to child processes is
-    // unchanged (bash): `export V; f(){ local V; }' keeps V in the environment,
-    // and a temp-env `V=x f' makes the local `V' exported too.
+    // unchanged (bash): `export V; f(){ local V; }' keeps V in the environment
+    // WITH the enclosing value (environ_block falls through the invisible
+    // local to the shadowed binding), and a temp-env `V=x f' makes the local
+    // `V' exported too.
     bool was_exported = it != vars.end() && it->second.exported;
     vars[n] = Variable{};  // fresh (unset) local
+    vars[n].invisible = true;
     vars[n].exported = was_exported;
   }
   // Localizing OPTIND saves and resets the getopts scan state (bash restores
@@ -1400,8 +1429,33 @@ void Shell::unset(const std::string &n_in, bool force, bool noref) {
     if (!force && !local_stack.empty())
       for (auto &e : local_stack.back())
         if (e.first == n) { cur_local = true; break; }
-    if (cur_local) { Variable v; v.invisible = true; vars[n] = v; }
-    else vars.erase(it);
+    if (cur_local) {
+      Variable v;
+      v.invisible = true;
+      // The declared-but-unset placeholder keeps the export attribute (a
+      // temp-env-inherited local stays `declare -x v' after unset, bash).
+      v.exported = it->second.exported;
+      vars[n] = v;
+      return;
+    }
+    // Unsetting a variable that is local to an ENCLOSING function scope POPS
+    // that local cell (bash's value-stack semantics): the binding beneath it
+    // -- an outer local or the global -- becomes visible immediately, at
+    // every scope, and the popped frame entry must not restore it again at
+    // return.  `outer(){ local r; inner; echo $r; }; inner(){ unset r; }'
+    // exposes the global r inside BOTH inner and outer (varenv10.sub).
+    if (!force && local_stack.size() > 1) {
+      for (auto fit = std::next(local_stack.rbegin()); fit != local_stack.rend(); ++fit) {
+        for (auto e = fit->begin(); e != fit->end(); ++e) {
+          if (e->first != n) continue;
+          if (e->second) vars[n] = *e->second;
+          else vars.erase(n);
+          fit->erase(e);
+          return;
+        }
+      }
+    }
+    vars.erase(it);
   }
 }
 
@@ -1412,8 +1466,24 @@ std::string Shell::ifs() const {
 
 std::vector<std::string> Shell::environ_block() const {
   std::vector<std::string> out;
-  for (const auto &kv : vars)
-    if (kv.second.exported) out.push_back(kv.first + "=" + kv.second.value);
+  for (const auto &kv : vars) {
+    if (!kv.second.exported) continue;
+    std::string val = kv.second.value;
+    // An INVISIBLE exported local (`export V=abc; f(){ local V; }') passes
+    // the SHADOWED value to children until the local is assigned (bash).
+    if (kv.second.invisible) {
+      bool found = false;
+      for (auto fit = local_stack.rbegin(); fit != local_stack.rend() && !found; ++fit)
+        for (const auto &e : *fit)
+          if (e.first == kv.first) {
+            if (e.second && !e.second->invisible && e.second->exported) val = e.second->value;
+            else val.clear();
+            found = true;
+            break;
+          }
+    }
+    out.push_back(kv.first + "=" + val);
+  }
   // Exported functions travel as BASH_FUNC_<name>%%=() {  body  }, which a
   // child bash/gnash re-imports at startup.
   for (const auto &name : exported_functions) {


### PR DESCRIPTION
Fixes #420.

Six decoded scoping behaviors (details in the issue): posix tempenv persistence with declare-created locals consuming the temp layer, value-stack pop unset, subscripted temp-assignment rejection, `local -` option snapshot/restore, compound-local values expanding in the enclosing scope (gated to values referencing the localized name or using indirection), and invisible exported locals with environment fallthrough.

**Verification (full-suite sweep):** varenv 84 → **16** (varenv7/10/13/18/20/21 byte-perfect), assoc 69 → **61**, array holds 53 (an initial +2 from array29 CTLESC data was found and fixed by gating the pre-expansion); ctest 22/22; run_diff 240/240.