### PR TITLE
fix(redir): exec stdin rebinding, compound-redirect ERR/errexit, subshell ERR traps (25 -> 19)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -176,6 +176,12 @@ class Shell {
   // itself ran `set' (source.def uw_maybe_pop_dollar_vars / ARGS_SETBLTIN),
   // and clears the flag after every such source.
   bool params_set_builtin = false;
+
+  // Set when `exec 0< file' rebinds fd 0 while commands are being read from
+  // standard input: the driver discards its buffered text and re-reads from
+  // the NEW fd 0 (`${SH} < redir1.sub' with `exec 0< redir2.sub' continues
+  // in redir2.sub -- redir.tests).
+  bool stdin_source_changed = false;
   std::vector<std::vector<std::pair<std::string, std::optional<Variable>>>> local_stack;
   // Per-scope saved getopt state, set when that scope localizes OPTIND.
   std::vector<std::optional<std::tuple<size_t, std::string, int>>> getopt_scope_saves;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -877,11 +877,21 @@ int Executor::run(const Command *c) {
   if (auto *p = dynamic_cast<const SimpleCommand *>(c)) return run_simple(p);
   if (auto *p = dynamic_cast<const Connection *>(c)) return run_connection(p);
 
-  // Compound commands: apply redirects in-process around the body.
+  // Compound commands: apply redirects in-process around the body.  A
+  // redirection failure runs the ERR trap and is fatal under `set -e',
+  // exactly like a failing simple command (redir12.sub).
   std::vector<SavedFd> saved;
   if (!apply_redirects(sh_, c->redirects, saved)) {
     restore_fds(saved);
-    return (sh_.last_status = 1);
+    sh_.last_status = 1;
+    if (sh_.errexit_suppress == 0 && !unwinding()) {
+      sh_.run_err_trap(1);
+      if (sh_.opt_errexit) {
+        sh_.exiting = true;
+        sh_.exit_status = 1;
+      }
+    }
+    return sh_.last_status;
   }
   int st = sh_.last_status;
   if (auto *pa = dynamic_cast<const Subshell *>(c)) st = run_subshell(pa);
@@ -953,6 +963,7 @@ int Executor::run_connection(const Connection *c) {
         sh_.job_control = false;  // background: descendants must not touch the tty
         sh_.subshell_level++;
         sh_.traps.erase("CHLD");  // the parent fires CHLD when it reaps this job
+        if (!sh_.opt_functrace) sh_.traps.erase("ERR");  // not inherited without -E
         sh_.pending_sigchld = 0;
         Executor ex(sh_);
         int s = ex.run(c->first.get());
@@ -1788,8 +1799,14 @@ int Executor::run_simple(const SimpleCommand *c) {
   flush_builtin_stdout();
   // `exec' makes its redirections permanent in the current shell (this path is
   // only reached when exec had no command word, or its exec failed).
-  if (builtin && !argv.empty() && argv[0] == "exec" && status == 0)
+  if (builtin && !argv.empty() && argv[0] == "exec" && status == 0) {
+    // `exec 0< file' while reading commands from stdin swaps the command
+    // source: tell the stdin driver to re-read from the new fd 0.
+    if (sh_.invocation_char == 's')
+      for (const SavedFd &sf : saved)
+        if (sf.fd == 0) sh_.stdin_source_changed = true;
     discard_saved_fds(saved);
+  }
   else
     restore_fds(saved);
   if (c->flags & CMD_INVERT_RETURN) status = status ? 0 : 1;
@@ -1845,6 +1862,7 @@ int Executor::run_coproc(const CoprocCommand *c) {
     sh_.job_control = false;
     sh_.subshell_level++;
     sh_.traps.erase("CHLD");  // the parent fires CHLD when it reaps this job
+    if (!sh_.opt_functrace) sh_.traps.erase("ERR");  // not inherited without -E
     sh_.pending_sigchld = 0;
     Executor ex(sh_);
     int s = ex.run(c->body.get());
@@ -1886,6 +1904,7 @@ int Executor::run_subshell(const Subshell *c) {
     // itself runs when it exits.
     sh_.traps.erase("EXIT");
     sh_.traps.erase("CHLD");  // the parent fires CHLD for the subshell as a whole
+    if (!sh_.opt_functrace) sh_.traps.erase("ERR");  // not inherited without -E
     sh_.pending_sigchld = 0;
     // (external): a lone simple command can exec in place, no second fork.
     if (dynamic_cast<const SimpleCommand *>(c->body.get())) sh_.can_exec_replace = true;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -513,9 +513,20 @@ int main(int argc, char **argv) {
     }
     sh.init_job_control(false);
     read_startup_files(sh, startup_prefix, login, false, sopts);
-    std::ostringstream ss;
-    ss << std::cin.rdbuf();
-    sh.run_script_lines(ss.str());
+    for (;;) {
+      // Raw read(2): std::cin's stdio buffering would not follow an
+      // `exec 0< file' rebinding of fd 0.
+      std::string buf;
+      char tmp[4096];
+      ssize_t n;
+      while ((n = ::read(0, tmp, sizeof tmp)) > 0) buf.append(tmp, static_cast<size_t>(n));
+      sh.run_script_lines(buf);
+      if (sh.stdin_source_changed && !sh.exiting) {
+        sh.stdin_source_changed = false;  // continue from the rebound fd 0
+        continue;
+      }
+      break;
+    }
   }
 
   int rc = sh.exiting ? sh.exit_status : sh.last_status;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -331,10 +331,11 @@ int Shell::run_debug_trap(const std::string &cmd_text) {
 void Shell::run_err_trap(int status) {
   auto it = traps.find("ERR");
   if (it == traps.end() || it->second.empty() || in_err_trap) return;
-  // Without errtrace (`set -E'), the ERR trap is not inherited into functions
-  // or subshells (a forked child raises subshell_level); only the enclosing
-  // shell fires it for the function call / subshell / pipeline as a whole.
-  if (!opt_functrace && (in_function() || subshell_level > 0)) return;
+  // Without errtrace (`set -E'), the ERR trap is not inherited into function
+  // bodies; subshell non-inheritance is already modeled by the fork-time
+  // trap erasure, so a trap SET INSIDE the subshell still fires
+  // (redir12.sub's \`(trap ... ERR; while ...)').
+  if (!opt_functrace && in_function()) return;
   in_err_trap = true;
   int saved = last_status;
   last_status = status;  // $? inside the ERR trap is the failing command's status
@@ -1971,7 +1972,7 @@ int Shell::run_script_lines(const std::string &text) {
     pending.clear();
   };
 
-  while (pos < text.size() && !exiting) {
+  while (pos < text.size() && !exiting && !stdin_source_changed) {
     size_t nl = text.find('\n', pos);
     std::string line = (nl == std::string::npos) ? text.substr(pos) : text.substr(pos, nl - pos);
     pos = (nl == std::string::npos) ? text.size() : nl + 1;
@@ -2292,6 +2293,7 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     no_current_job = true;  // bash resets the current job in the subshell
     subshell_level++;  // $BASH_SUBSHELL
     traps.erase("CHLD");  // the parent fires CHLD for the substitution as a whole
+    if (!opt_functrace) traps.erase("ERR");  // ERR is not inherited without -E
     pending_sigchld = 0;
     subshell_leaf = true;  // a lone external here can exec in place (no 2nd fork)
     // Command substitution unsets errexit in the subshell unless the caller has


### PR DESCRIPTION
Fixes #440.

redir.tests: 25 diff lines -> **19**. Two commits:

- **fix(stdin)**: the stdin script driver reads with raw read(2) and, when `exec 0< file` rebinds fd 0 (flagged from exec's permanent-redirect path), discards its buffered text and re-reads from the new fd — so `${SH} < redir1.sub` continues in redir2.sub.
- **fix(err)**: a redirection failure on a compound command runs the ERR trap and is fatal under `set -e`; the ERR-inheritance rule moved to fork time (subshell/pipeline/comsub/async/coproc children erase the trap unless `-E`), so a trap set inside a subshell fires while inherited ones stay silent — trap.tests confirms at its baseline 17.

The remaining 19 lines are compound-redirect line-number attribution (bash points past the compound), one stray grep fd message, and redir11 checks 3/4 — parked with the error-text batch.

Verified: ctest 22/22; run_diff.sh all 240 match; full sweep shows redir 25 -> 19 as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
