### PR TITLE
fix(func): wait status, tempenv write-through, posix special-builtin rules (35 -> 2)

### DIFF
--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -24,6 +24,10 @@ bool command_is_valid(Shell &sh, const std::string &name);
 // slash resolves to itself when executable.
 std::string find_in_path(Shell &sh, const std::string &name);
 
+// True for the POSIX special builtins (break, return, set, ...): posix-mode
+// command lookup finds them before functions.
+bool is_special_builtin_name(const std::string &n);
+
 // Every command name beginning with PREFIX -- shell keywords, aliases,
 // functions, builtins, and executables on $PATH -- sorted and de-duplicated.
 // Used for command-position tab completion.

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -174,6 +174,12 @@ class Shell {
   // `local'/`declare' during the command (see executor apply_temp/undo_temp).
   std::map<std::string, std::optional<Variable>> temp_prior;
   std::set<std::string> temp_consumed;
+  // Per-name nesting count of active temporary bindings, and names whose value
+  // a posix special builtin persisted THROUGH an enclosing temporary binding:
+  // `var=30 func' where func runs `var=20 return' keeps 20 after the call (the
+  // outer undo skips the restore and consumes the mark).
+  std::map<std::string, int> temp_env_depth;
+  std::set<std::string> temp_persist;
   // Names currently bound by a `VAR=val cmd' temporary environment.  make_local
   // inherits such a variable's value/attributes when a called function localizes
   // it (`v=t f; f(){ local v; }' -> the local is `v=t', exported), matching bash.

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -671,17 +671,11 @@ static bool func_name_is_assignment(const std::string &s) {
 std::string named_function_string(const std::string &name, const Command *body,
                                   bool posix) {
   MPrinter p;
-  // bash prefixes `function ' to a name that is not a valid function name: in
-  // the default mode that means an assignment-shaped name (`a=2'); under posix
-  // it also covers all-digit names and non-identifiers.
+  // bash prefixes `function ' only to an assignment-shaped name (`a=2' would
+  // reparse as an assignment without it); an all-digit or otherwise funky name
+  // prints bare in BOTH modes (`11111 () ', even under posix).
+  (void)posix;
   bool prefix = func_name_is_assignment(name);
-  if (posix && !prefix) {
-    bool all_digits = !name.empty();
-    for (char c : name) if (!std::isdigit((unsigned char)c)) { all_digits = false; break; }
-    bool ident = !name.empty() && (std::isalpha((unsigned char)name[0]) || name[0] == '_');
-    for (char c : name) if (!std::isalnum((unsigned char)c) && c != '_') { ident = false; break; }
-    if (all_digits || !ident) prefix = true;
-  }
   p.out = (prefix ? "function " : "") + name + " () ";
   p.out += '\n';
   p.print_func_body(body, 0);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3015,6 +3015,12 @@ static bool is_special_builtin(const std::string &n) {
   return kSpecial.count(n) != 0;
 }
 
+}  // namespace (close anon: the executor's posix lookup order needs this)
+
+bool is_special_builtin_name(const std::string &n) { return is_special_builtin(n); }
+
+namespace {  // reopen the anonymous namespace
+
 int bi_type(Shell &sh, const std::vector<std::string> &argv) {
   bool ft = false, fp = false, fP = false, fa = false, ff = false;
   size_t i = 1;
@@ -3067,8 +3073,13 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
     if (is_reserved_word(n)) locs.push_back({'k', {}});
     if (!ff && sh.functions.count(n)) locs.push_back({'f', {}});
     // A builtin disabled with `enable -n' is invisible to type: lookup falls
-    // through to the $PATH files (bash).
-    if (is_builtin_name(n) && !sh.disabled_builtins.count(n)) locs.push_back({'b', {}});
+    // through to the $PATH files (bash).  In posix mode a SPECIAL builtin is
+    // found before any function of the same name (posix command search order).
+    bool have_b = is_builtin_name(n) && !sh.disabled_builtins.count(n);
+    if (have_b && sh.opt_posix && is_special_builtin(n))
+      locs.insert(locs.end() - ((!ff && sh.functions.count(n)) ? 1 : 0), {'b', {}});
+    else if (have_b)
+      locs.push_back({'b', {}});
     for (const std::string &f : find_all_in_path(sh, n)) locs.push_back({'F', f});
 
     if (locs.empty()) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2260,7 +2260,12 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         bool ro = sh.readonly_functions.count(kv.first) > 0;
         if (readonly && !ro) continue;  // `-r' lists only readonly functions
         if (funcnames) std::printf("declare -f%s %s\n", ro ? "r" : "", kv.first.c_str());
-        else std::printf("%s\n", named_function_string(kv.first, kv.second, sh.opt_posix).c_str());
+        else {
+          std::printf("%s\n", named_function_string(kv.first, kv.second, sh.opt_posix).c_str());
+          // The `readonly -f' listing follows each body with the reusable
+          // attribute line (`declare -fr NAME'), unlike plain `declare -f'.
+          if (readonly) std::printf("declare -fr %s\n", kv.first.c_str());
+        }
       }
       return 0;
     }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1569,21 +1569,27 @@ int Executor::run_simple(const SimpleCommand *c) {
         if (argv[k].find('x') != std::string::npos ||
             argv[k].find('r') != std::string::npos) { persist = true; break; }
     }
+    bool special_persist = false;
     if (!persist && sh_.opt_posix) {
       static const std::set<std::string> kSpecial = {
           ":",      ".",     "break", "continue", "eval",  "exec",
           "exit",   "export", "readonly", "return", "set", "shift",
           "source", "times", "trap",  "unset"};
-      if (kSpecial.count(argv[0])) persist = true;
+      if (kSpecial.count(argv[0])) persist = special_persist = true;
     }
     if (persist) {
-      // A name also bound by an ENCLOSING temporary environment (depth >= 2:
-      // ours plus at least one outer) persists through it -- mark it so the
-      // outer undo keeps the value this builtin set.
-      for (const auto &a : assigns) {
-        auto d = sh_.temp_env_depth.find(a.first);
-        if (d != sh_.temp_env_depth.end() && d->second >= 2) sh_.temp_persist.insert(a.first);
-      }
+      // Under the POSIX-special rule only: a name also bound by an ENCLOSING
+      // temporary environment (depth >= 2: ours plus at least one outer)
+      // persists through it -- mark it so the outer undo keeps the value this
+      // builtin set (`var=30 func' + `var=20 return').  The export/readonly
+      // promotion path must NOT punch through: default-mode `a=7 f1' where f1
+      // runs `a=3 readonly a' restores the caller's a (and its attributes)
+      // at return (varenv23.sub).
+      if (special_persist)
+        for (const auto &a : assigns) {
+          auto d = sh_.temp_env_depth.find(a.first);
+          if (d != sh_.temp_env_depth.end() && d->second >= 2) sh_.temp_persist.insert(a.first);
+        }
       restore.clear();
     }
     undo_temp();

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1391,6 +1391,7 @@ int Executor::run_simple(const SimpleCommand *c) {
   auto apply_temp = [&]() {
     for (const auto &a : assigns) {
       sh_.temp_env_active.insert(a.first);  // let a called function's `local' inherit it
+      sh_.temp_env_depth[a.first]++;
       auto it = sh_.vars.find(a.first);
       restore.push_back({a.first,
                          it == sh_.vars.end() ? std::nullopt : std::optional<Variable>(it->second)});
@@ -1417,6 +1418,12 @@ int Executor::run_simple(const SimpleCommand *c) {
   auto undo_temp = [&]() {
     for (auto it = restore.rbegin(); it != restore.rend(); ++it) {
       if (sh_.temp_consumed.count(it->first)) continue;  // localized: frame owns it
+      // A posix special builtin persisted this binding through us: keep the
+      // value it set and consume the mark (`var=30 func' + `var=20 return').
+      if (sh_.temp_persist.count(it->first)) {
+        sh_.temp_persist.erase(it->first);
+        continue;
+      }
       if (it->second) sh_.vars[it->first] = *it->second;
       else sh_.vars.erase(it->first);
     }
@@ -1425,6 +1432,8 @@ int Executor::run_simple(const SimpleCommand *c) {
       sh_.temp_env_active.erase(a.first);
       sh_.temp_prior.erase(a.first);
       sh_.temp_consumed.erase(a.first);
+      auto d = sh_.temp_env_depth.find(a.first);
+      if (d != sh_.temp_env_depth.end() && --d->second <= 0) sh_.temp_env_depth.erase(d);
     }
   };
 
@@ -1562,7 +1571,16 @@ int Executor::run_simple(const SimpleCommand *c) {
           "source", "times", "trap",  "unset"};
       if (kSpecial.count(argv[0])) persist = true;
     }
-    if (persist) restore.clear();
+    if (persist) {
+      // A name also bound by an ENCLOSING temporary environment (depth >= 2:
+      // ours plus at least one outer) persists through it -- mark it so the
+      // outer undo keeps the value this builtin set.
+      for (const auto &a : assigns) {
+        auto d = sh_.temp_env_depth.find(a.first);
+        if (d != sh_.temp_env_depth.end() && d->second >= 2) sh_.temp_persist.insert(a.first);
+      }
+      restore.clear();
+    }
     undo_temp();
     // A builtin that performs an internal assignment (e.g. `declare -i a[$bad]=x'
     // under array_expand_once) can raise the arithmetic-error flag from deep in

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1370,6 +1370,11 @@ int Executor::run_simple(const SimpleCommand *c) {
   // Builtins and functions run in-process (with redirects applied/restored).
   auto fit = sh_.functions.find(argv[0]);
   bool is_func = !skip_functions && fit != sh_.functions.end();
+  // Posix command search order finds special builtins BEFORE functions: with
+  // a `break' function defined, posix-mode `break' runs the builtin.
+  if (is_func && sh_.opt_posix && is_special_builtin_name(argv[0]) &&
+      !sh_.disabled_builtins.count(argv[0]))
+    is_func = false;
   int dummy = 0;
   bool builtin = false;
   {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -2215,10 +2215,28 @@ int Executor::run_funcdef(const FunctionDef *c) {
   // bash rejects a function name that contained an unquoted `$' expansion
   // (W_HASDOLLAR) -- e.g. `function sys$read' -- or any quoting (`'a b c' ()')
   // as not a valid identifier; the raw word, quotes included, is echoed.
-  if (c->name.find_first_of("$'\"\\") != std::string::npos) {
+  if (c->name.find_first_of("$'\"\\") != std::string::npos ||
+      // A process-substitution-shaped name (`<(:) ()') is likewise rejected.
+      ((c->name[0] == '<' || c->name[0] == '>') && c->name.size() > 1 && c->name[1] == '(')) {
     std::fprintf(stderr, "%s`%s': not a valid identifier\n",
                  sh_.err_prefix().c_str(), c->name.c_str());
     return (sh_.last_status = 1);
+  }
+  // Posix interpretation 383: a function may not have the name of a special
+  // builtin.  bash reports it and aborts a non-interactive shell outright
+  // (jump_to_top_level(ERREXIT) with EX_BADUSAGE).
+  if (sh_.opt_posix) {
+    static const std::set<std::string> kSpecialB = {
+        ":",      ".",     "break", "continue", "eval",  "exec",
+        "exit",   "export", "readonly", "return", "set", "shift",
+        "source", "times", "trap",  "unset"};
+    if (kSpecialB.count(c->name)) {
+      std::fprintf(stderr, "%s`%s': is a special builtin\n", sh_.err_prefix().c_str(),
+                   c->name.c_str());
+      sh_.last_status = 2;
+      if (!sh_.interactive) { sh_.exiting = true; sh_.exit_status = 2; }
+      return 2;
+    }
   }
   // A readonly function cannot be redefined.
   if (sh_.readonly_functions.count(c->name)) {

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -313,7 +313,6 @@ int Shell::wait_next(const std::vector<int> &ids, long *finished_pid, bool *foun
 }
 
 int Shell::wait_all() {
-  int st = 0;
   // Block until every background job has terminated, reaping whichever child
   // changes state first (not job-by-job in order, so one job finishing early
   // is observed immediately).  A trapped signal interrupts the wait: bash's
@@ -354,7 +353,6 @@ int Shell::wait_all() {
       owner->done = true;
       owner->running = false;
       owner->status = rc;
-      st = rc;
     }
   }
   int wst;
@@ -362,7 +360,9 @@ int Shell::wait_all() {
   end_interruptible_wait();
   // bash's `wait' with no operands removes every terminated job it reaped.
   remove_jobs_if([](const Job &j) { return j.done; });
-  return st;
+  // `wait' with no operands always returns 0 (`f1 & wait' is 0 even though
+  // f1 exited 5); only a trap interruption above returns 128+signal.
+  return 0;
 }
 
 // Reap any finished/stopped children (non-blocking) and update the job table.


### PR DESCRIPTION
Fixes #430.

func.tests: 35 diff lines -> **2**. Seven commits:

- **fix(wait)**: no-operand `wait` returns 0 after reaping, not the last job's status.
- **fix(executor)**: posix-mode `var=30 func` where func runs `var=20 return 5` keeps var=20 after the call — the special builtin's prefix assignment writes through the enclosing call tempenv (per-name tempenv nesting depth + a persist mark the outer undo consumes). Oracle-verified matrix including the different-name nested case.
- **fix(funcdef)**: `<(:) ()` fails at execution with `not a valid identifier`; posix-mode definition of a special-builtin-named function (`break()`) reports `` `break': is a special builtin `` and exits a non-interactive shell with status 2.
- **fix(posix)**: special builtins precede functions in command lookup — posix-mode `break` runs the builtin with a `break` function defined; `type`/`type -t`/`type -a` report accordingly (special builtin first in posix; function first with the plain builtin line after in default mode).
- **fix(ast)**: all-digit function names print bare (`11111 () `) in both modes; only assignment-shaped names get the `function ` keyword (oracle-verified).
- **fix(readonly)**: the `readonly -f` listing appends `declare -fr NAME` after each body.

The 2 remaining lines are a line-number attribution difference (`line 92` vs bash's `line 94`) on the posix special-builtin error when the definition sits inside a subshell — same error, same semantics; deferred with the error-text batch for final review.

Verified: func5.sub otherwise diff-clean against the oracle; ctest 22/22; run_diff.sh all 240 match; full sweep shows func 35 -> 2 as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
