### PR TITLE
fix(expand,test,cond): finish quotearray (9 -> 0), test 121 -> 118

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -583,6 +583,15 @@ struct TestEval {
       // array treats them as ordinary literal keys (bash).
       auto vit = sh.vars.find(sh.deref(nm));
       bool assoc = vit != sh.vars.end() && vit->second.kind == VarKind::Assoc;
+      // Without assoc_expand_once, `test -v' expands an associative subscript
+      // a SECOND time (the word expansion was the first): with a key holding
+      // `$(echo foo)' literally, `test -v aa["$k"]' looks for `foo' and fails
+      // (quotearray1.sub).  ASSIGNMENT, by contrast, keeps the literal key.
+      if (assoc && !expand_once_on(sh) && sub != "@" && sub != "*" &&
+          sub.find_first_of("$`") != std::string::npos) {
+        Expander tex(sh);
+        sub = tex.expand_no_split(sub, false, /*do_procsub=*/false);
+      }
       if (!assoc && (sub == "@" || sub == "*")) return sh.array_count(nm) > 0;
       for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
       return false;
@@ -625,18 +634,7 @@ struct TestEval {
       if (o == 'n') { std::string s = a[i + 1]; i += 2; return !s.empty(); }
       if (o == 'v') { std::string arg = a[i + 1]; i += 2; return var_is_set(arg); }
     }
-    // A malformed element reference reaching the BINARY stage is bash's
-    // `binary operator expected': `test -v aa[$(echo foo)]' word-splits into
-    // `-v', `aa[$(echo', `foo)]' -- three arguments, no valid operator
-    // (quotearray1.sub).
-    if (i + 2 <= end && i + 1 < end && a[i].find('[') != std::string::npos &&
-        a[i].find(']') == std::string::npos) {
-      std::fprintf(stderr, "%stest: %s: binary operator expected\n",
-                   sh.err_prefix().c_str(), a[i].c_str());
-      ok = false;
-      i = end;
-      return false;
-    }
+
     // binary: a OP b
     if (i + 2 < end + 1 && i + 2 <= end) {
       std::string lhs = a[i];
@@ -666,6 +664,23 @@ int bi_test(Shell &sh, const std::vector<std::string> &argv, bool bracket) {
     a.pop_back();
   }
   if (a.empty()) return 1;
+  // bash dispatches `test' by ARGUMENT COUNT (test.c three_arguments): with
+  // exactly three, the middle one must be a binary operator unless the form
+  // is `! ARG1 ARG2' or `( ARG )'.  Otherwise it is `ARG1: binary operator
+  // expected' with status 2 -- which is what a word-split element reference
+  // produces (`test -v aa[$(echo foo)]' -> -v, aa[$(echo, foo)] --
+  // quotearray1.sub).
+  if (a.size() == 3 && a[0] != "!" && !(a[0] == "(" && a[2] == ")")) {
+    static const std::set<std::string> kBin = {
+        "=", "==", "!=", "<", ">", "-eq", "-ne", "-lt",
+        "-le", "-gt", "-ge", "-ef", "-nt", "-ot",
+        "-a", "-o"};  // the connectives also join two one-argument tests
+    if (!kBin.count(a[1])) {
+      std::fprintf(stderr, "%s%s: %s: binary operator expected\n", sh.err_prefix().c_str(),
+                   bracket ? "[" : "test", a[1].c_str());
+      return 2;
+    }
+  }
   TestEval te{sh, a, 0, a.size(), true};
   bool v = te.expr();
   if (!te.ok) return 2;  // a usage/syntax error: bash's status 2
@@ -6694,7 +6709,11 @@ struct CondEval {
           std::string nm = arg.substr(0, br);
           std::string sub = arg.substr(br + 1, arg.size() - br - 2);
           if (!sh.array_expand_once_ok(nm, sub)) return false;  // diagnostic printed
-          if (sub == "@" || sub == "*") return sh.array_count(nm) > 0;
+          // For an INDEXED array `@'/`*' means "any element set"; for an
+          // ASSOCIATIVE one they are ordinary literal keys (quotearray4.sub).
+          auto cvit = sh.vars.find(sh.deref(nm));
+          bool cassoc = cvit != sh.vars.end() && cvit->second.kind == VarKind::Assoc;
+          if (!cassoc && (sub == "@" || sub == "*")) return sh.array_count(nm) > 0;
           for (const std::string &k : sh.array_keys(nm)) if (k == sub) return true;
           return false;
         }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2603,13 +2603,16 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     std::string args = rest.substr(1);
     size_t colon2 = length_colon(args);
     bool ok = true;
-    long long off = eval_arith(
-        sh, ex.expand_no_split(colon2 == std::string::npos ? args : args.substr(0, colon2),
-                               false, false),
-        &ok);
+    // Offset and length are ARITHMETIC contexts: expand them the way (( ))
+    // does so a `NAME[...]' subscript is copied raw and expanded exactly once
+    // by the evaluator -- keys holding `]'/`['/$(...) then resolve
+    // (`${string:A[%]:A[$k3]}' with k3=`]' -- quotearray.tests).
+    std::string offtxt = colon2 == std::string::npos ? args : args.substr(0, colon2);
+    long long off = eval_arith_msg(sh, ex.expand_arith(offtxt), "", &ok, /*expand_subs=*/1);
     long long len = -1;
     if (colon2 != std::string::npos)
-      len = eval_arith(sh, ex.expand_no_split(args.substr(colon2 + 1), false, false), &ok);
+      len = eval_arith_msg(sh, ex.expand_arith(args.substr(colon2 + 1)), "", &ok,
+                           /*expand_subs=*/1);
     // Offset and length are counted in characters (bash), not bytes: map them
     // through mb_byteoff so a UTF-8 value slices on code-point boundaries.
     long long n = static_cast<long long>(mb_charlen(val));


### PR DESCRIPTION
Finishes #450.

quotearray.tests: 9 -> **0 (byte-perfect)**; test.tests 121 -> **118** as a side effect. Two commits:

- **fix(expand)**: substring offsets and lengths are arithmetic contexts — `${string:A[%]:A[$k3]}` now evaluates them the way `(( ))` does (arith-context expansion plus one-shot subscript expansion), so an associative key holding `]`, `[`, or `$(...)` resolves instead of breaking the subscript parse.
- **fix(test,cond)**: `test` with exactly three arguments requires a binary operator in the middle unless the form is `! A B` or `( A )` — otherwise `ARG: binary operator expected` with status 2, which is exactly what a word-split element reference produces (`test -v aa[$(echo foo)]` → `-v`, `aa[$(echo`, `foo)]`). The `-a`/`-o` connectives count as binary here, matching bash's dispatch, and that alone retires three long-standing test.tests diffs. Also: without assoc_expand_once, `test -v` expands an associative subscript a second time (assignment keeps the literal key), and `@`/`*` are literal keys for an associative array in `[[ -v a[@] ]]`.

Verified: ctest 22/22; run_diff all 240; full sweep shows quotearray 9 -> 0 and test 121 -> 118, nothing else moved. **52 of 83 suites now byte-perfect.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
