### PR TITLE
fix(nameref): temp assignments and `export` follow namerefs (nameref 81 -> 68)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1456,6 +1456,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
 
 int bi_export(Shell &sh, const std::vector<std::string> &argv) {
   bool funcs = false;
+  bool nflag = false;   // `-n': remove the export attribute instead of adding it
   char array_flag = 0;  // `-a' / `-A': force an indexed/associative array
   int st = 0;
   size_t i = 1;
@@ -1468,7 +1469,8 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
     for (size_t k = 1; k < a.size(); k++) {
       if (a[k] == 'f') funcs = true;
       else if (a[k] == 'a' || a[k] == 'A') array_flag = a[k];
-      else if (a[k] == 'n' || a[k] == 'p') { /* unmodeled here / no-op */ }
+      else if (a[k] == 'n') nflag = true;
+      else if (a[k] == 'p') { /* listing handled by the caller */ }
       else {
         std::fprintf(stderr, "%sexport: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
         std::fprintf(stderr, "export: usage: export [-fn] [name[=value] ...] or export -p [-f]\n");
@@ -1522,6 +1524,12 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       std::vector<std::string> d = {"export", opt, a};
       int r = bi_declare(sh, d, false, false);
       if (r) st = r;
+      // `export -n NAME=VALUE' still performs the assignment; it just does not
+      // leave the name exported.
+      if (!r && nflag) {
+        auto it = sh.vars.find(sh.deref(a.substr(0, eq)));
+        if (it != sh.vars.end()) it->second.exported = false;
+      }
     } else {
       // `export ref' where ref resolves to an array element is rejected like
       // `export a[5]': the resolved `var[0]' is not a valid identifier (bash).
@@ -1530,6 +1538,11 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
         std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
                      sh.err_prefix().c_str(), dn.c_str());
         st = 1;
+      } else if (nflag) {
+        // `export -n NAME' clears the export attribute of the nameref's target
+        // without creating anything: an unset name is simply left alone.
+        auto it = sh.vars.find(sh.deref(a));
+        if (it != sh.vars.end()) it->second.exported = false;
       } else
         sh.export_name(a);
     }

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1128,6 +1128,19 @@ int Executor::run_pipeline(const Connection *c) {
   return st;
 }
 
+// bash's assign_in_env(): a temporary assignment whose name is a nameref binds
+// the nameref's TARGET, so `ref=xxx cmd' puts var=xxx in the environment and
+// leaves `ref' itself alone.  A nameref with no target, or one aimed at an
+// array element, keeps its own name (bash's valid_nameref_value rejects an
+// array reference here because the name is used to create a variable directly).
+std::string temp_assign_name(Shell &sh, const std::string &name) {
+  auto it = sh.vars.find(name);
+  if (it == sh.vars.end() || !it->second.nameref) return name;
+  std::string t = sh.deref(name);
+  if (t == name || t.find('[') != std::string::npos) return name;
+  return t;
+}
+
 int Executor::run_simple(const SimpleCommand *c) {
   if (c->line > 0) sh_.cur_lineno = sh_.lineno_base + c->line;  // $LINENO
   // $BASH_COMMAND tracks the command currently executing (bash sets it before
@@ -1253,7 +1266,7 @@ int Executor::run_simple(const SimpleCommand *c) {
                                  (xtrace_rhs.empty() ? std::string()
                                                      : xtrace_quote_word(xtrace_rhs)));
         if (is_arr) sh_.array_set(a.name, "0", v);
-        else assigns.emplace_back(a.name, v);
+        else assigns.emplace_back(temp_assign_name(sh_, a.name), v);
       }
     } else {
       prefix = false;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1505,8 +1505,11 @@ void Shell::export_name(const std::string &n) {
   // value: a previously-unset variable stays unset (bash's att_invisible), so
   // `${NAME+set}' is empty and `declare -p NAME' prints just `declare -x NAME'
   // (no `=').  An existing variable keeps its value and visibility.
-  bool fresh = vars.find(n) == vars.end();
-  Variable &var = vars[n];
+  // `export ref' follows a nameref and exports its TARGET, leaving the nameref
+  // itself unexported (bash's declare_internal resolves the name first).
+  std::string t = deref(n);
+  bool fresh = vars.find(t) == vars.end();
+  Variable &var = vars[t];
   var.exported = true;
   if (fresh) var.invisible = true;
 }


### PR DESCRIPTION
Fixes #472. nameref.tests: 81 -> **68** (nameref14.sub is now byte-clean). Two commits.

## Temporary assignments bind the nameref's target

gnash recorded a prefix assignment under the name as written, with a comment asserting that a temporary assignment to a nameref shadows it for the duration of the command. bash's `assign_in_env` does the opposite — it resolves the name and creates the temp binding under the **target**:

```
declare -n ref=var; var=foo; ref=xxx declare -p ref var
  bash:  declare -n ref="var" / declare -x var="xxx"
  was:   declare -x ref="xxx" / declare -- var="foo"

declare -n ref=var; ref=xxx env | grep -E '^(ref|var)='
  bash:  var=xxx
  was:   ref=xxx
```

Resolved where the assignment list is built, so the environment handed to an external command, the shell bindings a builtin or function sees, and the save/restore bookkeeping all agree. A nameref with no target keeps its own name, as does one aimed at an array element — bash's `valid_nameref_value` rejects an array reference here because the name is used to create a variable directly. Both confirmed against the oracle, along with the append form (`ref+=new` appends to the *target's* value) and multi-hop chains (`r1 -> r2 -> var` resolves all the way).

## `export` follows namerefs, and `-n` works

`export ref` marked the nameref itself, so `declare -n ref=var; export ref` left `var` unexported — while the equivalent `declare -x ref` was already correct, since it goes through `declare_internal` as bash does. `bash-5.3/tests/nameref14.sub` even comments the line: `export ref  # follows nameref and exports var`.

`-n` was parsed and then discarded, so it neither removed the attribute nor left an unset name alone:

```
export V=1; export -n V; declare -p V     bash: declare -- V="1"   was: declare -x V="1"
export -n nosuch; declare -p nosuch       bash: not found          was: declare -x nosuch
```

Now clears the resolved target's attribute without creating anything, and still performs the assignment for `export -n NAME=VALUE`.

## Verification

ctest 22/22; run_diff all 240; full 83-suite sweep shows `nameref: 81 -> 68` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
