### PR TITLE
fix(expand): junk after a subscript is a bad substitution (#459)

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2283,6 +2283,16 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     have_sub = true;
   }
 
+  // Text left after a `name[sub]' reference must be an operator: bash rejects
+  // `${a[0]junk}' and `${a[0] + b[y]}' as `bad substitution' rather than
+  // silently reading the element and dropping the rest (issue #459).
+  if (have_sub && p < b.size() && !sh.is_zsh() &&
+      !std::strchr(":-+=?#%/^,@", b[p])) {
+    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+    sh.arith_error = true;
+    return std::string();
+  }
+
   // zsh: `${#a}' on an array is the element count (bash gives the length of
   // element 0); `${#a[i]}' keeps its meaning (length of that element).
   if (length && !have_sub && sh.is_zsh() && sh.is_array(name))


### PR DESCRIPTION
Fixes #459.

The reported symptom — `${a[10'] + b['y']}` silently expanding to nothing instead of bash's `bad substitution` — is one instance of a broader gap: gnash accepted **any** trailing text after a `name[sub]` reference and dropped it.

```
$ gnash -c 'declare -A a b; a[0]=100; b[y]=200; echo "[${a[0] + b[y]}]"'
[100]                    # bash: bad substitution
$ gnash -c 'declare -a a=(5); echo "[${a[0]junk}]"'
[5]                      # bash: bad substitution
```

Text following a subscript must begin an operator (`:-+=?#%/^,@`); anything else now reports `${BODY}: bad substitution` and aborts the command, matching bash. The issue's reproduction script now produces byte-identical output from both shells.

I kept the paired-quote scan in `read_ref()` as is: it is reached only for genuine arithmetic subscripts, and with this check in place the malformed `${...}` never gets that far. If a case turns up where the quote scan itself misreads a *valid* expression, that's worth a separate fix — a repro would be very welcome.

Verified: ctest 22/22; run_diff.sh all 240 match; full 83-suite sweep unchanged (57 byte-perfect, no regressions), with `${a[0]}`, `${a[@]}`, `${a[@]:1:1}`, `${a[0]:-d}`, `${a[0]#1}`, and `${a[0]@Q}` all still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
