### PR TITLE
fix(nameref): `declare +n` applies other attributes to the target (nameref 36 -> 32)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3406,9 +3406,21 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // target if needed -- e.g. `readonly ref' marks ref's target readonly.  bash
     // resolves the nameref because -n is not present.
     std::string aname = name;
-    if (!nameref && !rm_nameref) {
+    if (!nameref) {
       auto nit = sh.vars.find(name);
-      if (nit != sh.vars.end() && nit->second.nameref) aname = sh.deref(name);
+      if (nit != sh.vars.end() && nit->second.nameref) {
+        // `declare +n NAME' ALONE just strips the reference and leaves the
+        // target alone.  Combined with anything else -- another attribute or
+        // an assignment -- everything but the `+n' applies to the TARGET,
+        // which is created if it does not exist, and only then is the
+        // reference torn down (bash declare.def).
+        bool only_rm_nameref =
+            rm_nameref && eq == std::string::npos && !global && !integer && !readonly &&
+            !exported && !ucase && !lcase && !capcase && !mk_array && !mk_assoc &&
+            !rm_integer && !rm_readonly && !rm_exported && !rm_ucase && !rm_lcase &&
+            !rm_capcase && !rm_array && !rm_assoc;
+        if (!only_rm_nameref) aname = sh.deref(name);
+      }
     }
     // The `readonly'/`export' builtins require a plain identifier target.  A
     // nameref that resolves to an array element (`declare -n ref=var[0];
@@ -3550,12 +3562,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // does allow `+n' to strip the attribute -- bash/ksh93 only forbid it when
     // the nameref cell is non-null (declare.def).  A `+n' on a readonly
     // NON-nameref is a harmless no-op and does not error.
-    if (rm_nameref && v.readonly && v.nameref && !v.value.empty()) {
+    // The `+n' always applies to the NAME as written, even when the rest of
+    // the command was redirected to the reference's target above.
+    Variable &nself = sh.vars[name];
+    if (rm_nameref && nself.readonly && nself.nameref && !nself.value.empty()) {
       std::fprintf(stderr, "%s%s: %s: readonly variable\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
       ret = 1;
     } else if (rm_nameref) {
-      v.nameref = false;
+      nself.nameref = false;
     }
     if (rm_ucase) v.ucase = false;
     if (rm_lcase) v.lcase = false;


### PR DESCRIPTION
Fixes #478. nameref.tests: 36 -> **32**; nameref19.sub is now byte-clean.

`bi_declare` resolves a nameref name to its target before applying attributes, but skipped that resolution whenever `-n` **or** `+n` appeared. bash skips it only for `-n`. For `+n` it follows the chain to the end, applies the assignment and every other attribute to the target, and only then turns off the reference — `declare.def` puts it in capitals: "*CHANGING ITS VALUE AS A SIDE EFFECT*, then turn off the nameref flag *LEAVING THE NAMEREF VARIABLE'S VALUE UNCHANGED*".

```
unset bar; declare -n foo=bar; declare +n -x foo; declare -p foo bar
  bash:  declare -- foo="bar" / declare -x bar
  was:   declare -x foo="bar" / declare: bar: not found

unset bar; declare -n foo=bar; declare +n -i foo=7+4; declare -p foo bar
  bash:  declare -- foo="bar" / declare -i bar="11"
  was:   declare -i foo="bar" / declare -i bar="11"
```

The exception is `+n` **alone**: with no other flag and no assignment bash short-circuits and never touches the target, so `declare +n foo` must not create `bar`. That case is preserved.

One knock-on fix: `declare +n -r foo` used to fail outright, because gnash applied the readonly attribute to `foo` and then its own "cannot remove `-n` from a readonly nameref" check fired against the flag it had just set. The `+n` now consults and clears the attribute on the name as written, even when the rest of the command was redirected to the target — so a genuinely readonly nameref (`declare -rn r=x; declare +n r`) still reports correctly.

Verified against bash across `+n` with `-x`, `-r`, `-i`, `-u`, an assignment, bare `+n`, and the readonly-nameref rejection — all seven matching. ctest 22/22; run_diff all 240; full sweep shows `nameref: 36 -> 32` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
