### PR TITLE
fix: mapfile array creation and coproc variable teardown (nameref 28 -> 19)

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -411,6 +411,14 @@ class Shell {
   // --- status & options --------------------------------------------------
   int last_status = 0;
   int last_bg_pid = 0;  // $!
+  // The live coproc's variable name and pid.  When the coproc is reaped bash
+  // unsets NAME and NAME_PID (coproc_reap), so the fds it named stop being
+  // advertised once the process behind them is gone.
+  std::string coproc_name;
+  long coproc_pid = 0;
+  // Unset the coproc variables if its process has been reaped; a no-op while
+  // it is still running, or when there is no coproc.
+  void reap_coproc();
   // Exit status of the most recent command substitution, so a pure-assignment
   // command (a=$(cmd)) can take its status, as bash does.
   int last_cmdsub_status = 0;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1440,12 +1440,36 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
     recs.clear();
   if (count > 0 && static_cast<size_t>(count) < recs.size()) recs.resize(count);
 
-  if (!haveO) sh.unset(name);  // default: replace the whole array
+  std::vector<std::pair<std::optional<std::string>, std::string>> elems;
   for (size_t k = 0; k < recs.size(); k++) {
     std::string v = recs[k];
     if (strip && !v.empty() && v.back() == delim) v.pop_back();
-    sh.array_set(name, std::to_string(origin + static_cast<long>(k)), v);
+    elems.emplace_back(std::to_string(origin + static_cast<long>(k)), v);
   }
+  // Without `-O' the whole array is replaced.  Go through array_assign rather
+  // than unsetting first: bash's mapfile creates the array up front
+  // (find_or_make_array_variable) and only then flushes it, so the variable
+  // exists even when the input is empty -- and an unset nameref target is
+  // converted into a real array, with bash's warning, instead of being
+  // silently removed.
+  // mapfile fills an INDEXED array; an existing associative one is refused and
+  // left alone.
+  {
+    auto mit = sh.vars.find(sh.deref(name));
+    if (mit != sh.vars.end() && mit->second.kind == VarKind::Assoc) {
+      std::fprintf(stderr, "%smapfile: %s: not an indexed array\n",
+                   sh.err_prefix().c_str(), name.c_str());
+      return 1;
+    }
+  }
+  // Without `-O' the whole array is replaced.  Create and flush it rather than
+  // unsetting it first: bash's mapfile makes the array up front
+  // (find_or_make_array_variable) and only then empties it, so the variable
+  // exists even when the input is empty, it keeps its attributes, and an unset
+  // nameref target is converted into a real array -- with bash's warning --
+  // instead of being silently removed.
+  if (!haveO) sh.array_assign(name, {}, false, false);
+  for (const auto &e : elems) sh.array_set(name, *e.first, e.second);
   return 0;
 }
 

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1928,8 +1928,15 @@ int Executor::run_coproc(const CoprocCommand *c) {
   std::vector<std::pair<std::optional<std::string>, std::string>> elems;
   elems.emplace_back(std::string("0"), std::to_string(read_fd));
   elems.emplace_back(std::string("1"), std::to_string(write_fd));
+  // A readonly NAME stops the whole thing: bash reports the array assignment
+  // and never goes on to NAME_PID.
+  auto nit = sh_.vars.find(sh_.deref(name));
+  bool name_ro = nit != sh_.vars.end() && nit->second.readonly;
   sh_.array_assign(name, elems, false, false);
-  sh_.set(name + "_PID", std::to_string(pid));
+  if (!name_ro) sh_.set(name + "_PID", std::to_string(pid));
+  // Remember it so the variables go away once the coprocess is reaped.
+  sh_.coproc_name = name;
+  sh_.coproc_pid = pid;
   return (sh_.last_status = 0);
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -204,6 +204,27 @@ int wait_job(Shell::Job &j) {
 }
 }  // namespace
 
+// bash's coproc_reap(): once the coprocess has been reaped its NAME and
+// NAME_PID variables go away.  NAME_PID is unbound outright -- a readonly one
+// disappears silently -- while NAME goes through the ordinary unset, so a
+// readonly array reports and survives.
+void Shell::reap_coproc() {
+  if (coproc_pid == 0) return;
+  for (const auto &j : jobs)
+    for (long p : j.pids)
+      if (p == coproc_pid && !j.done) return;  // still running
+  std::string nm = coproc_name;
+  coproc_name.clear();
+  coproc_pid = 0;
+  unset(nm + "_PID", /*force=*/true, /*noref=*/true);
+  auto it = vars.find(nm);
+  if (it != vars.end() && it->second.readonly)
+    std::fprintf(stderr, "%s%s: cannot unset: readonly variable\n", err_prefix().c_str(),
+                 nm.c_str());
+  else
+    unset(nm, false, true);
+}
+
 int Shell::foreground_job(Job &j, bool cont) {
   if (job_control) tcsetpgrp(job_terminal, static_cast<pid_t>(j.pgid));
   if (cont) {
@@ -216,6 +237,7 @@ int Shell::foreground_job(Job &j, bool cont) {
     j.running = true;
   }
   int st = wait_job(j);
+  reap_coproc();
   if (job_control) {
     tcsetpgrp(job_terminal, static_cast<pid_t>(shell_pgid));
   }
@@ -242,6 +264,7 @@ int Shell::wait_for_pid(long pid) {
   for (auto &j : jobs)
     for (long p : j.pids)
       if (p == pid) { j.done = true; j.running = false; j.status = rc; }
+  reap_coproc();
   return rc;
 }
 
@@ -358,6 +381,7 @@ int Shell::wait_all() {
   int wst;
   while (waitpid(-1, &wst, WNOHANG) > 0) note_child_reaped();  // reap exited stragglers
   end_interruptible_wait();
+  reap_coproc();
   // bash's `wait' with no operands removes every terminated job it reaped.
   remove_jobs_if([](const Job &j) { return j.done; });
   // `wait' with no operands always returns 0 (`f1 & wait' is 0 even though


### PR DESCRIPTION
Fixes #485. Fixes #486. nameref.tests: 28 -> **19** (nameref11.sub 21 -> 12). Two commits.

## mapfile creates the array before filling it

mapfile assigned its records one at a time, so with no input it created nothing — and because it unset the variable first to replace the old contents, a targetless nameref was *destroyed* rather than converted, a nameref's target was never created, and any attributes were lost.

bash makes the array up front (`find_or_make_array_variable`) and only then flushes it. Going through `array_assign` for the same effect gets the nameref conversion — and bash's `removing nameref attribute` warning — for free, exactly as `read -a` already does.

```
declare -n r; mapfile r < /dev/null; declare -p r
  bash: warning: r: removing nameref attribute / declare -a r=()
  was:  declare: r: not found
```

Also refuses an existing associative array (`mapfile: a: not an indexed array`), which gnash was silently overwriting.

## coproc unsets NAME and NAME_PID once reaped

The variables naming a coprocess's file descriptors outlived it, so they kept advertising fds whose process was long gone. bash drops them in `coproc_reap`.

```
coproc C { :; }; wait; declare -p C C_PID
  bash: declare: C: not found / declare: C_PID: not found
  was:  declare -a C=([0]="10" [1]="11") / declare -- C_PID="20277"
```

The teardown is **asymmetric**, which only shows when the names are readonly: `NAME_PID` is unbound outright and disappears silently, while `NAME` goes through the ordinary unset and so reports `cannot unset: readonly variable` and survives. A readonly `NAME` also stops the *setup* before it reaches `NAME_PID` — gnash was reporting both.

## Verification

Nine mapfile shapes against bash (`-t`, `-O`, nameref with and without a target, associative, readonly, scalar-to-array, attribute retention) and the full readonly-coproc block from nameref11.sub reproduced standalone. ctest 22/22; run_diff all 240; full sweep shows `nameref: 28 -> 19` as the only change.

One pre-existing gap this surfaced but does not fix: `mapfile` and `read -a` into an integer array store records verbatim instead of evaluating them (`declare -i x; mapfile -t x` on `1+1` gives `1+1`, not `2`). The arithmetic happens in the executor's element-assignment path, which neither builtin goes through. Filed separately rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
