### PR TITLE
fix(funsub,posix): errexit inheritance, private REPLY, posix expand_aliases (comsub2 20 -> 4)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1650,7 +1650,14 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   else if (o == "noclobber") sh.opt_noclobber = on;
   else if (o == "history") { if (on) sh.enable_history(); else sh.opt_history = false; }
   else if (o == "histexpand") sh.opt_histexpand = on;
-  else if (o == "posix") sh.opt_posix = on;
+  else if (o == "posix") {
+    // Entering POSIX mode turns `expand_aliases' on (aliases are expanded in
+    // non-interactive shells there) and leaving it turns the option back off,
+    // exactly as bash's sv_strict_posix does -- `shopt expand_aliases' inside
+    // a posix-mode script reports `on' (comsub2.tests).
+    if (on != sh.opt_posix) sh.shopt_opts["expand_aliases"] = on;
+    sh.opt_posix = on;
+  }
   else if (o == "restricted") {
     if (on) sh.opt_restricted = true;
     else return false;  // cannot clear restricted; caller reports the error

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2268,20 +2268,37 @@ std::string Shell::run_and_capture_inproc(const std::string &script, int *status
   }
   int saved_base = lineno_base;  // run at the enclosing command's line
   lineno_base = cur_lineno - 1;
+  // A valsub's $REPLY is private: bash saves and restores it around the body,
+  // so `${| REPLY=x; }' leaves the caller's REPLY untouched (comsub26.sub).
+  bool had_reply = false;
+  Variable saved_reply;
+  if (valsub) {
+    auto rit = vars.find("REPLY");
+    if (rit != vars.end()) { had_reply = true; saved_reply = rit->second; }
+  }
   // A funsub runs in a fresh local scope (so a `local' inside it does not leak)
   // and is a return boundary like a function body: `return' ends the funsub
   // (its status becomes the funsub's) rather than unwinding the caller.
   bool saved_returning = returning;
   returning = false;
+  // Like a command substitution, a funsub does not inherit errexit unless
+  // `shopt -s inherit_errexit' or POSIX mode says otherwise: `${ false;
+  // echo after; }' still runs the echo under `set -e' (comsub22.sub).
+  bool saved_errexit = opt_errexit;
+  if (opt_errexit && !opt_posix && !shopt_opts["inherit_errexit"]) opt_errexit = false;
   push_scope();
   int st = run_string(script);
   pop_scope();
+  opt_errexit = saved_errexit;
   if (returning) { st = exit_status; returning = false; }
   returning = saved_returning;
   lineno_base = saved_base;
   if (valsub) {
     if (status) *status = st;
-    return get("REPLY");
+    std::string reply = get("REPLY");
+    if (had_reply) vars["REPLY"] = saved_reply;
+    else vars.erase("REPLY");
+    return reply;
   }
   std::fflush(stdout);
   dup2(saved, STDOUT_FILENO);


### PR DESCRIPTION
comsub2.tests: 20 -> **4**. One commit, three independent bash behaviors:

- **Funsub errexit**: a `${ ...; }` body does not inherit `set -e` unless `shopt -s inherit_errexit` or POSIX mode says so — exactly like a command substitution — so `${ false; echo after; }` still runs the echo (comsub22.sub now matches byte-for-byte, including the posix half where the shell *does* exit).
- **Private `$REPLY`**: bash saves and restores REPLY around a valsub, so `${| REPLY=x; }` leaves the caller's REPLY untouched (comsub26.sub).
- **`set -o posix` toggles `expand_aliases`**: entering POSIX mode turns the option on and leaving turns it off (bash's `sv_strict_posix`), so `shopt expand_aliases` reports `on` inside a posix-mode script.

Remaining 4 lines: bash's line attribution for a command inside a multi-line `${ }` (it reports a body-relative line that differs from the physical one in both directions depending on the case) — parked with the error-text batch.

Verified: ctest 22/22; run_diff all 240; full sweep shows comsub2 20 -> 4 as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
