### PR TITLE
fix(nameref): circular chains in assignment (nameref 30 -> 28)

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1136,8 +1136,13 @@ int Executor::run_pipeline(const Connection *c) {
 std::string temp_assign_name(Shell &sh, const std::string &name) {
   auto it = sh.vars.find(name);
   if (it == sh.vars.end() || !it->second.nameref) return name;
-  std::string t = sh.deref(name);
-  if (t == name || t.find('[') != std::string::npos) return name;
+  // A CIRCULAR chain has no target to resolve to: keep the name as written so
+  // the assignment reports the cycle against it (`v->w->x->v; x=4' warns about
+  // `x'), rather than against whichever link a bounded walk happened to stop
+  // on.
+  bool circular = false;
+  std::string t = sh.deref_ex(name, circular);
+  if (circular || t == name || t.find('[') != std::string::npos) return name;
   return t;
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1411,7 +1411,11 @@ bool Shell::set(const std::string &n_in, const std::string &v,
     if (!in_function()) {
       std::fprintf(stderr, "%swarning: %s: circular name reference\n",
                    err_prefix().c_str(), n_in.c_str());
-      return true;
+      // A cycle has nothing to assign to, so this is an assignment ERROR:
+      // `x=4; echo A' warns and abandons the rest of the list.  Inside a
+      // function the reference binds at global scope instead and execution
+      // carries on, which is why only the global-scope branch fails.
+      return false;
     }
     std::fprintf(stderr, "%swarning: %s: maximum nameref depth (8) exceeded\n",
                  err_prefix().c_str(), n_in.c_str());


### PR DESCRIPTION
Fixes #483. nameref8.sub is byte-clean again, and nameref.tests goes 30 -> **28**. Two commits.

## The regression

Resolving an assignment's name through its nameref used `Shell::deref`, whose cycle protection is a *bounded walk* — it gives up after 100 hops and returns whatever link it happened to stop on. For `v->w->x->v`, `deref("x")` returned `v`. The assignment was recorded under that name, so `x=4` reported the cycle against `v` where bash reports it against `x`.

`deref_ex` reports a cycle rather than guessing, so use that and keep the name as written when it finds one. (`Shell::set` was never at fault — it warns with the name it is given.)

## The behavior the regression was hiding

Chasing it turned up a second difference: a circular assignment is an **error** in bash, not just a warning.

```sh
typeset -n v=w; typeset -n w=x; typeset -n x=v
x=4; echo A     # bash warns and never runs `echo A'
echo B          # bash prints B
```

A cycle has nothing to assign to, so `Shell::set` now reports the failure and the bare-assignment path raises the same unwind it already does for a readonly target or an invalid nameref value (#480). Only the global-scope branch fails — inside a function the reference binds at global scope instead and bash keeps going, which I confirmed against the oracle (`f(){ ...; x=4; }; f; echo A` prints `A` after the max-nameref-depth warning).

## Verification

Checked against bash across the two-link and three-link cycles, assigning at each position in the chain, at global and function scope, on one line and across lines — plus the non-circular nameref paths the first commit touches (`r=xxx declare -p r var`, `r=new env`) to confirm ordinary target resolution is unaffected. ctest 22/22; run_diff all 240; full sweep shows `nameref: 30 -> 28` as the only change, and the alignment-independent count improves 28 -> 26.

Two known gaps remain in this area, both pre-existing and neither currently costing a test line: a circular assignment carried as a *prefix* to a command (`x=4 true`) should still warn, and the temp-env path takes its shadow branch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
