### PR TITLE
fix(parser,unset,for): bash's error forms (errors 12 -> 3, cond 73 -> 70)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1443,9 +1443,14 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     // A plain operand (no `[subscript]', handled above) must be a valid
     // identifier: `unset -v a-b' -> `a-b': not a valid identifier (bash).
     if (!valid_identifier(argv[i])) {
-      std::fprintf(stderr, "%sunset: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), argv[i].c_str());
-      ret = 1;
+      // Only `unset -v' reports an invalid identifier; a plain `unset' falls
+      // through to its function-unset attempt and stays silent with status 0
+      // (`unset /bin/sh' -- errors.tests), like the malformed-element case.
+      if (vflag) {
+        std::fprintf(stderr, "%sunset: `%s': not a valid identifier\n",
+                     sh.err_prefix().c_str(), argv[i].c_str());
+        ret = 1;
+      }
       continue;
     }
     // A readonly variable cannot be unset.  Resolve through a nameref (unless

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -2062,8 +2062,11 @@ int Executor::run_for(const ForCommand *c) {
         break;
       } else
         vit->second.value = item;
-    } else {
-      sh_.set(c->var, item);
+    } else if (!sh_.set(c->var, item)) {
+      // A readonly loop variable aborts the whole loop with status 1, after
+      // ONE diagnostic (bash: `for VAR in 1 2 3' with VAR readonly).
+      st = 1;
+      break;
     }
     st = run(c->body.get());
     if (sh_.break_count) { sh_.break_count--; break; }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -177,8 +177,14 @@ struct Parser {
       advance();
     else {
       if (eof_from_open()) return;
-      if (is(Tok::Eof)) incomplete = true;
-      fail(std::string("expected `") + w + "'");
+      if (is(Tok::Eof)) {
+        incomplete = true;
+        fail(std::string("expected `") + w + "'");
+        return;
+      }
+      // A real token in the wrong place is bash's "near unexpected token"
+      // (`for z in 1 2 3; done' -> near `done'), not a grammar expectation.
+      fail(std::string("near unexpected token `") + tok_to_text(cur()) + "'");
     }
   }
   void expect(Tok t, const char *name) {


### PR DESCRIPTION
errors.tests: 12 -> **3**; cond.tests 73 -> **70** as a side effect. One commit, three bash behaviors:

- **Reserved word in the wrong place** is `syntax error near unexpected token \`X'` (`for z in 1 2 3; done`), not gnash's grammar-level "expected `do'". This also feeds the recursive substitution validator, so `: $( for z in 1 2 3; done )` now gets bash's full `near unexpected token \`done' while looking for matching \`)'`.
- **Plain `unset` is silent on an invalid identifier** (`unset /bin/sh` → status 0); only `unset -v` reports one — the same asymmetry already implemented for malformed element references.
- **A readonly `for` variable aborts the loop** with status 1 after one diagnostic, instead of reporting once per iteration and running the body with the stale value.

Verified: ctest 22/22; run_diff all 240; full sweep shows errors 12 -> 3 and cond 73 -> 70, nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
