### PR TITLE
fix(shell): populate the GROUPS array (test.tests -> 0)

### DIFF
--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1691,6 +1691,24 @@ void Shell::set_personality(const std::string &name) {
     // arrays; virtual_array serves the live alias/hash tables for reads).
     for (const char *nm : {"BASH_ALIASES", "BASH_CMDS"})
       if (!vars.count(nm)) array_assign(nm, {}, false, true);
+    // GROUPS is the supplementary group list, with the REAL gid forced to
+    // element 0: bash prepends it when getgroups() omits it and swaps it
+    // forward when it is merely out of order (initialize_group_array).
+    if (!vars.count("GROUPS")) {
+      long maxg = sysconf(_SC_NGROUPS_MAX);
+      if (maxg <= 0) maxg = NGROUPS_MAX;
+      std::vector<gid_t> g(static_cast<size_t>(maxg));
+      int ng = getgroups(static_cast<int>(maxg), g.data());
+      gid_t rgid = getgid();
+      if (ng <= 0) { g[0] = rgid; ng = 1; }
+      g.resize(static_cast<size_t>(ng));
+      auto at = std::find(g.begin(), g.end(), rgid);
+      if (at == g.end()) g.insert(g.begin(), rgid);
+      else std::iter_swap(g.begin(), at);
+      std::vector<std::pair<std::optional<std::string>, std::string>> gv;
+      for (gid_t id : g) gv.emplace_back(std::nullopt, std::to_string(id));
+      array_assign("GROUPS", gv, false, false);
+    }
   }
 
   // Let an interactive REPL re-apply persona-dependent readline hooks when the


### PR DESCRIPTION
Fixes #470. **test.tests 6 -> 0** — bash's `test.tests` now passes byte-for-byte, bringing the scoreboard to **60 of 83**.

gnash already knew `GROUPS` is unassignable (it carries bash's `att_noassign`), but the array was never given a value, so `${GROUPS[0]}` expanded to nothing and `declare -p GROUPS` reported it as not found.

Seeded from `getgroups()` alongside the other bash identity arrays in `apply_persona`, following `initialize_group_array`: the **real** gid is forced to element 0 — prepended when `getgroups()` omits it, swapped forward when it is merely out of order — and the list is capped at `NGROUPS_MAX`, so it matches bash's even for a user in more groups than that (16 of 17 here).

This was the last of `test.tests`: the suite does `chgrp ${GROUPS[0]} /tmp/test.setgid`, which with an empty `GROUPS` degenerated to a bare `chgrp /tmp/test.setgid` — a usage message on stderr and the file's group left alone, so the following `test -g` and `test -G` both answered the wrong way.

Verified byte-identical to bash for `${GROUPS[0]}`, `${GROUPS[@]}`, `${#GROUPS[@]}`, `declare -p GROUPS`, presence in `set` and `compgen -A variable` output, and the silently-ignored assignment. ctest 22/22; run_diff all 240; full sweep shows `test: 6 -> 0` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
