### PR TITLE
fix(lexer,expand): $(( ambiguity, heredocs inside $( ), delimiter edges

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -63,6 +63,7 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
   const bool case_aware = (open == '(');
   bool cmd_pos = true;
   std::vector<int> case_stack;
+  std::vector<std::pair<std::string, bool>> heredocs;  // pending <<delim, <<-
   std::string word;
   bool word_plain = true;
   bool saw_word = false;
@@ -81,6 +82,68 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
   auto contaminate = [&]() { if (case_aware) { saw_word = true; word_plain = false; } };
   for (; i < t.size(); i++) {
     char c = t[i];
+    if (case_aware && c == '<' && i + 1 < t.size() && t[i + 1] == '<' &&
+        !(i + 2 < t.size() && t[i + 2] == '<')) {
+      // Remember a here-document delimiter; its body lines are skipped
+      // verbatim at the next newline (a `)' in them is not the closer).
+      i += 2;
+      bool strip_tabs = i < t.size() && t[i] == '-';
+      if (strip_tabs) i++;
+      while (i < t.size() && (t[i] == ' ' || t[i] == '\t')) i++;
+      std::string delim;
+      while (i < t.size() && !std::isspace(static_cast<unsigned char>(t[i])) &&
+             !std::strchr(";&|()<>", t[i])) {
+        char dc = t[i];
+        if (dc == '\'' || dc == '"') {
+          char q = dc;
+          i++;
+          while (i < t.size() && t[i] != q) delim += t[i++];
+          if (i < t.size()) i++;
+          continue;
+        }
+        if (dc == '\\' && i + 1 < t.size()) { i++; dc = t[i]; }
+        delim += dc;
+        i++;
+      }
+      i--;  // loop increment
+      if (!delim.empty()) heredocs.push_back({delim, strip_tabs});
+      contaminate();
+      wasdol = false;
+      continue;
+    }
+    if (case_aware && c == '\n' && !heredocs.empty()) {
+      i++;  // past the newline
+      bool closing = false;
+      for (auto &hd : heredocs) {
+        if (closing) break;
+        while (i < t.size()) {
+          size_t ls = i;
+          while (i < t.size() && t[i] != '\n') i++;
+          std::string line = t.substr(ls, i - ls);
+          bool had_nl = i < t.size();
+          std::string cmp = line;
+          size_t tt = 0;
+          if (hd.second)
+            while (tt < cmp.size() && cmp[tt] == '\t') tt++;
+          cmp = cmp.substr(tt);
+          // `EOF)': the closer may abut the delimiter -- resume at the `)'.
+          if (cmp.compare(0, hd.first.size(), hd.first) == 0 &&
+              cmp.size() > hd.first.size() && cmp[hd.first.size()] == ')') {
+            i = ls + tt + hd.first.size();
+            closing = true;
+            break;
+          }
+          if (had_nl) i++;
+          if (cmp == hd.first || !had_nl) break;
+        }
+      }
+      heredocs.clear();
+      i--;  // loop increment
+      if (case_aware) boundary();
+      cmd_pos = true;
+      wasdol = false;
+      continue;
+    }
     if (c == '\\') { contaminate(); i++; wasdol = false; continue; }
     if (c == '$' && i + 1 < t.size() && t[i + 1] == '\'') {
       // $'...': ANSI-C quoting, where a backslash escapes the next character
@@ -918,15 +981,25 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     }
   };
 
-  // $((expr))
+  // $((expr)) -- but `$((cmd);(cmd))' is the command substitution `$( (...)':
+  // it is ARITHMETIC only when the paren depth never falls below 2 before the
+  // closing `))', i.e. no top-level `)' appears inside (bash's rule; probe:
+  // `$((echo a);(echo b))' runs the subshells, `$((echo hi))' is an
+  // arithmetic syntax error).
   if (n1 == '(' && i + 2 < t.size() && t[i + 2] == '(') {
     size_t p = i + 3;
     int depth = 2;
     size_t end = std::string::npos;
+    bool cmd_sub = false;
     for (; p < t.size(); p++) {
       if (t[p] == '(') depth++;
-      else if (t[p] == ')') { if (--depth == 0) { end = p; break; } }
+      else if (t[p] == ')') {
+        if (--depth == 0) { end = p; break; }
+        if (depth == 1 && !(p + 1 < t.size() && t[p + 1] == ')'))
+          cmd_sub = true;  // a top-level `)' not immediately closing the whole span
+      }
     }
+    if (cmd_sub) end = std::string::npos;  // fall through to the $(cmd) branch
     if (end != std::string::npos) {
       std::string expr = t.substr(i + 3, (end - 1) - (i + 3));
       bool ok = true;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -142,6 +142,7 @@ struct Lexer {
   }
   void scan_paren(std::string &w) {  // pos at '('
     int depth = 0;
+    std::vector<std::pair<std::string, bool>> paren_heredocs;  // delim, <<-
     // A `)' that terminates a `case' pattern (`case x in x)') must not be
     // mistaken for the substitution's closing paren.  Track the paren depth of
     // each active (command-position) `case' body; a `)' at that depth is a
@@ -184,11 +185,75 @@ struct Lexer {
           pos++;
         }
         cmd_pos = true;
+      } else if (c == '<' && pos + 1 < n && in[pos + 1] == '<' &&
+                 !(pos + 2 < n && in[pos + 2] == '<')) {
+        // A here-document inside the substitution: remember its delimiter so
+        // the body lines (which may contain `)') are skipped verbatim at the
+        // next newline.
+        bool strip_tabs = pos + 2 < n && in[pos + 2] == '-';
+        w += "<<";
+        pos += 2;
+        if (strip_tabs) { w += '-'; pos++; }
+        while (pos < n && (in[pos] == ' ' || in[pos] == '\t')) { w += in[pos]; pos++; }
+        std::string delim;
+        while (pos < n && !std::isspace(static_cast<unsigned char>(in[pos])) &&
+               !std::strchr(";&|()<>", in[pos])) {
+          char dc = in[pos];
+          if (dc == '\'' || dc == '"') {
+            char q = dc;
+            w += in[pos++];
+            while (pos < n && in[pos] != q) { delim += in[pos]; w += in[pos]; pos++; }
+            if (pos < n) { w += in[pos]; pos++; }
+            continue;
+          }
+          if (dc == '\\' && pos + 1 < n) { w += dc; pos++; dc = in[pos]; }
+          delim += dc;
+          w += dc;
+          pos++;
+        }
+        if (!delim.empty()) paren_heredocs.push_back({delim, strip_tabs});
+        saw_word = true;
+        word_plain = false;
       } else if (c == ';' || c == '&' || c == '|' || c == '\n') {
         boundary();
+        bool was_nl = c == '\n';
         w += c;
         pos++;
         cmd_pos = true;
+        if (was_nl && !paren_heredocs.empty()) {
+          // Copy each pending here-document body up to its delimiter line;
+          // nothing in it (parens, quotes, comments) is structural.
+          bool closing = false;
+          for (auto &hd : paren_heredocs) {
+            if (closing) break;
+            while (pos < n) {
+              size_t ls = pos;
+              while (pos < n && in[pos] != '\n') pos++;
+              std::string line = in.substr(ls, pos - ls);
+              bool had_nl = pos < n;
+              std::string cmp = line;
+              size_t tt = 0;
+              if (hd.second)
+                while (tt < cmp.size() && cmp[tt] == '\t') tt++;
+              cmp = cmp.substr(tt);
+              // `EOF)': the substitution's closer may abut the delimiter --
+              // consume the delimiter and resume at the `)' (bash warns and
+              // ends the here-document at the end of the span).
+              if (cmp.compare(0, hd.first.size(), hd.first) == 0 &&
+                  cmp.size() > hd.first.size() && cmp[hd.first.size()] == ')') {
+                w += line.substr(0, tt + hd.first.size());
+                pos = ls + tt + hd.first.size();
+                closing = true;
+                break;
+              }
+              w += line;
+              if (had_nl) { w += '\n'; pos++; }
+              if (cmp == hd.first) break;
+              if (!had_nl) break;
+            }
+          }
+          paren_heredocs.clear();
+        }
       } else if (c == ' ' || c == '\t') {
         boundary();
         w += c;
@@ -561,7 +626,19 @@ struct Lexer {
           cmp = cmp.substr(t);
           stored = cmp;
         }
-        if (cmp == pd.delim) { found = true; break; }  // terminator line
+        std::string want = pd.delim;
+        if (pd.strip) {  // `<<-' tab-strips the delimiter as well (`<<-'\tEND'')
+          std::size_t t = 0;
+          while (t < want.size() && want[t] == '\t') t++;
+          want = want.substr(t);
+        }
+        if (cmp == want) {
+          // A delimiter with no trailing newline (`...\nEOF' at the end of a
+          // command substitution) ends the body but bash still reports it as
+          // delimited by end-of-file.
+          if (had_nl) found = true;
+          break;
+        }
         body += stored;
         body += '\n';
         if (!had_nl) break;  // EOF before delimiter

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1849,6 +1849,10 @@ int Shell::run_script_lines(const std::string &text) {
       return;
     }
     lineno_base = pending_line - 1;
+    // bash reads file input with a guaranteed trailing newline; without it a
+    // here-document whose delimiter is the last line of the file would be
+    // (wrongly) reported as delimited by end-of-file.
+    if (pending.back() != '\n') pending += '\n';
     st = run_string(pending);
     lineno_base = 0;
     hist_cur_cmd_index = -1;


### PR DESCRIPTION
Fixes #422.

The comsub/heredoc scanning cluster — the `$((`-vs-`$( (` disambiguation (probe-derived depth rule), here-document bodies opaque to `$( )` span scanning in both lexer and expander, the `EOF)` abutting closer with bash's EOF-delimited warning, guaranteed trailing newline for file input, and `<<-` delimiter tab-stripping.

**Verification (full-suite sweep):** comsub-posix 91 → **41**, heredoc 57 → **41**, comsub-eof 21 → 20, array 55 → 53; nquote/precedence transients caught and fixed mid-batch (back to 0); 47 files byte-perfect; ctest 22/22; run_diff 240/240.