### PR TITLE
fix(array): assignment-position compounds, subscript precedence, reparse matrix (51 -> 1)

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -708,8 +708,15 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing 
     // An associative key: the once-expanded text is the key, verbatim for the
     // arithmetic-source mode (`(( a[\" \"]=11 ))' keys on the literal `" "');
     // let's pre-expanded text drops its removable double-quote characters
-    // (`let 'a[" "]=11'` keys on the space).
-    if (ctx.expand_subs == 2) {
+    // (`let 'a[" "]=11'` keys on the space) -- EXCEPT under assoc_expand_once,
+    // whose literal-subscript rule keeps them (`let "a[\\" \\"]=11"' keys on
+    // `" "' with the quotes, array25.sub).
+    bool eo = false;
+    {
+      auto eoit = ctx.sh.shopt_opts.find("assoc_expand_once");
+      eo = eoit != ctx.sh.shopt_opts.end() && eoit->second;
+    }
+    if (ctx.expand_subs == 2 && !eo) {
       std::string k2;
       for (char c : out)
         if (c != '"') k2 += c;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1352,6 +1352,22 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
         ret = 1;
         continue;
       }
+      // A SET SCALAR is its own element 0: `unset scalar[0]' removes the whole
+      // variable, any OTHER subscript is `not an array variable' (bash); a
+      // missing variable stays a silent no-op above.
+      if (bit != sh.vars.end() && bit->second.kind == VarKind::Scalar &&
+          !bit->second.invisible) {
+        bool zok = true;
+        long long zk = eval_arith(sh, sub, &zok);
+        if (zok && zk == 0) {
+          sh.unset(bd);
+          continue;
+        }
+        std::fprintf(stderr, "%sunset: %s: not an array variable\n",
+                     sh.err_prefix().c_str(), bd.c_str());
+        ret = 1;
+        continue;
+      }
       // A negative subscript below the array's first element is rejected
       // (`unset a[-2]' on an empty or too-short indexed array); bash names just
       // the bracketed subscript, not the array.
@@ -2441,10 +2457,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       continue;
     }
     std::string a_display = a;  // error display; subscript shown expanded
+    // Whether the (deref'd) variable existed BEFORE this word's processing --
+    // later attribute plumbing can create the cell as a side effect.
+    bool preexisting_target = false;
     std::vector<std::pair<std::optional<std::string>, std::string>> pre_elems;
     bool have_pre_elems = false;
     size_t nend = a.find_first_of("[=");
     std::string name = (nend == std::string::npos) ? a : a.substr(0, nend);
+    preexisting_target = !name.empty() && sh.vars.count(sh.deref(name)) != 0;
     size_t eq = a.find('=');
     // A `+=' just before the `=' means append.  For a bare scalar (`name+=')
     // the `+' is part of neither the name nor the value.
@@ -2730,11 +2750,45 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           (cur->second.kind == VarKind::Indexed || cur->second.kind == VarKind::Assoc);
       bool unwrap_quoted = mk_array || mk_assoc ||
           (arrayvar && (argv[0] == "declare" || argv[0] == "typeset"));
-      if (!nameref && !arraylit && unwrap_quoted && val.size() >= 4 &&
-          (val.front() == '\'' || val.front() == '"') && val.back() == val.front() &&
-          val[1] == '(' && val[val.size() - 2] == ')') {
-        apply_assignment_word(sh, name + (append ? "+=" : "=") +
-                                      val.substr(1, val.size() - 2));
+      // Reparse a STRING compound against the EXPANDED value, so both the
+      // quoted-literal form (`declare -a d='(...)'`) and one reached through
+      // an expansion (`declare -a foo="$l"' with l='( zeroind )') become
+      // array literals -- and their elements expand a second time (bash's
+      // assign_array_var_from_string).  A SUBSCRIPTED declare never reparses:
+      // `declare a[1]='(var)'' stores the literal string (with bash's
+      // deprecation warning when the variable did not exist).
+      std::string exval;
+      bool exval_compound = false;
+      // A SUBSCRIPTED declare with an explicit -a/-A and a parenthesized value
+      // also reparses -- the subscript is dropped and the compound replaces
+      // the whole array (`declare -a e[10]='(test)'' -> [0]=test, bash).
+      bool sub_compound_ok = subscript && (mk_array || mk_assoc);
+      if (!nameref && !arraylit && (!subscript || sub_compound_ok) && unwrap_quoted &&
+          eq != std::string::npos) {
+        Expander vex(sh);
+        exval = vex.expand_assignment(val);
+        exval_compound = exval.size() >= 2 && exval.front() == '(' && exval.back() == ')';
+      }
+      if (subscript && !mk_array && !mk_assoc && !sh.is_zsh() && eq != std::string::npos) {
+        Expander wex(sh);
+        std::string ev = wex.expand_assignment(val);
+            if (ev.size() >= 2 && ev.front() == '(' && ev.back() == ')' && !preexisting_target)
+          std::fprintf(stderr, "%swarning: %s%s=%s: quoted compound array assignment deprecated\n",
+                       sh.err_prefix().c_str(), name.c_str(),
+                       a.substr(nend, (append ? eq - 1 : eq) - nend).c_str(), ev.c_str());
+      }
+      if (exval_compound) {
+        Expander pex2(sh);
+        auto elems2 = parse_array_elems(sh, pex2, name, integer, append, exval);
+        auto ivk = sh.vars.find(name);
+        if (integer || (ivk != sh.vars.end() && ivk->second.integer))
+          for (auto &e2 : elems2) {
+            bool iok2 = true;
+            e2.second = std::to_string(eval_arith(sh, e2.second, &iok2));
+          }
+        auto avk2 = sh.vars.find(name);
+        bool as_assoc2 = mk_assoc || (avk2 != sh.vars.end() && avk2->second.kind == VarKind::Assoc);
+        sh.array_assign(name, elems2, append, as_assoc2);
       } else if (have_pre_elems && arraylit && !nameref) {
         // The elements were expanded in the enclosing scope before make_local.
         auto avk = sh.vars.find(name);
@@ -3044,8 +3098,14 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // reports `cannot destroy array variables in this way' and leaves it be
     // (a `+a'/`+A' on a non-array is a harmless no-op).
     if ((rm_assoc && v.kind == VarKind::Assoc) || (rm_array && v.kind == VarKind::Indexed)) {
-      std::fprintf(stderr, "%s%s: %s: cannot destroy array variables in this way\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+      // A READONLY array reports the readonly violation instead (bash checks
+      // the attribute change first): `declare +a c' on readonly c.
+      if (v.readonly)
+        std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
+                     argv[0].c_str(), aname.c_str());
+      else
+        std::fprintf(stderr, "%s%s: %s: cannot destroy array variables in this way\n",
+                     sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
       ret = 1;
       continue;
     }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -572,6 +572,14 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
           if (!sh.array_expand_once_ok(name, sub)) break;  // diagnostic printed
           bool ok = true;
           long long k = eval_arith(sh, sub, &ok);
+          if (!ok) {
+            // Report with bash's subscript diagnostic and abort the whole
+            // assignment (the array keeps whatever was assigned so far).
+            eval_arith_msg(sh, sub, "", &ok);
+            out.clear();
+            break;
+          }
+          ok = true;
           if (ok && k < 0) k += maxidx + 1;  // resolve negative against running max
           if (ok && k < 0) {
             std::fprintf(stderr, "%s%s: bad array subscript\n",
@@ -623,10 +631,12 @@ namespace {
 
 void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   // Assigning to any part of a readonly array is an error (bash names the array,
-  // not the element).
+  // not the element).  For an ELEMENT assignment the subscript validates
+  // FIRST: `readonly -a c; c[-2]=4' is the bad-subscript error, so let
+  // array_set order the checks; only the compound form rejects here.
   {
     auto rit = sh.vars.find(sh.deref(a.name));
-    if (rit != sh.vars.end() && rit->second.readonly) {
+    if (!a.sub && rit != sh.vars.end() && rit->second.readonly) {
       std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
                    a.name.c_str());
       sh.last_status = 1;
@@ -1275,6 +1285,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.arith_error = false;
     return (sh_.last_status = 1);
   }
+  // An expansion that began the shell's exit (`set -u' unbound variable)
+  // suppresses the command itself: bash never runs the echo in
+  // `( echo ${#narray[4]} )'.
+  if (unwinding()) return sh_.last_status = sh_.exit_status;
 
   if (sh_.opt_xtrace) {
     // bash's xtrace prefix is $PS4 (default `+ '), decoded for prompt escapes

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2215,12 +2215,49 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       bool aok = true;
       long long idx = eval_arith_msg(sh, tsub, "", &aok);
       if (!aok) { sh.arith_error = true; return std::string(); }
+      // A negative index resolves against the highest set index; one still
+      // below zero is a bad subscript that aborts the command.  bash's length
+      // form names the bracketed raw text (`[-10]: bad array subscript'), the
+      // value form the base name (`c: bad array subscript').
+      if (idx < 0 && !sh.is_zsh()) {
+        long long maxi = -1;
+        if (vit != sh.vars.end() && vit->second.kind == VarKind::Indexed &&
+            !vit->second.idx.empty())
+          maxi = vit->second.idx.rbegin()->first;
+        else if (vit != sh.vars.end() && vit->second.kind == VarKind::Scalar &&
+                 !vit->second.value.empty())
+          maxi = 0;
+        idx += maxi + 1;
+        if (idx < 0) {
+          // The LENGTH form names the bracketed raw text and aborts the
+          // command; the VALUE form names the base and expands to empty with
+          // the command still running (`echo ${c[-4]}' prints a blank line).
+          if (length) {
+            std::fprintf(stderr, "%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
+                         sub.c_str());
+            sh.arith_error = true;
+          } else {
+            std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
+                         name.c_str());
+          }
+          return std::string();
+        }
+      }
       tsub = std::to_string(idx);
     }
     val = sh.array_get(name, tsub);
     // A defaulting/alternative operator on a single element (${a[i]-x}, ${a[i]=x},
     // ${a[i]+x}, ${a[i]?}) keys off whether THAT element is set, not the array.
     set = sh.array_elem_set(name, tsub);
+    // `set -u': an unset ELEMENT is an unbound-variable error naming the
+    // element (`narray[4]: unbound variable'), like param_value's for scalars.
+    if (!set && sh.opt_nounset && !defaulting_op && tsub != "@" && tsub != "*") {
+      std::fprintf(stderr, "%s%s[%s]: unbound variable\n", sh.err_prefix().c_str(),
+                   name.c_str(), tsub.c_str());
+      sh.exiting = true;
+      sh.exit_status = 127;
+      return std::string();
+    }
   } else {
     val = ex.param_value(name, set, defaulting_op);
   }
@@ -2627,7 +2664,16 @@ std::string Expander::expand_arith(const std::string &text) {
     mask += '0';
     i++;
   }
-  return out;
+  // `$@'/`$*' field markers become plain spaces in arithmetic -- `set -- 1 +
+  // 2' makes `$(( $@ ))' evaluate `1 + 2' (bash joins the positionals with
+  // spaces here, quoted or not) -- and the QNULL empty-field markers vanish.
+  std::string flat;
+  flat.reserve(out.size());
+  for (char ch : out) {
+    if (ch == FIELD_SEP) flat += ' ';
+    else if (ch != QNULL) flat += ch;
+  }
+  return flat;
 }
 
 std::string Expander::expand_dq_word(const std::string &w_in) {

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cwchar>
+#include <set>
 
 namespace gnash::core {
 
@@ -430,6 +431,59 @@ struct Lexer {
            c == ';' || c == '(' || c == ')' || c == '<' || c == '>';
   }
 
+  // True when a `name=(...)' compound may be recognized at the CURRENT word:
+  // the current simple command is still in assignment-prefix position (every
+  // word so far is an assignment), or its command word is an assignment
+  // builtin (declare/typeset/local/export/readonly/alias) -- options and
+  // redirections in between don't matter.  After an ordinary command word the
+  // `(' stays unconsumed and the parser reports bash's syntax error
+  // (`printf "%s\n" -a a=(a 'b  c')', array1.sub).
+  bool assignment_acceptable() const {
+    static const std::set<std::string> kAssignBuiltins = {
+        "declare", "typeset", "local", "export", "readonly", "alias",
+        "eval", "let"};  // bash marks eval/let assignment builtins too
+    static const std::set<std::string> kCmdStart = {
+        "if", "then", "else", "elif", "fi", "do", "done", "while", "until",
+        "for", "in", "case", "esac", "{", "}", "!", "time", "coproc", "function"};
+    auto is_sep = [](Tok ty) {
+      switch (ty) {
+        case Tok::Newline: case Tok::Amp: case Tok::Semi: case Tok::Pipe:
+        case Tok::AndAnd: case Tok::OrOr: case Tok::SemiSemi: case Tok::SemiAnd:
+        case Tok::SemiSemiAnd: case Tok::PipeAnd: case Tok::Lparen: case Tok::Rparen:
+          return true;
+        default:
+          return false;
+      }
+    };
+    auto assign_shaped = [](const std::string &s) {
+      size_t e = s.find('=');
+      if (e == std::string::npos || e == 0) return false;
+      if (!(std::isalpha(static_cast<unsigned char>(s[0])) || s[0] == '_')) return false;
+      size_t k = 0;
+      while (k < e && (std::isalnum(static_cast<unsigned char>(s[k])) || s[k] == '_')) k++;
+      if (k < e && s[k] == '[') {
+        size_t rb = s.rfind(']', e);
+        k = (rb != std::string::npos && rb < e) ? rb + 1 : k;
+      }
+      if (k < e && s[k] == '+') k++;
+      return k == e;
+    };
+    size_t start = out.size();
+    while (start > 0 && !is_sep(out[start - 1].type)) start--;
+    bool redir_target = false;
+    for (size_t k = start; k < out.size(); k++) {
+      const Token &t = out[k];
+      if (t.type == Tok::IoNumber) continue;
+      if (t.type != Tok::Word) { redir_target = true; continue; }  // a redir operator
+      if (redir_target) { redir_target = false; continue; }        // ... and its target
+      if (kCmdStart.count(t.text)) continue;  // reserved word: command not started yet
+      if (kAssignBuiltins.count(t.text)) return true;
+      if (assign_shaped(t.text)) continue;    // a prefix assignment keeps the position
+      return false;                           // an ordinary command word ends it
+    }
+    return true;  // still in command-prefix position
+  }
+
   // Bytes of the multibyte character starting at `pos' (1 for ASCII, invalid
   // sequences, or single-byte locales).  In charsets like Big5 a trail byte
   // can be `\' or a metacharacter value, so word scanning must consume a
@@ -463,6 +517,12 @@ struct Lexer {
         continue;
       }
       if (c == '(' && is_assignment_prefix(w)) {
+        // A compound value is only recognized where an ASSIGNMENT can appear:
+        // in command-prefix position or after an assignment builtin.  After an
+        // ordinary command word the `(' is a hard syntax error, exactly as
+        // bash's parser treats `printf "%s\n" -a a=(a 'b  c')' (array1.sub);
+        // leaving it unconsumed makes it an operator token the parser rejects.
+        if (!assignment_acceptable()) break;
         scan_paren(w);  // compound (array) assignment value: name=(...)
         quoted = true;
         continue;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -797,20 +797,22 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
     return;
   }
   Variable &v = vars[n];
-  if (v.readonly) return;
-  v.invisible = false;  // an assignment makes a declared-but-unset array visible
   // `declare -u'/`-l'/`-c' fold the case of each element value on assignment,
   // exactly as Shell::set does for scalars.
   std::string fv = fold_case(val, v.ucase, v.lcase, v.capcase);
   if (v.kind == VarKind::Assoc) {
+    if (v.readonly) {
+      std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+      last_status = 1;
+      return;
+    }
+    v.invisible = false;  // an assignment makes a declared-but-unset array visible
     assoc_put(v, sub, fv);
     return;
   }
-  // A subscripted assignment to an existing scalar promotes it to an indexed
-  // array, keeping the old value as element 0 (`a=abcde; a[2]=x' yields
-  // ([0]=abcde [2]=x)), matching bash.
-  if (v.kind == VarKind::Scalar && !v.value.empty() && v.idx.empty()) v.idx[0] = v.value;
-  v.kind = VarKind::Indexed;
+  // The subscript is validated BEFORE the readonly attribute is consulted:
+  // `readonly -a c; c[-2]=4' reports the bad subscript, not the readonly
+  // violation (bash), and the error unwinds the current command list.
   bool ok = true;
   long long k = eval_arith(*this, sub, &ok);
   if (!ok) {
@@ -824,16 +826,33 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
     return;
   }
   // A negative index counts back from the highest set index; one that resolves
-  // below zero is a bad subscript (bash errors and leaves the array unchanged).
-  // Under zsh the subscript was already translated by zsh_subscript.
+  // below zero is a bad subscript (bash errors, leaves the array unchanged, and
+  // unwinds the command list).  Under zsh the subscript was already translated.
   if (k < 0 && !is_zsh()) {
-    if (!v.idx.empty()) k += v.idx.rbegin()->first + 1;
+    // A set scalar counts as its would-be element 0 (`a=abcde; a[-1]=z').
+    long long maxi = !v.idx.empty() ? v.idx.rbegin()->first
+                    : (v.kind == VarKind::Scalar && !v.value.empty()) ? 0
+                                                                      : -1;
+    k += maxi + 1;
     if (k < 0) {
       std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", err_prefix().c_str(),
                    n.c_str(), sub.c_str());
+      arith_abort = true;
+      last_status = 1;
       return;
     }
   }
+  if (v.readonly) {
+    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    last_status = 1;
+    return;
+  }
+  v.invisible = false;  // an assignment makes a declared-but-unset array visible
+  // A subscripted assignment to an existing scalar promotes it to an indexed
+  // array, keeping the old value as element 0 (`a=abcde; a[2]=x' yields
+  // ([0]=abcde [2]=x)), matching bash.
+  if (v.kind == VarKind::Scalar && !v.value.empty() && v.idx.empty()) v.idx[0] = v.value;
+  v.kind = VarKind::Indexed;
   v.idx[k] = fv;
   if (k == 0) v.value = fv;
 }
@@ -1440,6 +1459,13 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   if (is_locale_var(n)) apply_ctype_locale(*this);
   // `declare -u' / `-l' / `-c' fold the value's case on every assignment.
   var.value = fold_case(var.value, var.ucase, var.lcase, var.capcase);
+  // A scalar assignment to an ARRAY variable writes element 0 (`declare -a x;
+  // read x' stores x[0]; `declare -A x; x=v' keys "0"), as bash does.
+  if (var.kind == VarKind::Indexed) var.idx[0] = var.value;
+  else if (var.kind == VarKind::Assoc) {
+    if (!var.assoc.count("0")) var.assoc_seq.push_back("0");
+    var.assoc["0"] = var.value;
+  }
   // Assigning HISTSIZE re-stifles the loaded history list, as bash does; a
   // non-numeric or empty value leaves the list unbounded.
   if (n == "HISTSIZE" && history_loaded) {


### PR DESCRIPTION
Fixes #436.

array.tests: 51 diff lines -> **1**, with side improvements posixexp 42 -> 26, comsub2 23 -> 20, exp 22 -> 21. Six commits:

- **fix(lexer)**: `name=(...)` compounds are recognized only in assignment-acceptable positions (assignment-prefix, or a command word among declare/typeset/local/export/readonly/alias/eval/let); after an ordinary command word the `(` is bash's parse error (array1.sub).
- **fix(array)**: element-assignment subscripts validate before the readonly attribute (`readonly -a c; c[-2]=4` is the bad-subscript error, which also unwinds); negative indices resolve against a set scalar's implicit element 0; a scalar assignment to an array variable writes element 0 (`declare -a x; read x`).
- **fix(expand)**: `${a[-N]}` out of range reports and expands empty with the command continuing, while `${#a[-N]}` aborts; `set -u` names unset elements (`narray[4]: unbound variable`); `$(( $@ ))` joins positionals with spaces (QNULL markers dropped).
- **fix(executor)**: a compound `[sub]=value` whose subscript fails arithmetic evaluation aborts the whole assignment with bash's diagnostic; an expansion that began the shell's exit suppresses the command itself.
- **fix(declare,unset)**: the string-compound reparse matrix — expanded parenthesized values reparse as compounds (with second-round element expansion and integer folding); subscripted `-a`/`-A` forms drop the subscript; unflagged subscripted forms store the literal string with bash's deprecation warning; `unset scalar[0]` removes the whole scalar, other subscripts are `not an array variable`.
- **fix(let)**: assoc keys keep their double-quote characters under assoc_expand_once (array25.sub).

The 1 remaining line is bash printing the `y[]: bad array subscript` diagnostic twice for `(( y[$none] ))` where gnash prints it once — an error-count quirk, deferred with the error-text batch.

Verified: array19.sub diff-clean directly; ctest 22/22; run_diff.sh all 240 match; full 83-suite sweep shows improvements only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
