### PR TITLE
docs: trailing newline (CLA check probe)

### DIFF
--- a/scripts/notes/gnash-1.8.7.md
+++ b/scripts/notes/gnash-1.8.7.md
@@ -66,3 +66,4 @@ and parser, redirection, and diagnostic behavior land major clusters.
   reached, prints even when the surrounding construct fails to parse,
   and `unexpected end of file from ... on line N` uses file
   coordinates.
+


### PR DESCRIPTION
Probe PR to reproduce and diagnose the failing required `cla` check. Will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)