### PR TITLE
fix(coproc): tear down through the nameref, not the reference (nameref 19 -> 17)

### DIFF
--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -216,13 +216,16 @@ void Shell::reap_coproc() {
   std::string nm = coproc_name;
   coproc_name.clear();
   coproc_pid = 0;
-  unset(nm + "_PID", /*force=*/true, /*noref=*/true);
-  auto it = vars.find(nm);
+  // Both names are resolved the way an ordinary `unset' would resolve them, so
+  // `declare -n ref=x; coproc ref' tears down `x' and leaves `ref' alone.
+  std::string tgt = deref(nm);
+  unset(nm + "_PID", /*force=*/true, /*noref=*/false);
+  auto it = vars.find(tgt);
   if (it != vars.end() && it->second.readonly)
     std::fprintf(stderr, "%s%s: cannot unset: readonly variable\n", err_prefix().c_str(),
                  nm.c_str());
   else
-    unset(nm, false, true);
+    unset(nm, false, false);
 }
 
 int Shell::foreground_job(Job &j, bool cont) {


### PR DESCRIPTION
Follow-up to #487, which I merged with this case wrong. nameref.tests: 19 -> **17**.

The coproc reap unset its variables by their literal names, so a coproc named through a nameref tore down the *reference* instead of what it points at:

```
declare -n ref=x; coproc ref { :; }; wait; declare -p ref x
  bash:  declare -n ref="x" / declare: x: not found
  was:   declare: ref: not found / declare -a x=([0]="10" [1]="11")
```

bash resolves both names the way an ordinary `unset` would. The readonly check now looks at the resolved target too, while the diagnostic still names the variable as written — which is what bash prints.

`NAME_PID` keeps its forced unset: that already bypasses resolution, and bash unbinds `ref_PID` literally.

Verified against bash for the nameref form, the plain form, and the full readonly-coproc block from nameref11.sub. ctest 22/22; run_diff all 240; full sweep shows `nameref: 19 -> 17` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
