### PR TITLE
fix(compgen,read,arith): finish complete, read, and array suites (56 byte-perfect)

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -736,9 +736,13 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing 
       // identifier (with the command prefix).
       ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
     } else {
-      // `(( y[$none] ))' -- a read: y[]: bad array subscript (bare).
+      // `(( y[$none] ))' -- a read: y[]: bad array subscript (bare).  bash
+      // reports it TWICE: once while resolving the reference and again when
+      // the arithmetic command reports the failed expression (array27.sub).
       ctx.full_msg = n->name + "[]: bad array subscript";
       ctx.full_msg_bare = true;
+      if (ctx.expand_subs == 1)
+        std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), ctx.full_msg.c_str());
     }
     return false;
   }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1972,8 +1972,11 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   }
 
   // With -e bash reads through readline, whose setup dominates a
-  // sub-millisecond timeout: the read times out before seeing any input.
-  if (edit && have_t && timeout > 0.0 && timeout < 0.001) {
+  // sub-millisecond timeout: the read times out before seeing any input --
+  // but only on a TERMINAL.  Off a terminal readline reads the fd directly,
+  // so an already-at-EOF input returns failure (status 1) immediately, with
+  // no timeout at all (read7.sub under the test harness).
+  if (edit && have_t && timeout > 0.0 && timeout < 0.001 && isatty(fd)) {
     for (const std::string &nm : names) sh.set(nm, std::string());
     return 128 + SIGALRM;
   }
@@ -2216,7 +2219,13 @@ bool is_builtin_name(const std::string &n) {
 
 std::vector<std::string> builtin_names_sorted() {
   std::vector<std::string> v;
-  for (int i = 0; kBuiltinNames[i]; i++) v.emplace_back(kBuiltinNames[i]);
+  for (int i = 0; kBuiltinNames[i]; i++) {
+    // `personality' is gnash's own pseudo-builtin: it is not part of bash's
+    // shell_builtins[], so listings (`compgen -b', `complete -A builtin',
+    // `enable') leave it out to stay byte-compatible.
+    if (std::strcmp(kBuiltinNames[i], "personality") == 0) continue;
+    v.emplace_back(kBuiltinNames[i]);
+  }
   std::sort(v.begin(), v.end());
   return v;
 }


### PR DESCRIPTION
Three one-line-cause suites finished: **complete 3 -> 0, read 2 -> 0, array 1 -> 0**. With procsub earlier today that makes **56 of 83 suites byte-perfect**.

- **`personality` is hidden from builtin listings.** It is gnash's own pseudo-builtin and not part of bash's `shell_builtins[]`, so `compgen -b`, `complete -A builtin`, and `enable` must not list it (it still runs, of course).
- **`read -e` with a sub-millisecond timeout only short-circuits on a terminal.** Off a terminal readline reads the fd directly, so an at-EOF input fails immediately with status 1 instead of reporting a timeout — which is what bash does under the test harness.
- **`(( y[$unset] ))` reports `y[]: bad array subscript` twice**, as bash does: once while resolving the reference and again when the arithmetic command reports the failed expression.

Verified: ctest 22/22; run_diff all 240; full sweep shows the three suites reaching 0 with nothing else moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
