### PR TITLE
fix(quoting): comsub quoting context and trailing-backslash rules (quote -> 0)

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2905,7 +2905,13 @@ void Expander::process(const std::string &text, std::string &out, std::string &m
         else if (nx == '\n') { i += 2; }  // line continuation
         else { out += c; mask += '2'; i++; }
       } else if (i + 1 < text.size()) { out += text[i + 1]; mask += '1'; i += 2; }
-      else i++;
+      else {
+        // A backslash with nothing to escape is a literal character (bash:
+        // `echo escape\' prints the backslash -- quote.tests).
+        out += c;
+        mask += '1';
+        i++;
+      }
     } else if (c == '$') {
       expand_dollar(text, i, false, out, mask, heredoc);
     } else if (c == '`') {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1951,6 +1951,7 @@ static bool ends_in_comment(const std::string &t) {
 
 static bool squote_backslash_literal(const std::string &t) {
   bool squote = false, dquote = false, btick = false;
+  std::vector<bool> dq_stack;  // enclosing double-quote state per `$(' level
   char prev = '\n';  // start of input behaves like just after a newline
   for (size_t i = 0; i < t.size(); i++) {
     char c = t[i];
@@ -1968,6 +1969,22 @@ static bool squote_backslash_literal(const std::string &t) {
       continue;  // the for-loop's ++i steps past the newline
     }
     if (c == '\\') { if (i + 1 < t.size()) i++; prev = 'x'; continue; }
+    // A `$(' starts a fresh quoting context: single quotes are quotes again
+    // even inside the enclosing double quotes (`echo "$(echo 'foo\' ...)"' --
+    // quote.tests), so remember the outer state and restart.
+    if (c == '$' && i + 1 < t.size() && t[i + 1] == '(' && !squote) {
+      dq_stack.push_back(dquote);
+      dquote = false;
+      i++;
+      prev = '(';
+      continue;
+    }
+    if (c == ')' && !squote && !dq_stack.empty()) {
+      dquote = dq_stack.back();
+      dq_stack.pop_back();
+      prev = c;
+      continue;
+    }
     if (c == '\'' && !dquote) squote = true;
     else if (c == '"') dquote = !dquote;
     else if (c == '`') btick = !btick;
@@ -2001,7 +2018,14 @@ int Shell::run_script_lines(const std::string &text) {
     // bash reads file input with a guaranteed trailing newline; without it a
     // here-document whose delimiter is the last line of the file would be
     // (wrongly) reported as delimited by end-of-file.
-    if (pending.back() != '\n') pending += '\n';
+    {
+      // ... except after an odd run of backslashes: the synthetic newline
+      // would turn the final `\' into a line continuation and swallow it,
+      // where bash keeps it literal (`sh -c 'echo escape\'' -- quote.tests).
+      size_t tb = 0;
+      while (tb < pending.size() && pending[pending.size() - 1 - tb] == '\\') tb++;
+      if (pending.back() != '\n' && tb % 2 == 0) pending += '\n';
+    }
     st = run_string(pending);
     lineno_base = 0;
     hist_cur_cmd_index = -1;
@@ -2011,6 +2035,7 @@ int Shell::run_script_lines(const std::string &text) {
   while (pos < text.size() && !exiting && !stdin_source_changed) {
     size_t nl = text.find('\n', pos);
     std::string line = (nl == std::string::npos) ? text.substr(pos) : text.substr(pos, nl - pos);
+    bool line_had_newline = nl != std::string::npos;
     pos = (nl == std::string::npos) ? text.size() : nl + 1;
     lineno++;
 
@@ -2095,8 +2120,12 @@ int Shell::run_script_lines(const std::string &text) {
                            : parse(pending, opt_posix);
       hd_quoted_now = hc.heredoc_eof && hc.heredoc_eof_quoted;
     }
-    if (nbs % 2 == 1 && !squote_backslash_literal(pending) && !ends_in_comment(pending) &&
-        !hd_quoted_now) {
+    // A `\' before a NEWLINE is a line continuation even at end of file
+    // (parser1.sub splices `echo AAA\' + newline into `echo AAA'); a `\'
+    // that ends the input with no newline at all is literal (`sh -c 'echo
+    // escape\'' prints the backslash -- quote.tests).
+    if (nbs % 2 == 1 && line_had_newline && !squote_backslash_literal(pending) &&
+        !ends_in_comment(pending) && !hd_quoted_now) {
       pending.pop_back();
       cont_bslash = true;
       continue;


### PR DESCRIPTION
quote.tests: 7 -> **0**; comsub 4 -> **2**. **58 of 83 suites byte-perfect.** One commit, two quoting rules:

- **`$(` starts a fresh quoting context.** A single quote inside a substitution quotes again even within the enclosing double quotes, so the line reader stops splicing `echo "$(echo 'foo\` + newline + `bar')"` into one line.
- **Trailing backslashes.** A `\` before a *newline* is a line continuation even at end of file (parser1.sub relies on `echo AAA\` + newline becoming `echo AAA`), while a `\` that ends the input with **no** newline is literal. That needed three matching pieces: the reader keeps it, it stops appending its synthetic trailing newline after an odd run of backslashes, and the expander emits a backslash that has nothing to escape — so `sh -c 'echo escape\'` prints `escape\` like bash.

The first attempt got the second rule backwards (treating end-of-input as the discriminator rather than the presence of a newline) and regressed parser.tests 2 -> 4; the sweep caught it and the rule is now split correctly, with both cases verified against bash.

Verified: ctest 22/22; run_diff all 240; full sweep shows quote 7 -> 0 and comsub 4 -> 2, nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
