### PR TITLE
fix(assoc): kvlist expansion, bracket-key unset, subscript validation (51 -> 0)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2453,16 +2453,38 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           a_display = elem + (eq == std::string::npos ? std::string() : a.substr(append ? eq - 1 : eq));
         }
       }
+      // Under `shopt -s assoc_expand_once' an ASSOCIATIVE subscript is a
+      // literal key spanning to the last `]': `declare x["a[b"]=1' keys on
+      // `a[b' (an unclosed `[' is fine), but a `]' BEFORE the final one still
+      // rejects the word (`foo["foo]bar"]=bax' -- assoc9.sub).
+      bool assoc_literal = false;
+      {
+        size_t elb2 = elem.find('[');
+        auto dbit = sh.vars.find(sh.deref(elem.substr(0, elb2)));
+        if (expand_once_on(sh) && dbit != sh.vars.end() &&
+            dbit->second.kind == VarKind::Assoc && elem.back() == ']' &&
+            elb2 + 1 < elem.size() - 1) {
+          std::string inner = elem.substr(elb2 + 1, elem.size() - elb2 - 2);
+          if (inner.find(']') != std::string::npos) {
+            std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
+                         sh.err_prefix().c_str(), argv[0].c_str(), a_display.c_str());
+            ret = 1;
+            continue;
+          }
+          assoc_literal = true;
+        }
+      }
       // An empty or invalid BASE name (`declare []=asdf') is the
       // invalid-identifier error, not a subscript diagnostic.
-      if (!valid_identifier(elem.substr(0, elem.find('['))) ||
-          !well_formed_element(elem, /*allow_empty=*/true)) {
+      if (!assoc_literal &&
+          (!valid_identifier(elem.substr(0, elem.find('['))) ||
+           !well_formed_element(elem, /*allow_empty=*/true))) {
         std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                      argv[0].c_str(), a_display.c_str());
         ret = 1;
         continue;
       }
-      if (!well_formed_element(elem)) {  // balanced but empty: a[]
+      if (!assoc_literal && !well_formed_element(elem)) {  // balanced but empty: a[]
         std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
                      elem.c_str());
         ret = 1;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2100,6 +2100,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   // `+X' flags remove an attribute rather than adding it (`typeset +n foo').
   bool rm_integer = false, rm_readonly = false, rm_exported = false;
   bool rm_nameref = false, rm_lcase = false, rm_ucase = false, rm_capcase = false;
+  bool rm_array = false, rm_assoc = false;
   for (; i < argv.size(); i++) {
     const std::string &a = argv[i];
     if (a == "--") { i++; break; }  // end-of-options marker
@@ -2130,8 +2131,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         switch (a[k]) {
           case 'f': funcs = true; break;
           case 'F': funcnames = true; break;
-          case 'a': mk_array = true; break;
-          case 'A': mk_assoc = true; break;
+          case 'a': (add ? mk_array : rm_array) = true; break;
+          case 'A': (add ? mk_assoc : rm_assoc) = true; break;
           case 'i': (add ? integer : rm_integer) = true; break;
           case 'r': (add ? readonly : rm_readonly) = true; break;
           case 'x': (add ? exported : rm_exported) = true; break;
@@ -2966,6 +2967,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // variable as readonly and leaves the flag set (declare.def refuses to
     // turn off att_readonly).  Only declare/typeset/local reach here with a
     // removable readonly, and they carry the builtin-name prefix.
+    // `+a'/`+A' cannot remove the array nature of an existing array: bash
+    // reports `cannot destroy array variables in this way' and leaves it be
+    // (a `+a'/`+A' on a non-array is a harmless no-op).
+    if ((rm_assoc && v.kind == VarKind::Assoc) || (rm_array && v.kind == VarKind::Indexed)) {
+      std::fprintf(stderr, "%s%s: %s: cannot destroy array variables in this way\n",
+                   sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+      ret = 1;
+      continue;
+    }
     if (rm_readonly) {
       // `+r' on a readonly TARGETLESS nameref (`declare -rn r; declare +r r')
       // follows the reference to nothing, so it is a silent no-op rather than a

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -338,6 +338,26 @@ static bool lenient_element_target(Shell &sh, size_t argv_idx) {
   return lb != std::string::npos && lb > 0 && r.text.back() == ']';
 }
 
+// Without assoc_expand_once, a `name[sub]' builtin target's subscript gets
+// expanded AGAIN by the assignment; a quote the first expansion left behind
+// (`a[80's]' from `a[$b]', b="80's") makes that re-expansion fail, so bash
+// rejects the whole word as not a valid identifier (assoc9.sub).  True when
+// the target either needs no re-expansion or its quotes are balanced.
+static bool subscript_reexpands(Shell &sh, const std::string &target) {
+  if (expand_once_on(sh)) return true;
+  size_t lb = target.find('[');
+  if (lb == std::string::npos || target.empty() || target.back() != ']') return true;
+  std::string sub = target.substr(lb + 1, target.size() - lb - 2);
+  bool sq = false, dq = false;
+  for (size_t i = 0; i < sub.size(); i++) {
+    char c = sub[i];
+    if (!sq && c == '\\') { i++; continue; }
+    if (!dq && c == '\'') sq = !sq;
+    else if (!sq && c == '"') dq = !dq;
+  }
+  return !sq && !dq;
+}
+
 bool well_formed_element(const std::string &s, bool allow_empty = false) {
   size_t lb = s.find('[');
   if (lb == std::string::npos) return s.find(']') == std::string::npos;
@@ -479,8 +499,9 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
 
   if (to_var) {
     auto lb = vname.find('[');
-    if (lb != std::string::npos && !lenient_element_target(sh, vname_idx) &&
-        !well_formed_element(vname)) {
+    if (lb != std::string::npos &&
+        ((!lenient_element_target(sh, vname_idx) && !well_formed_element(vname)) ||
+         !subscript_reexpands(sh, vname))) {
       std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
                    sh.err_prefix().c_str(), vname.c_str());
       return 1;
@@ -1848,7 +1869,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   for (size_t ni = 0; ni < names.size(); ni++) {
     const std::string &nm = names[ni];
     if (lenient_element_target(sh, ni < name_idx.size() ? name_idx[ni] : SIZE_MAX)) continue;
-    if (!valid_read_target(nm)) {
+    if (!valid_read_target(nm) || !subscript_reexpands(sh, nm)) {
       std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                    nm.c_str());
       return 1;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1263,8 +1263,16 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     }
     // A malformed element reference (an unbalanced bracket from word
     // splitting, e.g. `unset a[$(echo' + `foo)]') is a SILENT no-op in bash.
+    // EXCEPT when the base names an associative array: its subscript spans to
+    // the LAST `]' and may itself be a bracket (`unset A[]]' removes key `]',
+    // `unset A[[]' key `[' -- assoc17.sub), so no balance check applies.
     size_t lb = argv[i].find('[');
-    if (!noref && !expand_once_on(sh) &&
+    bool assoc_base = false;
+    if (lb != std::string::npos && lb > 0 && !argv[i].empty() && argv[i].back() == ']') {
+      auto abit = sh.vars.find(sh.deref(argv[i].substr(0, lb)));
+      assoc_base = abit != sh.vars.end() && abit->second.kind == VarKind::Assoc;
+    }
+    if (!noref && !expand_once_on(sh) && !assoc_base &&
         (lb != std::string::npos || argv[i].find(']') != std::string::npos) &&
         !well_formed_element(argv[i], /*allow_empty=*/true)) {
       continue;
@@ -1294,6 +1302,28 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       if (bit != sh.vars.end() && !sh.array_expand_once_ok(base, sub)) {
         ret = 1;
         continue;
+      }
+      // WITHOUT assoc_expand_once, an associative subscript is expanded a
+      // second time by unset itself (`unset -v "b[\$x]"' removes the key $x
+      // names -- assoc9.sub) -- EXCEPT under BASH_COMPAT <= 51, whose pre-5.2
+      // semantics take the text literally (`unset 'map[foo$(cmd)bar]'' removes
+      // that key without ever running the command substitution --
+      // quotearray3.sub).  A re-expansion that comes up empty is a bad
+      // subscript when the text had a `$' (an unset variable); otherwise the
+      // literal text stands (a lone `"' stays `"').
+      std::string ucompat = sh.get("BASH_COMPAT");
+      long ucv = ucompat.empty() ? 99 : std::strtol(ucompat.c_str(), nullptr, 10);
+      if (bit != sh.vars.end() && bit->second.kind == VarKind::Assoc &&
+          !expand_once_on(sh) && !(ucv > 0 && ucv <= 51) && sub != "@" && sub != "*") {
+        Expander uex(sh);
+        std::string esub = uex.expand_no_split(sub);
+        if (esub.empty() && sub.find('$') != std::string::npos) {
+          std::fprintf(stderr, "%sunset: [%s]: bad array subscript\n",
+                       sh.err_prefix().c_str(), sub.c_str());
+          ret = 1;
+          continue;
+        }
+        if (!esub.empty()) sub = esub;
       }
       if (bit != sh.vars.end() && bit->second.readonly) {
         std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -603,6 +603,14 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
                    sh.err_prefix().c_str(), name.c_str(), e.c_str());
       break;
     }
+    if (assoc) {
+      // An associative key/value list expands each word WITHOUT word
+      // splitting or pathname expansion (bash assign_assoc_from_kvlist):
+      // `v1=( $foo 3 )' with foo='1 2' keys on "1 2" whole, and an unquoted
+      // `*' stays a literal key (assoc11.sub, assoc12.sub).
+      out.emplace_back(std::nullopt, ex.expand_no_split(e, false, true));
+      continue;
+    }
     for (const std::string &f : ex.expand_args({Word{e, t.quoted ? W_QUOTED : 0}})) {
       out.emplace_back(std::nullopt, f);
       maxidx++;  // a positional element lands at the next index

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2193,6 +2193,15 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     // evaluator as `' '` / `~' and raise a syntax error rather than reading index 0.
     // Associative keys keep the plain expansion (their quoting rules differ).
     std::string esub = assoc_sub ? ex.expand_no_split(sub) : ex.expand_dq_word(sub);
+    // An associative subscript that expands empty is an error naming the RAW
+    // text: `${#wheat[$unset]}' -> `[$unset]: bad array subscript', and the
+    // command aborts (bash).
+    if (assoc_sub && esub.empty() && sub != "@" && sub != "*") {
+      std::fprintf(stderr, "%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
+                   sub.c_str());
+      sh.arith_error = true;
+      return std::string();
+    }
     if (!sh.array_expand_once_ok(name, esub)) { sh.arith_error = true; return std::string(); }
     // zsh subscripts are 1-based; translate before the (0-based) array read.
     tsub = sh.zsh_subscript(name, esub);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -960,7 +960,10 @@ void Shell::make_array(const std::string &n_in, bool assoc) {
       v.assoc["0"] = v.value;
       v.value.clear();
     }
-    if (assoc && !fresh) v.assoc_buckets = 128;
+    // Only a SET (visible) scalar is a real conversion; a declared-but-unset
+    // placeholder (a fresh `local'/`declare' cell) makes a NEW table with the
+    // full 1024 buckets, exactly like bash's make_new_assoc_variable.
+    if (assoc && !fresh && !v.invisible) v.assoc_buckets = 128;
     v.kind = assoc ? VarKind::Assoc : VarKind::Indexed;
   }
 }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1025,6 +1025,13 @@ void Shell::array_assign(
     for (size_t x = 0; x < elems.size(); x++) {
       if (elems[x].first) { assoc_put(v, *elems[x].first, fold_val(elems[x].second)); continue; }
       const std::string &key = elems[x].second;
+      // An empty key in the flat list is a bad subscript; bash reports it as
+      // `"": bad array subscript' and stops the assignment (assoc11.sub).
+      if (key.empty()) {
+        std::fprintf(stderr, "%s\"\": bad array subscript\n", err_prefix().c_str());
+        last_status = 1;
+        return;
+      }
       assoc_put(v, key,
                 fold_val((x + 1 < elems.size()) ? elems[x + 1].second : std::string()));
       x++;  // consumed the paired value


### PR DESCRIPTION
Fixes #434.

assoc.tests: 51 diff lines -> **0 (byte-perfect)**; quotearray 27 -> 25, array 53 -> 51 as side effects. Seven commits:

- **fix(assoc)**: key/value lists expand each word whole — no word splitting, no pathname expansion (`declare -A v1=( $foo 3 )` with `foo='1 2'` keys on "1 2"; an unquoted `*` stays literal); an empty key in the flat list is `"": bad array subscript`.
- **fix(assoc)**: a fresh function-local `declare -A` gets the 1024-bucket table — make_local's pre-created cell no longer trips the converted-scalar (128-bucket) rule.
- **fix(declare)**: `+a`/`+A` on an existing array reports `cannot destroy array variables in this way`.
- **fix(unset)**: associative subscripts span to the last `]` with no balance check (`unset A[]]` removes key `]`); without assoc_expand_once the subscript is expanded a second time by unset (empty + `$` = `[TEXT]: bad array subscript`), except under BASH_COMPAT <= 51 where the pre-5.2 literal semantics apply — so `unset 'map[foo$(cmd)bar]'` never runs the command substitution.
- **fix(expand)**: `${#wheat[$unset]}` (an associative subscript expanding empty) errors with the raw text and aborts the command.
- **fix(declare)**: under assoc_expand_once an associative assignment-word subscript is a literal key to the last `]` (`declare x["a[b"]=1` keys on `a[b`; a `]` before the final one still rejects) — oracle-verified pair.
- **fix(read,printf)**: without assoc_expand_once, a target whose subscript's first expansion left an unbalanced quote (`a[80's]`) is rejected as not a valid identifier.

Verified: ctest 22/22; run_diff.sh all 240 match; full 83-suite sweep pending in checks showed assoc 51 -> 0, quotearray -2, array -2, everything else unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
