### PR TITLE
fix(executor): a failed bare assignment abandons the command list (nameref 32 -> 29)

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1170,6 +1170,10 @@ int Executor::run_simple(const SimpleCommand *c) {
     ~ProcsubGuard() { s.reap_procsubs(base); }
   } psg{sh_, sh_.procsubs.size()};
   std::vector<std::pair<std::string, std::string>> assigns;
+  // The first assignment that could not be made (readonly target, invalid
+  // nameref value).  Replaying earlier assignments to expand a later RHS
+  // reports it, so remember which one it was and do not report it twice.
+  size_t first_bad_assign = std::string::npos;
   std::vector<Assign> pending_elem;  // subscripted prefix assigns, decided below
   std::vector<std::string> argv;
   std::vector<Shell::RawArg> raw_prov;
@@ -1229,11 +1233,13 @@ int Executor::run_simple(const SimpleCommand *c) {
         // (`A=1 B=$A'): apply the already-collected assignments, expand, then
         // roll them back so command arguments still see the original values.
         std::vector<std::pair<std::string, std::optional<Variable>>> prior;
-        for (const auto &pa : assigns) {
+        for (size_t pi = 0; pi < assigns.size(); pi++) {
+          const auto &pa = assigns[pi];
           auto pv = sh_.vars.find(pa.first);
           prior.push_back({pa.first, pv == sh_.vars.end() ? std::nullopt
                                                           : std::optional<Variable>(pv->second)});
-          sh_.set(pa.first, pa.second);
+          if (!sh_.set(pa.first, pa.second) && first_bad_assign == std::string::npos)
+            first_bad_assign = pi;
         }
         std::string v = ex.expand_assignment(a.value);
         // The traced value is the expanded RHS as written (for `+=' the appended
@@ -1380,8 +1386,23 @@ int Executor::run_simple(const SimpleCommand *c) {
   if (argv.empty()) {
     std::vector<SavedFd> saved;
     apply_redirects(sh_, c->redirects, saved);
-    for (const auto &a : assigns) sh_.set(a.first, a.second);
+    // A failed assignment in a command with NO command word is a fatal
+    // assignment error: bash longjmps out of the current top-level command
+    // list (`RO=z; echo hi' prints nothing, and the abort escapes functions and
+    // loops), while the reader carries on with the next line.  With a command
+    // word (`RO=z echo hi') the command still runs and nothing is abandoned.
+    // Assignments before the failing one still take effect (`a=1 RO=z b=2'
+    // leaves a set and b unset); the rest are abandoned.
+    bool assign_failed = false;
+    for (size_t ai = 0; ai < assigns.size() && !assign_failed; ai++) {
+      if (ai == first_bad_assign) { assign_failed = true; break; }  // already reported
+      if (!sh_.set(assigns[ai].first, assigns[ai].second)) assign_failed = true;
+    }
     restore_fds(saved);
+    if (assign_failed) {
+      sh_.arith_abort = true;
+      return (sh_.last_status = 1);
+    }
     int st = sh_.cmdsub_ran ? sh_.last_cmdsub_status : 0;
     if (c->flags & CMD_INVERT_RETURN) st = st ? 0 : 1;  // a bare `!'
     sh_.last_status = st;


### PR DESCRIPTION
Fixes #480. nameref.tests: 32 -> **29**; nameref12.sub is now byte-clean.

A variable-assignment error in a command with **no command word** is fatal to the enclosing command list in bash — it longjmps back to the reader, which carries on with the next input line. gnash reported the error and kept going.

```sh
declare -r RO=x
RO=z ; echo AFTER1     # bash prints the error only; AFTER1 never runs
echo AFTER2            # bash prints AFTER2
```

gnash already had the unwind machinery — `Shell::arith_abort`, which `Executor::unwinding()` propagates and `run_string` clears after each list — but the no-command-word path ignored `Shell::set`'s return value entirely. Its scope turns out to be exactly right: I verified against bash that the unwind escapes functions and loops (`f(){ RO=z; echo IN_F; }; f; echo AFTER_F` prints neither) while a subshell contains it (`( RO=z; echo IN_SUB ); echo AFTER_SUB` still prints `AFTER_SUB`).

Assignments before the failing one still take effect, and the rest are abandoned:

```sh
declare -r RO=x; a=1 RO=z b=2; echo "a=[$a] b=[$b]"
  bash: a=[1] b=[]      was: a=[1] b=[2]
```

The rule is specific to the bare form. With a command word the command still runs and nothing is abandoned (`RO=z echo hi` prints `hi`), and an assignment builtin reports through its exit status (`declare RO=z; echo A2` prints `A2`). Both checked. It covers invalid nameref targets as well as readonly variables.

**Also fixed: the diagnostic was printed twice.** Collecting the assignments replays the earlier ones so a later RHS can see them (`A=1 B=$A`), and that replay reported the failure a second time — bash never gets there, because the first failure unwinds. gnash now remembers which assignment failed and lets the replay's diagnostic stand.

Verified with four purpose-built scripts covering the abort scope, the boundary forms, partial persistence, and the duplicate message — all byte-identical to bash. ctest 22/22; run_diff all 240; full sweep shows `nameref: 32 -> 29` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
