### PR TITLE
fix(core, libtilde): minor fixes to compile on Debian

### DIFF
--- a/core/src/csh.cpp
+++ b/core/src/csh.cpp
@@ -389,7 +389,8 @@ struct Interp {
         bool first = true;
         for (size_t k = 0; k < o.size();) {
           if (o[k] == ' ' || o[k] == '\t' || o[k] == '\n') { k++; continue; }
-          if (!first) flush(); first = false;
+          if (!first) flush();
+          first = false;
           while (k < o.size() && o[k] != ' ' && o[k] != '\t' && o[k] != '\n') push_char(o[k++]);
         }
         continue;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3540,9 +3540,9 @@ std::vector<std::string> brace_expand(const std::string &text) {
                 auto fmt = [&](long v) {
                   if (!pad) return std::to_string(v);
                   bool neg = v < 0;
-                  std::string d = std::to_string(neg ? -v : v);
-                  while (d.size() < width) d = "0" + d;
-                  return (neg ? "-" : "") + d;
+                  std::string ds = std::to_string(neg ? -v : v);
+                  while (ds.size() < width) ds = "0" + ds;
+                  return (neg ? "-" : "") + ds;
                 };
                 unsigned long long span =
                     (va <= vb) ? static_cast<unsigned long long>(vb) - static_cast<unsigned long long>(va)

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -7,6 +7,7 @@
 #include "gnash/core/subscript.hpp"
 
 #include <cctype>
+#include <cstring>
 #include <cstdlib>
 #include <cwchar>
 #include <set>

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -52,7 +52,11 @@ Shell::Shell() {
   set("PPID", std::to_string(static_cast<long>(getppid())));
   set("$", std::to_string(static_cast<long>(getpid())));
   // bash exposes the real/effective user id as readonly integer variables.
-  for (const auto &uv : {std::make_pair("UID", getuid()), std::make_pair("EUID", geteuid())}) {
+  const std::initializer_list<std::pair<const char *, unsigned int>> uid_vars = {
+    {"UID", static_cast<unsigned int>(getuid())},
+    {"EUID", static_cast<unsigned int>(geteuid())}
+  };
+  for (const auto &uv : uid_vars) {
     set(uv.first, std::to_string(static_cast<long>(uv.second)));
     Variable &v = vars[uv.first];
     v.integer = true;

--- a/libtilde/src/tilde.cpp
+++ b/libtilde/src/tilde.cpp
@@ -163,7 +163,7 @@ extern "C" char *tilde_expand(const char *string) {
       result = static_cast<char *>(
           xrealloc(result, 1 + (result_size += static_cast<size_t>(start) + 20)));
 
-    std::strncpy(result + result_index, string, static_cast<size_t>(start));
+    std::memcpy(result + result_index, string, static_cast<size_t>(start));
     result_index += static_cast<size_t>(start);
     string += start;
 


### PR DESCRIPTION
csh: set first = false before consuming chars
expand: rename local var d to ds to avoid shadowing the outer d declared at line 3476
lexer: add missing #include <cstring>
shell: extract inline initializer_list into named variable
tilde: replace strncpy with memcpy for known-length copy