### PR TITLE
fix(procsub): $! names the substitution child and it stays waitable (procsub -> 0)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -385,6 +385,9 @@ class Shell {
   // --- process substitutions <(...) / >(...) live for one command ---------
   struct ProcSub { long pid; int fd; };
   std::vector<ProcSub> procsubs;
+  // Exit status of already-reaped process-substitution children, so a later
+  // `wait "$!"' can still report it (bash keeps them waitable).
+  std::map<long, int> reaped_procsub_status;
   // Close fds and wait for substitution children added since index `from`.
   void reap_procsubs(size_t from = 0);
 

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -6296,6 +6296,25 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
             long pp = std::atol(spec.c_str());
             Shell::Job *pj = sh.job_by_spec(spec);
             if (!pj) {
+              // A process-substitution child is waitable too, though it is not
+              // a job: `cat <(exit 123); wait "$!"' reports 123 (procsub1.sub).
+              bool is_procsub = false;
+              for (const auto &ps : sh.procsubs)
+                if (ps.pid == pp) { is_procsub = true; break; }
+              if (is_procsub) {
+                st = sh.wait_for_pid(pp);
+                finished_pid = pp;
+                found = true;
+                continue;
+              }
+              auto rps = sh.reaped_procsub_status.find(pp);
+              if (rps != sh.reaped_procsub_status.end()) {
+                st = rps->second;
+                finished_pid = pp;
+                found = true;
+                sh.reaped_procsub_status.erase(rps);
+                continue;
+              }
               std::fprintf(stderr, "%swait: pid %ld is not a child of this shell\n",
                            sh.err_prefix().c_str(), pp);
               st = 127;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3221,6 +3221,9 @@ std::string spawn_procsub(Shell &sh, const std::string &cmd, bool input) {
   close(input ? fds[1] : fds[0]);
   if (pid < 0) { close(keep); return std::string(); }
   sh.procsubs.push_back({static_cast<long>(pid), keep});
+  // bash sets $! to the process-substitution child, so `cat <(exit 123)'
+  // can be followed by `wait "$!"' (procsub1.sub).
+  sh.last_bg_pid = static_cast<int>(pid);
   return "/dev/fd/" + std::to_string(keep);
 }
 }  // namespace

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -405,7 +405,14 @@ void Shell::reap_procsubs(size_t from) {
   for (size_t k = from; k < procsubs.size(); k++) {
     if (procsubs[k].fd >= 0) close(procsubs[k].fd);
     int st = 0;
-    waitpid(static_cast<pid_t>(procsubs[k].pid), &st, 0);
+    if (waitpid(static_cast<pid_t>(procsubs[k].pid), &st, 0) > 0) {
+      // Remember the status so a later `wait "$!"' can report it: bash keeps
+      // process-substitution children waitable after the command that
+      // created them finishes (procsub1.sub).
+      int rc = WIFEXITED(st) ? WEXITSTATUS(st)
+                             : 128 + (WIFSIGNALED(st) ? WTERMSIG(st) : 0);
+      reaped_procsub_status[procsubs[k].pid] = rc;
+    }
   }
   if (from < procsubs.size()) procsubs.resize(from);
 }


### PR DESCRIPTION
procsub.tests: 3 -> **0 (byte-perfect)** — 53 of 83 suites now match bash byte-for-byte.

bash sets `$!` to a process substitution's child and keeps it waitable, so `cat <(exit 123) >/dev/null; wait "$!"` reports 123. Three pieces:

- the spawner records the child's pid as `$!`;
- `wait` accepts a live process-substitution child, not just jobs;
- `reap_procsubs` remembers the status of a child it already collected, so a `wait` issued after the creating command finishes still reports it.

Verified: ctest 22/22; run_diff all 240; full sweep shows procsub 3 -> 0 as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
