### PR TITLE
fix(comsub): alias-aware spans, here-documents pending across the span (22 -> 14)

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -11,6 +11,7 @@
 #ifndef GNASH_CORE_LEXER_HPP
 #define GNASH_CORE_LEXER_HPP
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -84,7 +85,16 @@ const char *tok_name(Tok t);
 // (quote/case/comment/heredoc-aware); npos when unterminated.
 std::size_t comsub_span_end(const std::string &text, std::size_t open_pos);
 
-std::vector<Token> tokenize(const std::string &input, bool posix_mode = false);
+// Same, but resolving one level of ALIAS for the `case'/`esac' keywords: bash
+// expands aliases while scanning substitution content, so `alias switch=case'
+// makes `$( switch x in y) ...;; esac )' scan correctly (comsub5.sub).  Pass
+// the shell's alias table; names whose expansion is exactly `case' or `esac'
+// are treated as that keyword.
+std::size_t comsub_span_end_aliased(const std::string &text, std::size_t open_pos,
+                                    const std::map<std::string, std::string> &aliases);
+
+std::vector<Token> tokenize(const std::string &input, bool posix_mode = false,
+                            const std::map<std::string, std::string> *span_aliases = nullptr);
 
 }  // namespace gnash::core
 

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1134,7 +1134,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     // knows case patterns (`$(case x in in|esac) ...;; esac)'), comments,
     // and here-documents; fall back to the plain balanced scan if it calls
     // the span unterminated.
-    size_t end = comsub_span_end(t, i + 1);
+    size_t end = sh_.aliases_active() ? comsub_span_end_aliased(t, i + 1, sh_.aliases)
+                                      : comsub_span_end(t, i + 1);
     end = (end == std::string::npos) ? scan_balanced(t, i + 1, '(', ')') : end - 1;
     if (end != std::string::npos) {
       std::string inner = t.substr(i + 2, end - (i + 2));

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -68,6 +68,9 @@ struct Lexer {
   std::size_t n;
   std::vector<Token> out;
   std::vector<Pending> pending;
+  // Alias table used ONLY to recognize `case'/`esac' through one alias level
+  // while scanning a substitution span (see comsub_span_end_aliased).
+  const std::map<std::string, std::string> *span_aliases = nullptr;
   // Heredocs pending when a $(...) closed mid-line (bash warns `command
   // substitution: N unterminated here-document'); converted into comsub
   // Pending entries when the containing word token lands.
@@ -159,7 +162,7 @@ struct Lexer {
   }
   void scan_paren(std::string &w, bool comsub_ctx = false) {  // pos at '('
     int depth = 0;
-    struct PHd { std::string delim; bool strip; int depth; };
+    struct PHd { std::string delim; bool strip; int depth; bool quoted; };
     std::vector<PHd> paren_heredocs;  // pending heredocs inside the parens
     // A `)' that terminates a `case' pattern (`case x in x)') must not be
     // mistaken for the substitution's closing paren.  Track the paren depth of
@@ -173,10 +176,21 @@ struct Lexer {
     std::string word;             // current unquoted identifier word
     bool word_plain = true;       // word is only identifier chars (a keyword?)
     bool saw_word = false;        // any word content since the last delimiter
+    auto kw = [&](const std::string &w2) -> std::string {
+      if (!span_aliases) return w2;
+      auto it = span_aliases->find(w2);
+      if (it == span_aliases->end()) return w2;
+      std::string v = it->second;
+      while (!v.empty() && (v.back() == ' ' || v.back() == '\t')) v.pop_back();
+      size_t s = v.find_first_not_of(" \t");
+      if (s != std::string::npos) v = v.substr(s);
+      return (v == "case" || v == "esac") ? v : w2;
+    };
     auto boundary = [&]() {
       if (saw_word) {
-        if (cmd_pos && word_plain && word == "case") case_stack.push_back(depth);
-        else if (word_plain && word == "esac" && !case_stack.empty() && !after_pipe)
+        std::string word_kw = kw(word);
+        if (cmd_pos && word_plain && word_kw == "case") case_stack.push_back(depth);
+        else if (word_plain && word_kw == "esac" && !case_stack.empty() && !after_pipe)
           // `esac' closes the case even out of command position: after a
           // stray `done' (`$(case x in x) ;; x) done esac)') bash's scanner
           // still ends the case body and finds the substitution's closer,
@@ -230,24 +244,27 @@ struct Lexer {
         if (strip_tabs) { w += '-'; pos++; }
         while (pos < n && (in[pos] == ' ' || in[pos] == '\t')) { w += in[pos]; pos++; }
         std::string delim;
+        bool dquoted = false;
         while (pos < n && !std::isspace(static_cast<unsigned char>(in[pos])) &&
                !std::strchr(";&|()<>", in[pos])) {
           char dc = in[pos];
           if (dc == '\'' || dc == '"') {
+            dquoted = true;
             char q = dc;
             w += in[pos++];
             while (pos < n && in[pos] != q) { delim += in[pos]; w += in[pos]; pos++; }
             if (pos < n) { w += in[pos]; pos++; }
             continue;
           }
-          if (dc == '\\' && pos + 1 < n) { w += dc; pos++; dc = in[pos]; }
+          if (dc == '\\' && pos + 1 < n) { dquoted = true; w += dc; pos++; dc = in[pos]; }
           delim += dc;
           w += dc;
           pos++;
         }
         // Only depth 1 is a real here-document: `<<'/`>>' at depth 2 inside
         // `$((...))' are the arithmetic shifts (multiline $(( )) bodies).
-        if (!delim.empty() && depth == 1) paren_heredocs.push_back({delim, strip_tabs, depth});
+        if (!delim.empty() && depth == 1)
+          paren_heredocs.push_back({delim, strip_tabs, depth, dquoted});
         saw_word = true;
         word_plain = false;
       } else if (c == ';' || c == '&' || c == '|' || c == '\n') {
@@ -286,7 +303,18 @@ struct Lexer {
               w += line;
               if (had_nl) { w += '\n'; pos++; }
               if (cmp == hd.delim) break;
-              if (!had_nl) break;
+              if (!had_nl) {
+                // Input ended inside the body: the command is incomplete and
+                // the reader must know the delimiter's quoting (a trailing
+                // `\' in a QUOTED body is literal, not a continuation).
+                if (!heredoc_eof) {
+                  heredoc_eof = true;
+                  heredoc_eof_delim = hd.delim;
+                  heredoc_eof_line = line_for(pos);
+                  heredoc_eof_quoted = hd.quoted;
+                }
+                break;
+              }
             }
           }
           paren_heredocs.clear();
@@ -326,7 +354,21 @@ struct Lexer {
         pos++;
       }
     } while (pos < n && depth > 0);
-    if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = ')'; }
+    if (depth > 0) {
+      unterminated = true;
+      if (!unterm_close) unterm_close = ')';
+      // Input ended with the substitution still open and a here-document
+      // registered inside it: the reader must know a BODY is pending (and
+      // its delimiter's quoting) before it sees any body line, so a trailing
+      // `\' in a quoted body is literal rather than a line continuation
+      // (comsub4.sub).
+      if (!paren_heredocs.empty() && !heredoc_eof) {
+        heredoc_eof = true;
+        heredoc_eof_delim = paren_heredocs.front().delim;
+        heredoc_eof_line = line_for(pos);
+        heredoc_eof_quoted = paren_heredocs.front().quoted;
+      }
+    }
     // The substitution closed on the same line with here-documents still
     // pending: carry them out so their bodies come from the lines after the
     // full command (spliced back in before the closer), with bash's warning.
@@ -896,10 +938,22 @@ std::size_t comsub_span_end(const std::string &text, std::size_t open_pos) {
   return lx.unterminated ? std::string::npos : lx.pos;
 }
 
+std::size_t comsub_span_end_aliased(const std::string &text, std::size_t open_pos,
+                                    const std::map<std::string, std::string> &aliases) {
+  Lexer lx{text};
+  lx.pos = open_pos;
+  lx.span_aliases = &aliases;
+  std::string dummy;
+  lx.scan_paren(dummy);
+  return lx.unterminated ? std::string::npos : lx.pos;
+}
 
-std::vector<Token> tokenize(const std::string &input, bool posix_mode) {
+
+std::vector<Token> tokenize(const std::string &input, bool posix_mode,
+                            const std::map<std::string, std::string> *span_aliases) {
   Lexer lx(input);
   lx.posix = posix_mode;
+  lx.span_aliases = span_aliases;
   lx.run();
   return std::move(lx.out);
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1139,6 +1139,15 @@ struct Parser {
       res.error = cl ? std::string("unexpected EOF while looking for matching `") + cl + "'"
                      : std::string("unterminated quoted string or substitution");
       res.error_line = toks.back().line;
+      // An unterminated span may still have a here-document pending inside
+      // it; the reader needs the delimiter's quoting to decide whether a
+      // trailing `\' is a line continuation (comsub4.sub).
+      if (toks.back().heredoc_eof) {
+        res.heredoc_eof = true;
+        res.heredoc_eof_delim = toks.back().heredoc_eof_delim;
+        res.heredoc_eof_line = toks.back().heredoc_eof_line;
+        res.heredoc_eof_quoted = toks.back().heredoc_eof_quoted;
+      }
       return res;
     }
     newline_list();
@@ -1471,8 +1480,21 @@ static AliasExpansion alias_splice_text(const std::string &input,
 // in x) ;; x) done esac)' -> "near unexpected token `done' while ...").
 // Spans starting `$((' are skipped (arithmetic or `$( (subshell' -- both
 // validated elsewhere); quoted (') and escaped `$(' are literal.
+ParseResult parse_with_aliases(const std::string &input,
+                               const std::map<std::string, std::string> &aliases,
+                               const std::map<std::string, std::string> &global_aliases,
+                               const std::map<std::string, std::string> &suffix_aliases,
+                               bool posix_mode);
+
+struct AliasTables {
+  const std::map<std::string, std::string> *aliases;
+  const std::map<std::string, std::string> *global_aliases;
+  const std::map<std::string, std::string> *suffix_aliases;
+};
+
 static bool validate_comsubs(const std::vector<Token> &toks, bool posix_mode,
-                             ParseResult &res, int depth) {
+                             ParseResult &res, int depth,
+                             const AliasTables *at = nullptr) {
   if (depth > 16) return true;
   for (const Token &t : toks) {
     if (t.type != Tok::Word) continue;
@@ -1487,12 +1509,18 @@ static bool validate_comsubs(const std::vector<Token> &toks, bool posix_mode,
       if (i + 2 < w.size() && w[i + 2] == '(') { i++; continue; }  // $(( form
       // The lexer's own scanner finds the closer (case patterns, quotes,
       // comments, and here-documents included).
-      std::size_t jend = comsub_span_end(w, i + 1);
+      std::size_t jend = at ? comsub_span_end_aliased(w, i + 1, *at->aliases)
+                            : comsub_span_end(w, i + 1);
       if (jend == std::string::npos) break;  // unterminated: already flagged
       size_t j = jend - 1;  // the `)'
       std::string inner = w.substr(i + 2, j - (i + 2));
       if (inner.find_first_not_of(" \t\n") == std::string::npos) { i = j; continue; }
-      ParseResult ir = parse(inner, posix_mode);
+      // bash parses substitution content with ALIASES ACTIVE (posix mode
+      // requires it), so `$( switch foo in foo) ... esac )' with
+      // `alias switch=case' is valid (comsub5.sub).
+      ParseResult ir = at ? parse_with_aliases(inner, *at->aliases, *at->global_aliases,
+                                               *at->suffix_aliases, posix_mode)
+                          : parse(inner, posix_mode);
       if (!ir.ok) {
         res.ok = false;
         res.command.reset();
@@ -1529,7 +1557,9 @@ ParseResult parse_with_aliases(const std::string &input,
                                bool posix_mode) {
   AliasExpansion ax =
       alias_splice_text(input, aliases, global_aliases, suffix_aliases, posix_mode);
-  std::vector<Token> toks = tokenize(ax.text, posix_mode);
+  // The substitution scanner resolves `case'/`esac' through one alias level,
+  // so a `$( switch x in y) ...;; esac )' span ends at the right `)'.
+  std::vector<Token> toks = tokenize(ax.text, posix_mode, &aliases);
   if (ax.changed) {
     // Tokens report the line of the byte they start at: original bytes keep
     // their physical line, spliced bytes the invoking word's line.  The Eof
@@ -1541,6 +1571,9 @@ ParseResult parse_with_aliases(const std::string &input,
     }
   }
   Parser p(std::move(toks));
+  AliasTables at{&aliases, &global_aliases, &suffix_aliases};
+  ParseResult pre;
+  if (!validate_comsubs(p.toks, posix_mode, pre, 0, &at)) return pre;
   return p.run();
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2076,8 +2076,20 @@ int Shell::run_script_lines(const std::string &text) {
     // character, not a line continuation.  In an unquoted here-document bash
     // still splices `\<newline>' (before even checking for the delimiter), so
     // only suppress the continuation for a quoted delimiter.
+    // A pending here-document with a QUOTED delimiter makes a trailing `\'
+    // literal body text.  in_heredoc reflects the PREVIOUS parse, so also ask
+    // the parse of the text INCLUDING this line -- the `<<' may have been read
+    // only now (`x=$(cat <<'"'"'EOT'"'"'' then a body line -- comsub4.sub).
+    bool hd_quoted_now = in_heredoc && in_heredoc_quoted;
+    if (nbs % 2 == 1 && !hd_quoted_now) {
+      ParseResult hc = aliases_active()
+                           ? parse_with_aliases(pending, aliases, global_aliases,
+                                                suffix_aliases, opt_posix)
+                           : parse(pending, opt_posix);
+      hd_quoted_now = hc.heredoc_eof && hc.heredoc_eof_quoted;
+    }
     if (nbs % 2 == 1 && !squote_backslash_literal(pending) && !ends_in_comment(pending) &&
-        !(in_heredoc && in_heredoc_quoted)) {
+        !hd_quoted_now) {
       pending.pop_back();
       cont_bslash = true;
       continue;


### PR DESCRIPTION
Addresses #453 (clusters 1 and 2; the unbalanced-paren aliases stay open on the issue).

comsub.tests: 22 -> **14**. One commit:

- **Alias-aware substitution spans.** The scanner resolves `case`/`esac` through one alias level, `tokenize()` and `comsub_span_end()` accept the alias table, and the recursive validator parses substitution content with aliases active — so `alias switch=case` makes `$( switch foo in foo) echo ok 2;; esac )` span and parse the way bash's POSIX mode does (comsub5.sub).
- **Here-documents pending across an unterminated span.** A here-document registered inside an unclosed `$( )` now marks the parse's heredoc-EOF state (delimiter plus its quoting), the lex-error return path propagates it, and the line reader re-parses the pending text before deciding whether a trailing backslash is a continuation. `x=$(cat <<'EOT'` with a body line ending in `\` keeps it literal instead of splicing the next line (comsub4.sub).

Verified: ctest 22/22; run_diff all 240; full sweep shows comsub 22 -> 14 as the only change (alias/nquote/precedence/heredoc all stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
