### PR TITLE
fix(expand,lexer,read): locale-aware \u encoding and Big5-safe byte handling

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,6 +23,13 @@ target_link_libraries(gnash_core
   PUBLIC  gnash_common
   PRIVATE gnash::glob gnash::readline gnash::history gnash_warnings)
 
+# ANSI-C \u/\U escapes encode via iconv when the locale charset is not UTF-8.
+find_package(Iconv)
+if(Iconv_FOUND)
+  target_link_libraries(gnash_core PRIVATE Iconv::Iconv)
+  target_compile_definitions(gnash_core PRIVATE GNASH_HAVE_ICONV=1)
+endif()
+
 # gnash-parse: syntax-check / dump the AST (accept/reject like `bash -n`).
 add_executable(gnash-parse tools/gnash_parse.cpp)
 target_link_libraries(gnash-parse PRIVATE gnash::core)

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1870,12 +1870,35 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     }
     return cnt;
   };
+  // Bytes inside a multibyte character are data: in charsets like Big5 a
+  // trail byte can be `\' or the delimiter value, and must be neither escape
+  // nor terminator.  mb_pend buffers a character in progress; a byte that
+  // completes (or turns out not to start) a multibyte character resets it.
+  std::string mb_pend;
+  auto mb_data_byte = [&](char ch) -> bool {
+    if (MB_CUR_MAX <= 1) return false;
+    if (mb_pend.empty() && static_cast<unsigned char>(ch) < 0x80) return false;
+    mb_pend += ch;
+    wchar_t wc;
+    std::mbstate_t st{};
+    size_t r = std::mbrtowc(&wc, mb_pend.data(), mb_pend.size(), &st);
+    if (r == static_cast<size_t>(-2)) return true;  // incomplete: need more bytes
+    bool valid = r != static_cast<size_t>(-1) && mb_pend.size() > 1;
+    mb_pend.clear();
+    return valid;  // a completed multibyte trail byte is data; else reprocess
+  };
   if (!(have_n && nchars == 0)) {
     for (;;) {
       char ch;
       int r = read_byte(ch);
       if (r <= 0) { eof = (r == 0); timed_out = (r < 0); break; }
       if (ch == '\0' && delim != 0) continue;    // stray NULs are discarded
+      if (mb_data_byte(ch)) {
+        line += ch;
+        quoted += '\0';
+        if (have_n && mb_count(line) >= nchars) break;
+        continue;
+      }
       if (!raw && ch == '\\') {                  // backslash escaping (unless -r)
         char nx;
         int r2 = read_byte(nx);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -20,6 +20,10 @@
 #include <cwchar>
 #include <cwctype>
 #include <functional>
+#ifdef GNASH_HAVE_ICONV
+#include <iconv.h>
+#endif
+#include <langinfo.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -326,8 +330,53 @@ static std::string mb_case_fold(const std::string &val, const std::string &pat,
   return out;
 }
 
-// Encode a Unicode code point as UTF-8 (for \u / \U), matching bash's u32cconv.
+// Encode a Unicode code point for \u / \U, matching bash's u32cconv: in the
+// active LC_CTYPE locale's charset when it is not UTF-8 (Big5, EUC, ...), with
+// UTF-8 as both the common case and the can't-convert fallback.  wcrtomb is
+// no use here: on the BSDs (macOS included) wchar_t in a Big5 locale is the
+// zero-extended multibyte value, not a Unicode code point, so like bash we
+// convert the UTF-8 form with iconv.
+void append_utf8_raw(std::string &out, unsigned long v);
+
 void append_utf8(std::string &out, unsigned long v) {
+#ifdef GNASH_HAVE_ICONV
+  if (v > 0x7f) {
+    const char *cs = nl_langinfo(CODESET);
+    if (cs && *cs && std::strcmp(cs, "UTF-8") != 0) {
+      // Convert the UTF-8 form to the locale charset; an unknown charset
+      // falls back to ASCII (bash: "We assume ASCII when presented with an
+      // unknown encoding").  Only a failed iconv_open yields raw UTF-8; a
+      // conversion failure for this particular character yields the ISO C99
+      // escape text instead (bash u32tocesc: \uXXXX below 0x10000, \UXXXXXXXX
+      // above, uppercase hex).
+      iconv_t cd = iconv_open(cs, "UTF-8");
+      if (cd == reinterpret_cast<iconv_t>(-1)) cd = iconv_open("ASCII", "UTF-8");
+      if (cd != reinterpret_cast<iconv_t>(-1)) {
+        std::string u8;
+        append_utf8_raw(u8, v);
+        char inbuf[8], outbuf[25];
+        std::memcpy(inbuf, u8.data(), u8.size());
+        char *ip = inbuf, *op = outbuf;
+        size_t il = u8.size(), ol = sizeof(outbuf);
+        size_t r = iconv(cd, &ip, &il, &op, &ol);
+        iconv_close(cd);
+        if (r != static_cast<size_t>(-1) && il == 0) {
+          out.append(outbuf, sizeof(outbuf) - ol);
+        } else {
+          char esc[16];
+          std::snprintf(esc, sizeof(esc), v < 0x10000 ? "\\u%04lX" : "\\U%08lX", v);
+          out += esc;
+        }
+        return;
+      }
+    }
+  }
+#endif
+  append_utf8_raw(out, v);
+}
+
+// The plain UTF-8 encoding (also the fallback when iconv can't convert).
+void append_utf8_raw(std::string &out, unsigned long v) {
   if (v <= 0x7f) {
     out += static_cast<char>(v);
   } else if (v <= 0x7ff) {

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -7,6 +7,8 @@
 #include "gnash/core/subscript.hpp"
 
 #include <cctype>
+#include <cstdlib>
+#include <cwchar>
 
 namespace gnash::core {
 
@@ -428,12 +430,32 @@ struct Lexer {
            c == ';' || c == '(' || c == ')' || c == '<' || c == '>';
   }
 
+  // Bytes of the multibyte character starting at `pos' (1 for ASCII, invalid
+  // sequences, or single-byte locales).  In charsets like Big5 a trail byte
+  // can be `\' or a metacharacter value, so word scanning must consume a
+  // multibyte character atomically or the trail byte is misread as syntax.
+  std::size_t mb_len() const {
+    if (static_cast<unsigned char>(in[pos]) < 0x80 || MB_CUR_MAX <= 1) return 1;
+    wchar_t wc;
+    std::mbstate_t st{};
+    std::size_t r = std::mbrtowc(&wc, in.data() + pos, n - pos, &st);
+    return (r == static_cast<std::size_t>(-1) || r == static_cast<std::size_t>(-2) || r == 0)
+               ? 1
+               : r;
+  }
+
   Token read_word() {
     std::string w;
     bool quoted = false;
     while (pos < n) {
       char c = in[pos];
       if (c == ' ' || c == '\t' || c == '\n') break;
+      if (static_cast<unsigned char>(c) >= 0x80) {
+        std::size_t l = mb_len();
+        w.append(in, pos, l);
+        pos += l;
+        continue;
+      }
       if ((c == '<' || c == '>') && pos + 1 < n && in[pos + 1] == '(') {
         w += c;
         pos++;


### PR DESCRIPTION
Fixes #426.

glob.tests: 2 diff lines -> **0 (byte-perfect)**. Three commits:

- **fix(expand)**: `$'\u3b1'` now encodes via the active LC_CTYPE locale like bash's u32cconv — iconv from the UTF-8 form when the codeset is not UTF-8 (Big5 A3 5C), ASCII converter fallback for unknown charsets, ISO C99 escape text (`\u03B1` / `\U...`, uppercase hex) when the charset cannot represent the character, raw UTF-8 only when iconv_open fails entirely. wcrtomb cannot do this: BSD wchar_t in a Big5 locale is the zero-extended multibyte value, not Unicode. CMake links Iconv when found (`GNASH_HAVE_ICONV`).
- **fix(lexer)**: read_word consumes a valid multibyte character atomically, so a Big5 trail byte 0x5C is no longer misread as an escape (`[[ α = α ]]` under zh_TW.big5 failed with ``expected `]]'``).
- **fix(read)**: read without -r tracks a multibyte character in progress with mbrtowc; bytes inside it are data, never escapes or the delimiter (the Big5 trail 5C previously swallowed the following space and shifted all fields).

Verified against the bash 5.3.15 oracle byte-for-byte in zh_TW.big5, UTF-8, and C locales (C locale correctly yields the literal `\u03B1` text). ctest 22/22; run_diff.sh all 240 match; full 83-suite sweep shows glob 2 -> 0 as the only change, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
