### PR TITLE
fix(nameref): reject `declare -n` on a set but empty variable

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3497,8 +3497,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
                    "%s%s: %s: nameref variable self references not allowed\n",
                    sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
       ret = 1;
-    } else if (nameref && !v.value.empty() && v.value != name &&
+    } else if (nameref && !v.invisible && v.value != name &&
                !Shell::valid_nameref_target(v.value)) {
+      // An existing but EMPTY value is rejected too (`r=""; declare -n r'):
+      // only a declared-but-unset variable becomes a targetless reference,
+      // which is why this tests visibility rather than emptiness.
       std::fprintf(stderr,
                    "%s%s: `%s': invalid variable name for name reference\n",
                    sh.err_prefix().c_str(), argv[0].c_str(), v.value.c_str());


### PR DESCRIPTION
`r=""; declare -n r` quietly made `r` a reference with an empty target. bash rejects it — an empty string is not a valid nameref target — and leaves `r` a plain variable:

```
$ bash -c 'r=""; declare -n r; declare -p r'
bash: line 1: declare: `': invalid variable name for name reference
declare -- r=""
```

The check tested the *value* for emptiness, which exempted exactly this case. It now tests **visibility**: only a declared-but-unset variable becomes a targetless reference, so `declare -n y` on a fresh name (and a re-declared targetless `declare -n y; declare -n y`) still works, while a name that has been assigned an empty string does not. Verified against bash across all seven spellings, including `declare y; declare -n y`, `declare -n r=""`, and the function-local form.

## On the scoreboard number

nameref11.sub goes 22 -> 21, and an alignment-independent comparison of the whole suite improves from 29 to 28 differing lines. The *ordered* diff-line count that the scoreboard reports ticks 29 -> 30, purely because removing one line realigns the diff around the still-broken readonly-coproc block further down. Nothing else regressed — every other nameref sub-test is unchanged.

ctest 22/22; run_diff all 240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
