### PR TITLE
fix(glob): bracket-slash rule, literal dequoting, GLOBSORT, failglob

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -16,10 +16,12 @@
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <cwchar>
 #include <cwctype>
 #include <functional>
 #include <pwd.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <sys/wait.h>
 
@@ -2782,6 +2784,111 @@ static bool opens_bracket(const std::string &field, const std::string &mask, siz
   return false;
 }
 
+// $GLOBSORT (bash 5.3, pathexp.c setup_globsort): an optional leading `+'
+// (ignored) or `-' (reverse), then one of name/size/mtime/atime/ctime/blocks/
+// numeric/nosort.  Unset, empty, or an unrecognized keyword mean the default
+// name sort in ascending order (an unknown keyword also drops the `-').  Ties
+// under the stat-based sorts fall back to the name comparison, which itself
+// honors the reverse flag ("secondary sorting preserves reverse ordering").
+static void globsort_results(Shell &sh, std::vector<std::string> &v) {
+  enum SortType { S_NAME, S_SIZE, S_MTIME, S_ATIME, S_CTIME, S_BLOCKS, S_NUMERIC, S_NOSORT };
+  std::string spec = sh.get("GLOBSORT");
+  size_t p = 0;
+  while (p < spec.size() && (spec[p] == ' ' || spec[p] == '\t')) p++;
+  bool rev = false;
+  if (p < spec.size() && (spec[p] == '+' || spec[p] == '-')) rev = (spec[p++] == '-');
+  std::string t = spec.substr(p);
+  SortType type;
+  if (spec.empty()) type = S_NAME;                       // unset/empty: default
+  else if (t.empty()) type = S_NAME;                     // bare `+' / `-'
+  else if (t == "name") type = S_NAME;
+  else if (t == "size") type = S_SIZE;
+  else if (t == "mtime") type = S_MTIME;
+  else if (t == "atime") type = S_ATIME;
+  else if (t == "ctime") type = S_CTIME;
+  else if (t == "blocks") type = S_BLOCKS;
+  else if (t == "numeric") type = S_NUMERIC;
+  else if (t == "nosort") type = S_NOSORT;
+  else { type = S_NAME; rev = false; }                   // unknown: historical
+  if (type == S_NOSORT) return;
+  auto namecmp = [rev](const std::string &a, const std::string &b) {
+    return rev ? b.compare(a) : a.compare(b);
+  };
+  if (type == S_NAME) {
+    std::sort(v.begin(), v.end(),
+              [&](const std::string &a, const std::string &b) { return namecmp(a, b) < 0; });
+    return;
+  }
+  struct Ent {
+    std::string name;
+    bool statted;
+    struct stat st;
+  };
+  std::vector<Ent> ents(v.size());
+  for (size_t i = 0; i < v.size(); i++) {
+    ents[i].name = v[i];
+    ents[i].statted = stat(v[i].c_str(), &ents[i].st) == 0;
+    if (!ents[i].statted) std::memset(&ents[i].st, 0, sizeof(ents[i].st));
+  }
+#ifdef __APPLE__
+#define GN_ST_MTIM st_mtimespec
+#define GN_ST_ATIM st_atimespec
+#define GN_ST_CTIM st_ctimespec
+#else
+#define GN_ST_MTIM st_mtim
+#define GN_ST_ATIM st_atim
+#define GN_ST_CTIM st_ctim
+#endif
+  auto gencmp = [](long long a, long long b) { return (a > b) - (a < b); };
+  auto cmp = [&](const Ent &a, const Ent &b) {
+    int x = 0;
+    switch (type) {
+      case S_SIZE:
+        x = gencmp(a.st.st_size, b.st.st_size);
+        break;
+      case S_BLOCKS:
+        x = gencmp(a.st.st_blocks, b.st.st_blocks);
+        break;
+      case S_MTIME:
+      case S_ATIME:
+      case S_CTIME: {
+        struct timespec ta, tb;
+        if (type == S_MTIME) { ta = a.st.GN_ST_MTIM; tb = b.st.GN_ST_MTIM; }
+        else if (type == S_ATIME) { ta = a.st.GN_ST_ATIM; tb = b.st.GN_ST_ATIM; }
+        else { ta = a.st.GN_ST_CTIM; tb = b.st.GN_ST_CTIM; }
+        x = gencmp(ta.tv_sec, tb.tv_sec);
+        if (x == 0) x = gencmp(ta.tv_nsec, tb.tv_nsec);
+        break;
+      }
+      case S_NUMERIC: {
+        // Names that are all digits compare as numbers; a numeric name sorts
+        // before a non-numeric one; two non-numeric names compare as names
+        // (and that comparison needs no reverse-tiebreak special case).
+        auto num = [](const std::string &s, long long &out) {
+          if (s.empty()) return false;
+          for (char c : s)
+            if (c < '0' || c > '9') return false;
+          out = std::strtoll(s.c_str(), nullptr, 10);
+          return true;
+        };
+        long long ia = 0, ib = 0;
+        bool va = num(a.name, ia), vb = num(b.name, ib);
+        if (va && vb) x = gencmp(ia, ib);
+        else if (!va && !vb) return namecmp(a.name, b.name) < 0;
+        else x = va ? -1 : 1;
+        break;
+      }
+      default:
+        break;
+    }
+    if (rev) x = -x;
+    if (x != 0) return x < 0;
+    return namecmp(a.name, b.name) < 0;
+  };
+  std::sort(ents.begin(), ents.end(), cmp);
+  for (size_t i = 0; i < v.size(); i++) v[i] = std::move(ents[i].name);
+}
+
 std::vector<std::string> Expander::glob_field(const std::string &field, const std::string &mask) {
   // Build a glob pattern: unquoted metacharacters stay special, quoted ones are
   // backslash-escaped; also produce the literal (quotes already removed).
@@ -2865,6 +2972,7 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
     if (it != sh_.shopt_opts.end() && it->second) return {};  // nullglob: remove word
     return {field};  // default: keep the pattern literally
   }
+  globsort_results(sh_, matches);
   return matches;
 }
 

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2968,6 +2968,17 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
                   matches.end());
   }
   if (matches.empty()) {
+    // `shopt -s failglob': a pattern with no matches is an error that aborts
+    // the whole command (bash longjmps with DISCARD; status 1).  Only the
+    // first failing pattern reports -- bash never expands the rest.
+    auto fg = sh_.shopt_opts.find("failglob");
+    if (fg != sh_.shopt_opts.end() && fg->second) {
+      if (!sh_.arith_error) {
+        std::fprintf(stderr, "%sno match: %s\n", sh_.err_prefix().c_str(), field.c_str());
+        sh_.arith_error = true;
+      }
+      return {};
+    }
     auto it = sh_.shopt_opts.find("nullglob");
     if (it != sh_.shopt_opts.end() && it->second) return {};  // nullglob: remove word
     return {field};  // default: keep the pattern literally

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2773,8 +2773,12 @@ static bool opens_bracket(const std::string &field, const std::string &mask, siz
   size_t j = i + 1;
   if (j < field.size() && mask[j] != '1' && (field[j] == '!' || field[j] == '^')) j++;
   if (j < field.size() && mask[j] != '1' && field[j] == ']') j++;  // literal first `]'
-  for (; j < field.size(); j++)
+  for (; j < field.size(); j++) {
+    // Posix 2.13.3: an unquoted slash renders the bracket expression invalid,
+    // so `[qwe/qwe]' is not a pattern at all (a quoted `/' is fine).
+    if (mask[j] != '1' && field[j] == '/') return false;
     if (mask[j] != '1' && field[j] == ']') return true;
+  }
   return false;
 }
 
@@ -2790,6 +2794,20 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
   for (size_t i = 0; i < field.size(); i++) {
     char c = field[i];
     bool q = mask[i] == '1';
+    // A backslash in unquoted expansion data quotes the following character
+    // for the matcher, so neither it nor that character can make the word a
+    // pattern (bash unquoted_glob_pattern_p skips both): `var='a\?'; echo
+    // ${var}' is not a glob even with a file `a?' present.
+    if (!q && c == '\\') {
+      pattern += c;
+      if (i + 1 < field.size()) {
+        char n = field[++i];
+        if (mask[i] == '1' && (n == '*' || n == '?' || n == '[' || n == '\\' || n == ']'))
+          pattern += '\\';
+        pattern += n;
+      }
+      continue;
+    }
     if (!q && (c == '*' || c == '?' ||
                (c == '[' && opens_bracket(field, mask, i))))
       magic = true;

--- a/libglob/src/glob.cpp
+++ b/libglob/src/glob.cpp
@@ -54,6 +54,23 @@ bool has_magic(const std::string &s) {
   return false;
 }
 
+// Remove backslash quoting from a pattern component that will be used as a
+// literal pathname: `t\mp' names the directory `tmp', `tmp\' (a backslash
+// that quoted the following `/' before the pattern was split) names `tmp'.
+// bash dequotes every non-pattern component the same way (glob.c:glob_filename
+// via dequote_pathname).
+std::string dequote(const std::string &s) {
+  std::string out;
+  for (size_t i = 0; i < s.size(); i++) {
+    if (s[i] == '\\') {
+      if (i + 1 < s.size()) out += s[++i];
+      continue;  // a trailing backslash quotes nothing and disappears
+    }
+    out += s[i];
+  }
+  return out;
+}
+
 bool sm_match(const std::string &pat, const std::string &name, int smflags) {
   std::string p = pat, n = name;
   return strmatch(p.data(), n.data(), smflags) == 0;
@@ -179,7 +196,7 @@ void glob_recurse(const std::string &dir, const std::string &pat, int smflags, b
   }
 
   if (!has_magic(head)) {
-    std::string next = dir + head;
+    std::string next = dir + dequote(head);
     if (last) {
       if (path_exists(next)) results.push_back(next);
     } else if (is_dir(next)) {


### PR DESCRIPTION
Fixes #424.

glob.tests: 30 diff lines -> 2. Four fixes, one commit each:

- **Posix 2.13.3 bracket-slash rule + data-backslash pattern detection** (core/src/expand.cpp): an unquoted `/` inside `[...]` invalidates the bracket expression, so `[qwe/qwe]` is not a pattern and survives nullglob untouched (glob7.sub). A backslash in unquoted expansion data quotes the following character for the matcher, so `var='a\?'; echo ${var}` is not a glob even with a file `a?` present — mirroring bash's `unquoted_glob_pattern_p`, which skips both characters (glob4.sub).
- **Literal component dequoting** (libglob/src/glob.cpp): non-pattern components are dequoted before filesystem use, so `./tmp\/a/b/*` and `./t\mp/a/b/*` resolve to `./tmp/a/b/c`, and `*/\.` matches `searchable/.` (glob5.sub, glob6.sub).
- **GLOBSORT** (core/src/expand.cpp): results sort per `$GLOBSORT` — `[+-]?(name|size|mtime|atime|ctime|blocks|numeric|nosort)`, unknown keyword = name ascending with the reverse flag dropped, stat-sort ties break by name honoring reverse — mirroring pathexp.c `setup_globsort`/`globsort_sortarray` (glob11.sub).
- **failglob** (core/src/expand.cpp): a matchless pattern under `shopt -s failglob` reports `no match: PATTERN` once with the standard line prefix and aborts the whole command with status 1.

The 2 remaining glob.tests lines are glob2.sub's `$'\u3b1'` under `LC_ALL=zh_TW.big5`, which requires locale-aware ANSI-C `\u` encoding (Big5 bytes A3 5C rather than UTF-8) — a separate defect, filed next.

Verified: ctest 22/22; tests/harness/run_diff.sh all 240 match; full 83-suite sweep shows glob 30 -> 2 as the only change (47 suites byte-perfect, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)