### PR TITLE
feat(assoc,vars): bash hash-order enumeration, allexport, localvar_unset (varenv -> 0)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -33,6 +33,11 @@ struct Variable {
   std::map<std::string, std::string> assoc;    // associative array
   std::vector<std::string> assoc_seq;          // assoc key insertion order (for
                                                // bash-compatible hash iteration)
+  // Simulated bash hash-table size: fresh `declare -A' tables have 1024
+  // buckets (ASSOC_HASH_BUCKETS); a scalar CONVERTED to an associative array
+  // gets 128 (convert_var_to_assoc -> assoc_create(0)), so the same keys
+  // enumerate differently (varenv11.sub relies on both).
+  unsigned assoc_buckets = 1024;
   bool exported = false;
   bool readonly = false;
   bool integer = false;
@@ -102,6 +107,10 @@ class Shell {
   // and within a bucket newest-first), so `${a[@]}' etc. match bash byte for
   // byte.  Public so `declare -p' can print in the same order.
   static std::vector<std::string> assoc_order(const Variable &v);
+  // bash hash-table enumeration order for KEYS given in insertion order:
+  // buckets 0..n-1, newest-first within a bucket (hashlib.c layout).
+  static std::vector<std::string> bash_hash_order(const std::vector<std::string> &insertion,
+                                                  unsigned buckets);
   std::string array_get(const std::string &n, const std::string &sub) const;
   // True when the array element NAME[sub] currently exists (is set), as opposed
   // to array_get returning "" for both an unset element and one set to "".  Used
@@ -188,9 +197,25 @@ class Shell {
   // --- shell state for builtins -----------------------------------------
   bool login_shell = false;                  // logout only works in a login shell
   std::map<std::string, std::string> hashed;  // `hash': command name -> full path
+  std::vector<std::string> hashed_seq;        // insertion order (bash hash-walk)
   std::map<std::string, bool> shopt_opts;     // `shopt' option states
   std::set<std::string> disabled_builtins;    // `enable -n': builtins turned off
   std::map<std::string, std::string> aliases;  // `alias': name -> expansion
+  std::vector<std::string> alias_seq;          // insertion order (bash hash-walk)
+  // Remember a command path / alias, recording first-insertion order: bash
+  // walks its hash tables bucket-by-bucket, so `hash', BASH_CMDS, and
+  // BASH_ALIASES enumerate in the simulated table order (256 / 64 buckets).
+  void hash_remember(const std::string &name, const std::string &path) {
+    if (!hashed.count(name)) hashed_seq.push_back(name);
+    hashed[name] = path;
+  }
+  void alias_remember(const std::string &name, const std::string &val) {
+    if (!aliases.count(name)) alias_seq.push_back(name);
+    aliases[name] = val;
+  }
+  // Live keys of the hash/alias tables in bash enumeration order.
+  std::vector<std::string> hashed_order() const;
+  std::vector<std::string> aliases_order() const;
   std::map<std::string, std::string> global_aliases;  // zsh `alias -g': expand anywhere
   std::map<std::string, std::string> suffix_aliases;  // zsh `alias -s ext=cmd'
   std::map<std::string, std::string> completions;  // `complete': name -> spec string

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -417,6 +417,7 @@ class Shell {
   bool opt_noexec = false;    // -n: read/parse commands but don't execute them
   bool opt_pipefail = false;  // -o pipefail: pipeline status = last non-zero stage
   bool opt_noclobber = false; // -C / -o noclobber: `>' won't overwrite an existing file
+  bool opt_allexport = false; // -a / -o allexport: every assignment marks the var exported
   bool opt_functrace = false; // -T / -o functrace: DEBUG/RETURN traps inherited
   bool opt_history = false;     // -o history: record command lines in the history
   bool opt_histexpand = false;  // -H / -o histexpand: `!' history expansion

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2519,7 +2519,12 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             std::fprintf(stderr, "%s%s: cannot convert %s array\n", pfx.c_str(),
                          name.c_str(), cvt_dir);
           } else {
-            if (global)
+            // The function-name line also appears when a localvar_inherit'd
+            // (or -I'd) local copied the mismatched enclosing array AND the
+            // word carries an assignment: `declare -A var+=(...)' reports the
+            // failed make-local conversion first, a bare `declare -A var'
+            // only the builtin's own line (varenv14.sub lines 31 vs 77).
+            if (global || (inherited_local && eq != std::string::npos))
               std::fprintf(stderr, "%s%s: %s: cannot convert %s array\n", pfx.c_str(),
                            funcname.c_str(), name.c_str(), cvt_dir);
             std::fprintf(stderr, "%s%s: %s: cannot convert %s array\n", pfx.c_str(),

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4110,7 +4110,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
     bool consumed = false;
     for (size_t k = 1; k < a.size(); k++) {
       char o = a[k];
-      if (o == 'r') { sh.hashed.clear(); expunge = true; }
+      if (o == 'r') { sh.hashed.clear(); sh.hashed_seq.clear(); expunge = true; }
       else if (o == 'l') list_l = true;
       else if (o == 'd') del_d = true;
       else if (o == 't') print_t = true;
@@ -4153,7 +4153,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
                    ppath.c_str());
       return 1;
     }
-    sh.hashed[argv[i]] = ppath;
+    sh.hash_remember(argv[i], ppath);
     return 0;
   }
   if (i >= argv.size()) {
@@ -4162,12 +4162,13 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
       if (!list_l) std::printf("hash: hash table empty\n");
       return 0;
     }
+    // Both listings walk the hash table in bash's bucket order, not sorted.
     if (list_l)
-      for (const auto &kv : sh.hashed)
-        std::printf("builtin hash -p %s %s\n", kv.second.c_str(), kv.first.c_str());
+      for (const auto &k : sh.hashed_order())
+        std::printf("builtin hash -p %s %s\n", sh.hashed.at(k).c_str(), k.c_str());
     else {
       std::printf("hits\tcommand\n");
-      for (const auto &kv : sh.hashed) std::printf("%4d\t%s\n", 0, kv.second.c_str());
+      for (const auto &k : sh.hashed_order()) std::printf("%4d\t%s\n", 0, sh.hashed.at(k).c_str());
     }
     return 0;
   }
@@ -4193,7 +4194,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
     }
     std::string p = find_in_path(sh, n);
     if (p.empty()) { std::fflush(stdout); std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str()); st = 1; }
-    else sh.hashed[n] = p;
+    else sh.hash_remember(n, p);
   }
   return st;
 }
@@ -4621,7 +4622,8 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
         st = 1;
         continue;
       }
-      table[name] = a.substr(eq + 1);
+      if (kind == 0) sh.alias_remember(name, a.substr(eq + 1));
+      else table[name] = a.substr(eq + 1);
     }
   }
   return st;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1547,7 +1547,8 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   else if (o == "ignoreeof") { if (on) sh.set("IGNOREEOF", "10"); else sh.unset("IGNOREEOF"); }
   // Valid bash `set -o' names whose behavior is unimplemented: accept as no-ops
   // (a script may set them; erroring would diverge from bash, which knows them).
-  else if (o == "allexport" || o == "braceexpand" ||
+  else if (o == "allexport") sh.opt_allexport = on;
+  else if (o == "braceexpand" ||
            o == "interactive-comments" || o == "nolog" ||
            o == "notify" || o == "onecmd")
     ;  // no-op
@@ -1563,7 +1564,7 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
 std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
   bool i = sh.interactive;
   return {
-      {"allexport", false},   {"braceexpand", true},
+      {"allexport", sh.opt_allexport},   {"braceexpand", true},
       {"emacs", i ? (rl_editing_mode == 1) : sh.opt_emacs},
       {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
@@ -1659,7 +1660,8 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'h': sh.opt_hashall = on; break;  // -h/+h: hashall
           // Flags accepted as no-ops where the behavior is unimplemented:
           // allexport/notify/onecmd/braceexpand.
-          case 'a': case 'b': case 't': case 'B': break;
+          case 'a': sh.opt_allexport = on; break;  // allexport: assignments export
+          case 'b': case 't': case 'B': break;
           default:
             std::fprintf(stderr, "%sset: %c%c: invalid option\n", sh.err_prefix().c_str(),
                          a[0], a[k]);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2183,6 +2183,18 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       } else {
         // `declare -p' with attribute flags (`-pa', `-pi', `-pr', ...) lists
         // only the variables carrying those attributes, not every variable.
+        // SHELLOPTS is a real readonly variable in bash's table; gnash keeps
+        // it dynamic, so a readonly listing splices it in at its sorted spot
+        // (`readonly -p | grep SHELLOPTS').
+        bool need_shellopts = readonly && !nameref && !integer && !exported && !mk_array &&
+                              !mk_assoc && !lcase && !ucase && !capcase && !sh.is_zsh();
+        auto emit_shellopts = [&]() {
+          if (!need_shellopts) return;
+          std::string sv;
+          if (sh.dynamic_var("SHELLOPTS", sv))
+            std::printf("declare -r SHELLOPTS=\"%s\"\n", sv.c_str());
+          need_shellopts = false;
+        };
         for (const auto &kv : sh.vars) {
           const std::string &nm = kv.first;
           if (nm.empty() || !(std::isalpha(static_cast<unsigned char>(nm[0])) || nm[0] == '_'))
@@ -2197,8 +2209,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           if (lcase && !v.lcase) continue;
           if (ucase && !v.ucase) continue;
           if (capcase && !v.capcase) continue;
+          if (need_shellopts && nm > "SHELLOPTS") emit_shellopts();
           declare_print_var(kv.first, v, argv[0], sh.opt_posix);
         }
+        emit_shellopts();
       }
     } else {
       // `local -p NAME' reports only variables local to the CURRENT function
@@ -2302,6 +2316,18 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   if (i >= argv.size() &&
       (nameref || readonly || integer || exported || mk_array || mk_assoc ||
        lcase || ucase || capcase)) {
+    // SHELLOPTS is a real readonly variable in bash's table; gnash keeps it
+    // dynamic, so a readonly listing must splice it in at its sorted spot
+    // (`readonly -p | grep SHELLOPTS' -- varenv.tests).
+    bool need_shellopts = readonly && !nameref && !integer && !exported && !mk_array &&
+                          !mk_assoc && !lcase && !ucase && !capcase && !sh.is_zsh();
+    auto emit_shellopts = [&]() {
+      if (!need_shellopts) return;
+      std::string sv;
+      if (sh.dynamic_var("SHELLOPTS", sv))
+        std::printf("declare -r SHELLOPTS=\"%s\"\n", sv.c_str());
+      need_shellopts = false;
+    };
     for (const auto &kv : sh.vars) {
       const std::string &nm = kv.first;
       if (nm.empty() || !(std::isalpha(static_cast<unsigned char>(nm[0])) || nm[0] == '_'))
@@ -2316,7 +2342,29 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       if (lcase && !v.lcase) continue;
       if (ucase && !v.ucase) continue;
       if (capcase && !v.capcase) continue;
+      if (need_shellopts && nm > "SHELLOPTS") emit_shellopts();
       declare_print_var(kv.first, v, argv[0], sh.opt_posix);
+    }
+    emit_shellopts();
+    return 0;
+  }
+
+  // Bare `local' inside a function lists the current scope's local variables
+  // in declare form (`declare -a avar=(...)', `declare -- z="yy"'), sorted.
+  if (local && !global && i >= argv.size()) {
+    if (!sh.local_stack.empty()) {
+      std::vector<std::string> names;
+      for (const auto &e : sh.local_stack.back()) {
+        const std::string &nm = e.first;
+        if (nm.empty() || !(std::isalpha(static_cast<unsigned char>(nm[0])) || nm[0] == '_'))
+          continue;  // skip the `-' set -o snapshot and other markers
+        if (std::find(names.begin(), names.end(), nm) == names.end()) names.push_back(nm);
+      }
+      std::sort(names.begin(), names.end());
+      for (const auto &nm : names) {
+        auto vit = sh.vars.find(nm);
+        if (vit != sh.vars.end()) declare_print_var(nm, vit->second, "declare", sh.opt_posix);
+      }
     }
     return 0;
   }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1570,11 +1570,14 @@ int Executor::run_simple(const SimpleCommand *c) {
             argv[k].find('r') != std::string::npos) { persist = true; break; }
     }
     bool special_persist = false;
-    if (!persist && sh_.opt_posix) {
+    if (sh_.opt_posix) {
       static const std::set<std::string> kSpecial = {
           ":",      ".",     "break", "continue", "eval",  "exec",
           "exit",   "export", "readonly", "return", "set", "shift",
           "source", "times", "trap",  "unset"};
+      // In posix mode export/readonly write through an enclosing tempenv TOO
+      // (they are special builtins); in default mode their promotion stays
+      // within the current command's scope.
       if (kSpecial.count(argv[0])) persist = special_persist = true;
     }
     if (persist) {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1619,7 +1619,7 @@ int Executor::run_simple(const SimpleCommand *c) {
           std::string fresh = find_in_path(sh_, argv[0]);
           if (!fresh.empty()) {
             exec_file = fresh;
-            sh_.hashed[argv[0]] = fresh;
+            sh_.hash_remember(argv[0], fresh);
           }
         }
       }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1500,6 +1500,18 @@ void Shell::unset(const std::string &n_in, bool force, bool noref) {
       for (auto fit = std::next(local_stack.rbegin()); fit != local_stack.rend(); ++fit) {
         for (auto e = fit->begin(); e != fit->end(); ++e) {
           if (e->first != n) continue;
+          // `shopt -s localvar_unset': treat the enclosing scope's local as
+          // if unset THERE (ash semantics, varenv24.sub) -- it stays a local,
+          // now-unset binding until its frame returns -- instead of popping
+          // the cell to expose what lies beneath.
+          auto lvu = shopt_opts.find("localvar_unset");
+          if (lvu != shopt_opts.end() && lvu->second) {
+            Variable v;
+            v.invisible = true;
+            v.exported = it->second.exported;
+            vars[n] = v;
+            return;
+          }
           if (e->second) vars[n] = *e->second;
           else vars.erase(n);
           fit->erase(e);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -201,11 +201,11 @@ std::vector<std::string> Shell::bash_argv_view() const {
 bool Shell::virtual_array(const std::string &name,
                           std::vector<std::pair<std::string, std::string>> &pairs) const {
   if (name == "BASH_ALIASES") {
-    for (const auto &kv : aliases) pairs.emplace_back(kv.first, kv.second);
+    for (const auto &k : aliases_order()) pairs.emplace_back(k, aliases.at(k));
     return true;
   }
   if (name == "BASH_CMDS") {
-    for (const auto &kv : hashed) pairs.emplace_back(kv.first, kv.second);
+    for (const auto &k : hashed_order()) pairs.emplace_back(k, hashed.at(k));
     return true;
   }
   if (name == "DIRSTACK") {
@@ -575,31 +575,59 @@ static void assoc_put(Variable &v, const std::string &key, const std::string &va
 // Order an associative array's keys the way bash walks its hash table: by
 // bucket index (hash & (nbuckets-1)), then, within a bucket, newest key first
 // (bash prepends on insert).  Associative arrays use ASSOC_HASH_BUCKETS=1024.
-std::vector<std::string> Shell::assoc_order(const Variable &v) {
-  const unsigned kBuckets = 1024;
-  std::vector<std::string> keys;
-  keys.reserve(v.assoc.size());
-  // Insertion order: keys recorded in assoc_seq, then any stragglers not yet
-  // tracked (defensive, so a missed seq update never drops a key).
-  std::vector<const std::string *> ins;
-  for (const auto &k : v.assoc_seq)
-    if (v.assoc.count(k)) ins.push_back(&k);
-  for (const auto &kv : v.assoc) {
-    bool seen = false;
-    for (const auto *p : ins) if (*p == kv.first) { seen = true; break; }
-    if (!seen) ins.push_back(&kv.first);
-  }
+std::vector<std::string> Shell::bash_hash_order(const std::vector<std::string> &insertion,
+                                                unsigned buckets) {
   struct E { unsigned bucket; size_t seq; const std::string *key; };
   std::vector<E> es;
-  es.reserve(ins.size());
-  for (size_t s = 0; s < ins.size(); s++)
-    es.push_back({assoc_hash_string(*ins[s]) & (kBuckets - 1), s, ins[s]});
+  es.reserve(insertion.size());
+  for (size_t s = 0; s < insertion.size(); s++)
+    es.push_back({assoc_hash_string(insertion[s]) & (buckets - 1), s, &insertion[s]});
   std::stable_sort(es.begin(), es.end(), [](const E &a, const E &b) {
     if (a.bucket != b.bucket) return a.bucket < b.bucket;
     return a.seq > b.seq;  // newest-first within a bucket
   });
+  std::vector<std::string> keys;
+  keys.reserve(es.size());
   for (const auto &e : es) keys.push_back(*e.key);
   return keys;
+}
+
+// Enumeration order of a name->value table given its recorded insertion
+// sequence: stale seq entries (erased names) are skipped, untracked names
+// (defensive) appended, then bash's bucket layout applied.
+static std::vector<std::string> table_order(const std::map<std::string, std::string> &table,
+                                            const std::vector<std::string> &seq,
+                                            unsigned buckets) {
+  std::vector<std::string> ins;
+  ins.reserve(table.size());
+  for (const auto &k : seq)
+    if (table.count(k)) ins.push_back(k);
+  for (const auto &kv : table) {
+    bool seen = false;
+    for (const auto &p : ins) if (p == kv.first) { seen = true; break; }
+    if (!seen) ins.push_back(kv.first);
+  }
+  return Shell::bash_hash_order(ins, buckets);
+}
+
+// bash's hashed-command table has 256 buckets (FILENAME_HASH_BUCKETS), the
+// alias table 64 (ALIAS_HASH_BUCKETS).
+std::vector<std::string> Shell::hashed_order() const { return table_order(hashed, hashed_seq, 256); }
+std::vector<std::string> Shell::aliases_order() const { return table_order(aliases, alias_seq, 64); }
+
+std::vector<std::string> Shell::assoc_order(const Variable &v) {
+  // Insertion order: keys recorded in assoc_seq, then any stragglers not yet
+  // tracked (defensive, so a missed seq update never drops a key).
+  std::vector<std::string> ins;
+  ins.reserve(v.assoc.size());
+  for (const auto &k : v.assoc_seq)
+    if (v.assoc.count(k)) ins.push_back(k);
+  for (const auto &kv : v.assoc) {
+    bool seen = false;
+    for (const auto &p : ins) if (p == kv.first) { seen = true; break; }
+    if (!seen) ins.push_back(kv.first);
+  }
+  return bash_hash_order(ins, v.assoc_buckets);
 }
 
 std::vector<std::string> Shell::array_values(const std::string &n_in) const {
@@ -725,7 +753,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
       std::fprintf(stderr, "%s`%s': invalid alias name\n", err_prefix().c_str(), sub.c_str());
       return;
     }
-    aliases[sub] = val;
+    alias_remember(sub, val);
     return;
   }
   // BASH_CMDS is the live command hash: BASH_CMDS[name]=value adds a hash
@@ -737,7 +765,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
         std::fprintf(stderr, "%s%s: restricted\n", err_prefix().c_str(), val.c_str());
         return;
       }
-      hashed[sub] = val;
+      hash_remember(sub, val);
       return;
     }
     std::string path = get("PATH"), full;
@@ -755,7 +783,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
       std::fprintf(stderr, "%s%s: not found\n", err_prefix().c_str(), val.c_str());
       return;
     }
-    hashed[sub] = full;
+    hash_remember(sub, full);
     return;
   }
   // DIRSTACK is the live directory stack: DIRSTACK[N]=dir rewrites a stack entry
@@ -922,6 +950,17 @@ void Shell::make_array(const std::string &n_in, bool assoc) {
       v.idx[0] = v.value;
       v.value.clear();
     }
+    // Converting to an associative array keeps the old value under the string
+    // key "0" (bash convert_var_to_assoc), and the converted table simulates
+    // bash's 128-bucket layout (assoc_create(0)) -- only a fresh `declare -A'
+    // gets the 1024-bucket ASSOC_HASH_BUCKETS one, so the same keys can
+    // enumerate differently (varenv11.sub).
+    if (assoc && !v.value.empty()) {
+      v.assoc_seq.push_back("0");
+      v.assoc["0"] = v.value;
+      v.value.clear();
+    }
+    if (assoc && !fresh) v.assoc_buckets = 128;
     v.kind = assoc ? VarKind::Assoc : VarKind::Indexed;
   }
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1533,21 +1533,28 @@ std::string Shell::ifs() const {
 std::vector<std::string> Shell::environ_block() const {
   std::vector<std::string> out;
   for (const auto &kv : vars) {
-    if (!kv.second.exported) continue;
     std::string val = kv.second.value;
-    // An INVISIBLE exported local (`export V=abc; f(){ local V; }') passes
-    // the SHADOWED value to children until the local is assigned (bash).
+    bool emit = kv.second.exported;
+    // An INVISIBLE local passes the SHADOWED exported value to children until
+    // it is assigned (bash): `export V=abc; f(){ local V; }' keeps V=abc in
+    // the environment, and so does `typeset +x V' (an unexported invisible
+    // local does not block the exported global underneath -- varenv12.sub).
     if (kv.second.invisible) {
       bool found = false;
       for (auto fit = local_stack.rbegin(); fit != local_stack.rend() && !found; ++fit)
         for (const auto &e : *fit)
           if (e.first == kv.first) {
-            if (e.second && !e.second->invisible && e.second->exported) val = e.second->value;
-            else val.clear();
+            if (e.second && !e.second->invisible && e.second->exported) {
+              val = e.second->value;
+              emit = true;
+            } else {
+              val.clear();
+            }
             found = true;
             break;
           }
     }
+    if (!emit) continue;
     out.push_back(kv.first + "=" + val);
   }
   // Exported functions travel as BASH_FUNC_<name>%%=() {  body  }, which a

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1422,6 +1422,8 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   }
   var.value = v;
   var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
+  // `set -a': every assignment marks the variable for export (bash allexport).
+  if (opt_allexport) var.exported = true;
   // Setting POSIXLY_CORRECT (to any value) enables POSIX mode, as in bash.
   if (n == "POSIXLY_CORRECT") opt_posix = true;
   // A locale assignment re-applies LC_CTYPE so multibyte handling follows it.

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -978,8 +978,15 @@ void Shell::array_assign(
                  n.c_str());
     return;
   }
+  bool existed = vars.count(n) != 0;
   Variable &v = vars[n];
-  if (v.readonly) return;
+  if (v.readonly) {
+    // A compound assignment to a readonly variable reports and assigns
+    // nothing (`readonly a=7; a=(1 2 3)' -- varenv11.sub).
+    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    last_status = 1;
+    return;
+  }
   // Array-assigning to an unset nameref (deref stopped on the nameref itself)
   // converts it into a real array and drops the nameref attribute, with bash's
   // warning (assign_array_var_from_word_list -> make_variable_value).  A nameref
@@ -1000,6 +1007,12 @@ void Shell::array_assign(
     v.idx.clear();
     v.assoc.clear();
     v.assoc_seq.clear();
+    v.value.clear();
+  } else if (v.kind == VarKind::Scalar && existed && !v.invisible && !assoc) {
+    // Appending a compound to a SET scalar converts it keeping the old value
+    // as element 0: `s=X; s+=(Y)' -> ([0]="X" [1]="Y"), including the empty
+    // string (bash); an unset variable starts at [0] with the new elements.
+    v.idx[0] = v.value;
     v.value.clear();
   }
   v.kind = (assoc || v.kind == VarKind::Assoc) ? VarKind::Assoc : VarKind::Indexed;


### PR DESCRIPTION
Fixes #432.

varenv.tests: 16 diff lines -> **0 (byte-perfect)**; assoc.tests 61 -> 51. Seven commits:

- **feat(assoc)**: bash hash-table enumeration order everywhere. `Shell::bash_hash_order` factors the bucket-walk layout (bucket 0..n-1, newest-first chains); the bucket count now follows bash's per-table sizes — fresh `declare -A` 1024 (ASSOC_HASH_BUCKETS), a converted scalar 128 (convert_var_to_assoc, which also keeps the old value at key "0"), hashed commands 256 (FILENAME_HASH_BUCKETS), aliases 64 (ALIAS_HASH_BUCKETS). BASH_CMDS/BASH_ALIASES virtual arrays and both `hash` listings enumerate through it, with first-insertion order tracked at every write site.
- **fix(array)**: `s=X; s+=(Y)` keeps the scalar as element 0 (including empty), and a compound assignment to a readonly variable reports `readonly variable` instead of silently assigning.
- **fix(declare)**: a localvar_inherit'd local that copies a mismatched enclosing array reports the make-local conversion failure with the function's name before the builtin's own line — only when the word carries an assignment, matching bash.
- **feat(shopt)**: `localvar_unset` — unsetting an enclosing scope's local leaves it a local, now-unset binding (ash semantics) instead of popping the value-stack cell.
- **feat(set)**: `-a`/`-o allexport` — assignments mark variables exported, live in `set -o` listings and $SHELLOPTS.
- **fix(env)**: an unexported invisible local (`typeset +x foo`) no longer blocks the exported global underneath in children's environments.
- **feat(local)**: bare `local` lists the current scope's locals in declare form; `readonly -p` (and the bare/-p readonly listings) splice in `declare -r SHELLOPTS="..."` with the live option string at its sorted position.
- **fix(executor)**: posix-mode export/readonly (special builtins) write through an enclosing call tempenv like `return` does; the default-mode promotion still unwinds.

Verified: varenv14.sub diff-clean against the oracle directly; ctest 22/22; run_diff.sh all 240 match; full 83-suite sweep shows varenv 16 -> 0 and assoc 61 -> 51 with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
