### PR TITLE
feat(parser): recursive comsub validation; scanner-accurate spans (comsub-posix 41 -> 5)

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -80,6 +80,10 @@ const char *tok_name(Tok t);
 // Tokenize INPUT.  Always ends with a single Tok::Eof token.  Unterminated
 // quotes/spans are tolerated (consumed to end of input); the parser decides
 // whether the result is a syntax error.
+// Offset just past the `)' closing the substitution whose `(' is at open_pos
+// (quote/case/comment/heredoc-aware); npos when unterminated.
+std::size_t comsub_span_end(const std::string &text, std::size_t open_pos);
+
 std::vector<Token> tokenize(const std::string &input, bool posix_mode = false);
 
 }  // namespace gnash::core

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -9,6 +9,7 @@
 
 #include "gnash/core/builtins.hpp"
 #include "gnash/core/expand.hpp"
+#include "gnash/core/lexer.hpp"
 #include "gnash/core/subscript.hpp"
 
 #include <algorithm>
@@ -1129,7 +1130,12 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   }
   // $(cmd)
   if (n1 == '(') {
-    size_t end = scan_balanced(t, i + 1, '(', ')');
+    // The lexer's scanner is the single source of truth for the span: it
+    // knows case patterns (`$(case x in in|esac) ...;; esac)'), comments,
+    // and here-documents; fall back to the plain balanced scan if it calls
+    // the span unterminated.
+    size_t end = comsub_span_end(t, i + 1);
+    end = (end == std::string::npos) ? scan_balanced(t, i + 1, '(', ')') : end - 1;
     if (end != std::string::npos) {
       std::string inner = t.substr(i + 2, end - (i + 2));
       int st = 0;

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -166,6 +166,8 @@ struct Lexer {
     // pattern terminator, not the closer.  Keyword recognition is gated on
     // command position so a `case'/`esac' used as an argument is unaffected.
     bool cmd_pos = true;          // next plain word starts a command
+    bool after_pipe = false;      // the previous separator was `|' (a pattern
+                                  // alternative: `in|esac)' keeps its case open)
     std::vector<int> case_stack;  // paren depths of open `case' bodies
     std::string word;             // current unquoted identifier word
     bool word_plain = true;       // word is only identifier chars (a keyword?)
@@ -173,7 +175,12 @@ struct Lexer {
     auto boundary = [&]() {
       if (saw_word) {
         if (cmd_pos && word_plain && word == "case") case_stack.push_back(depth);
-        else if (cmd_pos && word_plain && word == "esac" && !case_stack.empty())
+        else if (word_plain && word == "esac" && !case_stack.empty() && !after_pipe)
+          // `esac' closes the case even out of command position: after a
+          // stray `done' (`$(case x in x) ;; x) done esac)') bash's scanner
+          // still ends the case body and finds the substitution's closer,
+          // leaving the grammar to report the real error.  A pattern
+          // ALTERNATIVE (`in|esac)') stays open.
           case_stack.pop_back();
         // Most words consume the command slot; a few reopen command position.
         cmd_pos = word_plain && (word == "then" || word == "do" ||
@@ -182,6 +189,7 @@ struct Lexer {
       word.clear();
       word_plain = true;
       saw_word = false;
+      after_pipe = false;
     };
     do {
       char c = in[pos];
@@ -236,11 +244,14 @@ struct Lexer {
           w += dc;
           pos++;
         }
-        if (!delim.empty()) paren_heredocs.push_back({delim, strip_tabs, depth});
+        // Only depth 1 is a real here-document: `<<'/`>>' at depth 2 inside
+        // `$((...))' are the arithmetic shifts (multiline $(( )) bodies).
+        if (!delim.empty() && depth == 1) paren_heredocs.push_back({delim, strip_tabs, depth});
         saw_word = true;
         word_plain = false;
       } else if (c == ';' || c == '&' || c == '|' || c == '\n') {
         boundary();
+        after_pipe = (c == '|');
         bool was_nl = c == '\n';
         w += c;
         pos++;
@@ -872,6 +883,18 @@ struct Lexer {
 };
 
 }  // namespace
+
+// Offset of the character just past the `)' closing the substitution whose
+// `(' is at OPEN_POS (quote-, case-pattern-, comment-, and heredoc-aware --
+// the lexer's own scanner).  npos when unterminated.
+std::size_t comsub_span_end(const std::string &text, std::size_t open_pos) {
+  Lexer lx{text};
+  lx.pos = open_pos;
+  std::string dummy;
+  lx.scan_paren(dummy);
+  return lx.unterminated ? std::string::npos : lx.pos;
+}
+
 
 std::vector<Token> tokenize(const std::string &input, bool posix_mode) {
   Lexer lx(input);

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1464,8 +1464,61 @@ static AliasExpansion alias_splice_text(const std::string &input,
   return ax;
 }
 
+// bash parses command-substitution content recursively at PARSE time, so a
+// construct left open inside `$( )' is a syntax error of the OUTER parse:
+// `echo $( if x; then echo foo )' reports "near unexpected token `)'", and a
+// definite inner error appends "while looking for matching `)'" (`: $(case x
+// in x) ;; x) done esac)' -> "near unexpected token `done' while ...").
+// Spans starting `$((' are skipped (arithmetic or `$( (subshell' -- both
+// validated elsewhere); quoted (') and escaped `$(' are literal.
+static bool validate_comsubs(const std::vector<Token> &toks, bool posix_mode,
+                             ParseResult &res, int depth) {
+  if (depth > 16) return true;
+  for (const Token &t : toks) {
+    if (t.type != Tok::Word) continue;
+    const std::string &w = t.text;
+    bool sq = false;
+    for (size_t i = 0; i + 1 < w.size(); i++) {
+      char c = w[i];
+      if (sq) { if (c == '\'') sq = false; continue; }
+      if (c == '\'') { sq = true; continue; }
+      if (c == '\\') { i++; continue; }
+      if (c != '$' || w[i + 1] != '(') continue;
+      if (i + 2 < w.size() && w[i + 2] == '(') { i++; continue; }  // $(( form
+      // The lexer's own scanner finds the closer (case patterns, quotes,
+      // comments, and here-documents included).
+      std::size_t jend = comsub_span_end(w, i + 1);
+      if (jend == std::string::npos) break;  // unterminated: already flagged
+      size_t j = jend - 1;  // the `)'
+      std::string inner = w.substr(i + 2, j - (i + 2));
+      if (inner.find_first_not_of(" \t\n") == std::string::npos) { i = j; continue; }
+      ParseResult ir = parse(inner, posix_mode);
+      if (!ir.ok) {
+        res.ok = false;
+        res.command.reset();
+        res.error_line = t.line;
+        if (ir.incomplete) {
+          // The construct ran into the closing paren: bash blames the `)'.
+          res.error = "near unexpected token `)'";
+        } else if (ir.error.compare(0, 22, "near unexpected token ") == 0) {
+          res.error = ir.error + " while looking for matching `)'";
+        } else {
+          res.error = ir.error;
+        }
+        return false;
+      }
+      i = j;
+    }
+  }
+  return true;
+}
+
 ParseResult parse(const std::string &input, bool posix_mode) {
   Parser p(tokenize(input, posix_mode));
+  // Substitution content validates FIRST, as bash's recursive parser would:
+  // its diagnosis wins over any knock-on error in the outer grammar.
+  ParseResult pre;
+  if (!validate_comsubs(p.toks, posix_mode, pre, 0)) return pre;
   return p.run();
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1913,6 +1913,31 @@ static OpenCtx open_context(const std::string &t) {
 // old-style backtick, whose own backslash pre-pass splices `\<newline>' away
 // before the inner quoting is even seen.  A single quote inside `$(...)' (or at
 // top level) keeps the backslash literal; only backticks force the splice.
+// True when T's final character sits inside a comment (an unquoted `#' that
+// began a word, running to end of line with no newline after it): a trailing
+// backslash there is comment TEXT, never a line continuation (bash --
+// `echo $(\n echo hi # \\\n)' closes fine).
+static bool ends_in_comment(const std::string &t) {
+  bool squote = false, dquote = false;
+  char prev = '\n';
+  for (size_t i = 0; i < t.size(); i++) {
+    char c = t[i];
+    if (squote) { if (c == '\'') squote = false; prev = c; continue; }
+    if (!dquote && c == '#' && (prev == ' ' || prev == '\t' || prev == '\n' ||
+                                prev == ';' || prev == '(' || prev == '&' || prev == '|')) {
+      while (i < t.size() && t[i] != '\n') i++;
+      if (i >= t.size()) return true;  // comment runs to the end
+      prev = '\n';
+      continue;
+    }
+    if (c == '\\') { if (i + 1 < t.size()) i++; prev = 'x'; continue; }
+    if (c == '\'' && !dquote) squote = true;
+    else if (c == '"') dquote = !dquote;
+    prev = c;
+  }
+  return false;
+}
+
 static bool squote_backslash_literal(const std::string &t) {
   bool squote = false, dquote = false, btick = false;
   char prev = '\n';  // start of input behaves like just after a newline
@@ -2047,7 +2072,7 @@ int Shell::run_script_lines(const std::string &text) {
     // character, not a line continuation.  In an unquoted here-document bash
     // still splices `\<newline>' (before even checking for the delimiter), so
     // only suppress the continuation for a quoted delimiter.
-    if (nbs % 2 == 1 && !squote_backslash_literal(pending) &&
+    if (nbs % 2 == 1 && !squote_backslash_literal(pending) && !ends_in_comment(pending) &&
         !(in_heredoc && in_heredoc_quoted)) {
       pending.pop_back();
       cont_bslash = true;


### PR DESCRIPTION
Continues #442.

comsub-posix.tests: 41 -> **5**, with bonuses errors 15 -> 12 and more-exp 17 -> 16. Four commits:

- **fix(reader)**: a backslash ending a comment is not a line continuation (`echo $(\n echo hi # \\n)` closes).
- **feat(parser)**: command-substitution content is parse-validated recursively BEFORE the outer grammar, exactly as bash's parser behaves: an inner construct that runs into the closer reports ``near unexpected token `)'``; a definite inner error appends ``while looking for matching `)'``. The substitution spans come from the lexer's own scanner, newly exposed as `comsub_span_end()`.
- **fix(lexer)**: case tracking matches bash's scanner — `esac` closes the case even out of command position (so a stray `done` still lets the closer be found), except as a pattern alternative (`in|esac)` stays open); `<<` registers as a here-document only at paren depth 1 (depth 2 is `$((...))` left-shift, unbreaking multiline arithmetic).
- **fix(expand)**: the `$(cmd)` expansion takes its span from the same lexer scanner, fixing `$(case x in in|esac) ...;; esac)` truncation at the pattern's `)`.

Remaining 5 lines: two scanner-edge cases needing bash's full grammar-aware comsub states (`esac|in)` first-pattern and `done`-without-`esac`), parked with the error-text batch.

Verified: ctest 22/22; run_diff all 240; full sweep shows comsub-posix 41 -> 5, errors -3, more-exp -1, nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
