### PR TITLE
fix(cond): keep the user's quoting on a `=~` regex operand (cond 70 -> 51)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -36,6 +36,12 @@ class Expander {
   // characters stay active.
   std::string expand_pattern(const std::string &text);
 
+  // Expand a word used as a REGEX (a `[[ =~ ]]' right-hand side).  Like
+  // expand_pattern, but only those quoted characters that are special in a
+  // POSIX ERE are backslash-escaped: `\a' is not a portable way to write a
+  // literal `a', so escaping everything would change what the pattern means.
+  std::string expand_regex(const std::string &text);
+
   // Expand a word as if inside double quotes (bash-family default words after
   // ${x:-w}/${x:+w}): `$'/backquote expand, backslash escapes the shell
   // specials, single quotes are literal.  Not used under the zsh personality,

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -17,6 +17,17 @@
 
 namespace gnash::core {
 
+// The `[[ ... ]]' body is reconstructed into a string that the conditional
+// evaluator re-tokenizes.  Characters the lexer would treat as operators or
+// separators cannot survive that trip literally, so inside a `=~' operand they
+// are replaced by COND_RX_ESC plus the matching letter from kCondRxSub, and the
+// evaluator puts them back before expanding the operand.  A backslash would not
+// do: the expander records backslash-escaped characters as QUOTED, and quoting
+// is exactly what decides whether a regex metacharacter matches literally.
+constexpr char COND_RX_ESC = '\x1d';        // GS -- an ordinary character to the lexer
+inline constexpr const char *kCondRxRaw = "()|&;<> \t";
+inline constexpr const char *kCondRxSub = "abcdefghi";
+
 struct ParseResult {
   CommandPtr command;   // null for empty input
   bool ok = true;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7086,6 +7086,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
 }  // namespace gnash::core
 
 #include "gnash/core/lexer.hpp"
+#include "gnash/core/parser.hpp"  // COND_RX_ESC: the `[[ =~ ]]' transport encoding
 
 namespace gnash::core {
 
@@ -7094,13 +7095,23 @@ namespace {
 // Compile REG_EXTENDED regexes once and reuse them: regcomp() is expensive
 // (it builds a whole automaton) and a loop such as opsh's semver::parse runs
 // `[[ $v =~ $re ]]' with the same pattern every iteration, as bash caches too.
-regex_t *cached_regex(const std::string &pat) {
+regex_t *cached_regex(const std::string &pat, std::string *why = nullptr) {
   static std::map<std::string, regex_t> cache;
   auto it = cache.find(pat);
   if (it != cache.end()) return &it->second;
   if (cache.size() >= 64) { for (auto &kv : cache) regfree(&kv.second); cache.clear(); }
   regex_t rx;
-  if (regcomp(&rx, pat.c_str(), REG_EXTENDED) != 0) return nullptr;
+  int rc = regcomp(&rx, pat.c_str(), REG_EXTENDED);
+  if (rc != 0) {
+    // bash reports why the pattern would not compile and fails the whole
+    // conditional with status 2, rather than treating it as "no match".
+    if (why) {
+      char buf[256];
+      regerror(rc, &rx, buf, sizeof buf);
+      *why = buf;
+    }
+    return nullptr;
+  }
   return &cache.emplace(pat, rx).first->second;  // map owns the compiled data
 }
 
@@ -7125,6 +7136,26 @@ struct CondEval {
   std::string expand_pat(const std::string &s) {
     Expander ex(sh);
     return ex.expand_pattern(s);
+  }
+  // A `=~' right-hand side is a REGEX.  Undo the parser's transport encoding
+  // first -- those characters were never quoted by the user -- then expand,
+  // escaping only the ERE-special characters that the user really did quote.
+  std::string expand_re(const std::string &s) {
+    std::string raw;
+    raw.reserve(s.size());
+    for (size_t k = 0; k < s.size(); k++) {
+      if (s[k] == COND_RX_ESC && k + 1 < s.size()) {
+        const char *s2 = std::strchr(kCondRxSub, s[k + 1]);
+        if (s[k + 1] != '\0' && s2) {
+          raw += kCondRxRaw[s2 - kCondRxSub];
+          k++;
+          continue;
+        }
+      }
+      raw += s[k];
+    }
+    Expander ex(sh);
+    return ex.expand_regex(raw);
   }
 
   bool or_expr() {
@@ -7230,9 +7261,15 @@ struct CondEval {
           return strmatch(p.data(), l.data(), FNM_EXTMATCH) != 0;
         }
         if (op == "=~") {
-          std::string re = expand(rhs_raw);
-          regex_t *rx = cached_regex(re);
-          if (!rx) return false;
+          std::string re = expand_re(rhs_raw);
+          std::string why;
+          regex_t *rx = cached_regex(re, &why);
+          if (!rx) {
+            std::fprintf(stderr, "%s[[: invalid regular expression `%s': %s\n",
+                         sh.err_prefix().c_str(), re.c_str(), why.c_str());
+            synerr = 2;
+            return false;
+          }
           size_t ng = rx->re_nsub + 1;
           std::vector<regmatch_t> m(ng);
           bool matched = regexec(rx, lhs.c_str(), ng, m.data(), 0) == 0;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3437,6 +3437,68 @@ std::string Expander::expand_pattern(const std::string &text) {
   return r;
 }
 
+// bash's ere_char(): the characters that are special in a POSIX extended
+// regular expression, and so need a backslash to match themselves.  Note that
+// `]' and `}' are not among them.
+static bool ere_special(char c) {
+  return c != '\0' && std::strchr(".[\\()*+?{|^$", c) != nullptr;
+}
+
+std::string Expander::expand_regex(const std::string &text) {
+  std::string src = expand_leading_tilde(sh_, text);
+  extract_procsubs(src);
+  std::string out, mask;
+  bool saved_split = splitting_;
+  splitting_ = false;
+  process(src, out, mask, false);
+  splitting_ = saved_split;
+  std::string r;
+  r.reserve(out.size());
+  bool in_bracket = false;   // inside a [...] bracket expression
+  size_t bracket_at = 0;     // index just past the opening `[' (and any `^')
+  for (size_t i = 0; i < out.size(); i++) {
+    char c = out[i];
+    bool quoted = i < mask.size() && mask[i] == '1';
+    if (i < mask.size() && mask[i] == MMARK) {
+      if (c == FIELD_SEP) r += ' ';
+      continue;  // marker bytes never reach the pattern
+    }
+    if (!in_bracket && c == '[' && !quoted) {
+      in_bracket = true;
+      bracket_at = r.size() + 1;
+      r += c;
+      if (i + 1 < out.size() && out[i + 1] == '^') { r += out[++i]; bracket_at++; }
+      continue;
+    }
+    if (in_bracket) {
+      // `[:class:]', `[=equiv=]' and `[.symbol.]' are copied whole: their
+      // closing `]' does not end the enclosing bracket expression.
+      if (c == '[' && i + 1 < out.size() && std::strchr(":=.", out[i + 1])) {
+        char kind = out[i + 1];
+        std::string close = std::string(1, kind) + "]";
+        size_t end = out.find(close, i + 2);
+        if (end != std::string::npos) {
+          r.append(out, i, end + 2 - i);
+          i = end + 1;
+          continue;
+        }
+      }
+      // A `]' closes it, unless it is the first character inside.
+      if (c == ']' && r.size() > bracket_at) in_bracket = false;
+      r += c;
+      continue;
+    }
+    // Quoted AND special in an ERE: escape it so it matches itself.  A quoted
+    // ordinary character is left alone.  Inside a bracket expression nothing is
+    // escaped -- a backslash there is an ordinary member of the set, so adding
+    // one would change which characters match (`[[ "\\" =~ ["."] ]]' must not
+    // match a backslash).
+    if (quoted && ere_special(c)) r += '\\';
+    r += c;
+  }
+  return r;
+}
+
 std::string Expander::expand_no_split(const std::string &text, bool do_glob, bool do_procsub) {
   std::string src = expand_leading_tilde(sh_, text);  // case subjects, redirects
   // Arithmetic contexts pass do_procsub=false: there `4>(2+3)' is a comparison,

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -140,16 +140,25 @@ struct Parser {
     }
   }
 
-  // Encode a reconstructed =~ regex so it survives re-tokenization and quote
-  // removal in the conditional evaluator: existing backslashes are doubled
-  // (quote removal halves them again) and characters the lexer treats as
-  // operators/separators are backslash-escaped.  `$' is left alone so
-  // variables in the pattern still expand.
+  // Encode a reconstructed =~ regex so it survives re-tokenization in the
+  // conditional evaluator.  A user's backslashes are left exactly as written,
+  // so the expander sees what they quoted and the regex escaping can follow
+  // it: `\(' marks the paren quoted, and a quoted paren matches literally.
+  // Characters the lexer treats as operators or separators are replaced by a
+  // COND_RX_ESC marker plus an ordinary letter, rather than being
+  // backslash-escaped: a backslash here would be indistinguishable from the
+  // user's own quoting once the expander records what was quoted, and quoting
+  // is what decides whether a regex metacharacter matches literally.  `$' is
+  // left alone so variables in the pattern still expand.
   static std::string encode_regex(const std::string &rx) {
     std::string e;
     for (char c : rx) {
-      if (c == '\\') { e += "\\\\"; continue; }
-      if (std::strchr("()|&;<> \t", c)) e += '\\';
+      const char *k = std::strchr(kCondRxRaw, c);
+      if (c != '\0' && k) {
+        e += COND_RX_ESC;
+        e += kCondRxSub[k - kCondRxRaw];
+        continue;
+      }
       e += c;
     }
     return e;


### PR DESCRIPTION
Fixes #493. cond.tests: 70 -> **51**. cond-regexp1.sub, cond-regexp2.sub and cond-regexp3.sub are all byte-clean.

## The blocker, resolved

A quoted part of a `=~` operand must match literally, but gnash expanded it with ordinary quote removal so quoting had no effect: `[[ a =~ "[[:alpha:]]" ]]` matched.

The reason the obvious fix failed (as noted in #493) is that the parser reconstructs the `[[ ]]` body into a string the evaluator re-tokenizes, backslash-escaping the characters the lexer would otherwise take as operators. The expander records those as *quoted*, indistinguishable from the user's own quoting — so escaping quoted metacharacters made an unquoted `(a)b` match literally.

Two changes fix the provenance:

- Those characters now travel as a `COND_RX_ESC` marker plus a letter, which the lexer passes through untouched and the evaluator decodes before expanding.
- The parser no longer doubles the user's backslashes, so the expander sees exactly what they quoted. `\(` marks the paren quoted, and a quoted paren matches literally — which is what bash does.

## The escaping rule

New `Expander::expand_regex` escapes only quoted characters that are special in a POSIX ERE — bash's `ere_char`: `. [ \ ( ) * + ? { | ^ $`. Escaping everything (i.e. reusing `expand_pattern`) changes the pattern, since `\a` is not portably a literal `a`.

Inside a bracket expression **nothing** is escaped: a backslash there is an ordinary member of the set, so `[[ "\" =~ ["."] ]]` must not match a backslash. Character classes, equivalence classes and collating symbols are copied whole, since their closing `]` does not end the enclosing bracket — that is what makes `[[ dog =~ [[=d=]].. ]]` work.

## Invalid regexes

A pattern that will not compile now reports bash's `[[: invalid regular expression `RE': REASON` with status 2, instead of silently answering "no match". The reason text comes from `regerror`, and matches bash's for all three cases the suite exercises (unbalanced parentheses, invalid character range, invalid character class).

## Verification

The three regex sub-tests in full, plus the metacharacter matrix from #493 that caught the earlier attempts — grouping vs. literal parens, `\|`, backslash-space, quoted and unquoted character classes. ctest 22/22; run_diff all 240; full 83-suite sweep shows `cond: 70 -> 51` as the only change.

What remains in cond.tests is the conditional syntax-error *text* (bash prints three lines per error where gnash prints one or two) and `[[ ]]` not being traced under `set -x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
