### PR TITLE
ci(cla): fast-path maintainer PRs so the required check cannot stick

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -35,15 +35,35 @@ permissions:
   pull-requests: write
   statuses: write
 
+# One run per PR at a time: a new push supersedes the queued run instead of
+# piling up behind it.
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cla:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      # Fast path: the maintainer's own pull requests (and bots') never need a
+      # signature -- succeed immediately instead of exercising the full CLA
+      # action, whose slow/failing runs were leaving the required `cla' status
+      # unreported and pull requests stuck at "expected".
+      - name: Maintainer fast-path
+        if: >-
+          github.event_name == 'pull_request_target' &&
+          (github.event.pull_request.user.login == 'brianjfox' ||
+           endsWith(github.event.pull_request.user.login, '[bot]'))
+        run: echo "Maintainer/bot pull request -- CLA not required."
       - name: CLA Assistant
         if: >-
-          (github.event.comment.body == 'recreate-signatures' ||
-           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
-          github.event_name == 'pull_request_target'
+          ((github.event.comment.body == 'recreate-signatures' ||
+            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+           github.event_name == 'pull_request_target') &&
+          !(github.event_name == 'pull_request_target' &&
+            (github.event.pull_request.user.login == 'brianjfox' ||
+             endsWith(github.event.pull_request.user.login, '[bot]')))
         # Pin to the latest release of contributor-assistant/github-action.
         uses: contributor-assistant/github-action@v2.6.1
         env:


### PR DESCRIPTION
The required `cla` status was the "stuck PR" culprit: CLA Assistant runs queued ~30 minutes, then failed after 15, so the status never reported and PRs sat blocked at "expected" (every recent merge needed `--admin`; PRs #441–#445 never even got a run before merging).

- Maintainer/bot pull requests now pass the `cla` job immediately via a fast-path step — the full action only runs for external contributors.
- `timeout-minutes: 10` caps the action so a hang can never occupy the run for 15+ minutes.
- A per-PR concurrency group cancels superseded runs.

Since `pull_request_target` executes the BASE branch workflow, this takes effect for all PRs once merged (this PR itself still needs one last admin merge under the old workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)