### PR TITLE
fix(shell): assignments cannot shadow computed variables

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -419,6 +419,9 @@ class Shell {
   // Unset the coproc variables if its process has been reaped; a no-op while
   // it is still running, or when there is no coproc.
   void reap_coproc();
+  // True for a computed variable that carries bash's att_noassign: assigning to
+  // it succeeds and changes nothing.
+  bool noassign_var(const std::string &n) const;
   // Exit status of the most recent command substitution, so a pure-assignment
   // command (a=$(cmd)) can take its status, as bash does.
   int last_cmdsub_status = 0;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -126,6 +126,19 @@ const std::vector<std::string> &Shell::special_var_names() {
   return names;
 }
 
+// The computed variables that carry bash's att_noassign: an assignment to one
+// succeeds and changes nothing, and the dynamic value keeps being reported.
+// BASH_SUBSHELL and BASH_TRAPSIG are deliberately absent -- bash does let those
+// be overwritten -- as are BASHOPTS/SHELLOPTS, which are readonly instead.
+bool Shell::noassign_var(const std::string &n) const {
+  if (is_zsh()) return false;  // zsh has no such variables
+  static const std::set<std::string> kNoAssign = {
+      "GROUPS",   "FUNCNAME",     "LINENO",       "BASHPID",
+      "HISTCMD",  "BASH_COMMAND", "BASH_ARGC",    "BASH_ARGV",
+      "EPOCHSECONDS", "EPOCHREALTIME", "BASH_MONOSECONDS"};
+  return kNoAssign.count(n) != 0;
+}
+
 // Defined in builtins.cpp: the state of every `set -o' option, in name order.
 std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh);
 
@@ -754,10 +767,10 @@ bool Shell::array_elem_set(const std::string &n_in, const std::string &sub) cons
 
 void Shell::array_set(const std::string &n_in, const std::string &sub, const std::string &val) {
   std::string n = deref(n_in);
-  // GROUPS/FUNCNAME carry bash's att_noassign: an assignment is silently
-  // discarded (and does not fail).  Only in the bash family -- zsh has no such
-  // dynamic variables, so an assignment there is ordinary.
-  if ((n == "GROUPS" || n == "FUNCNAME") && !is_zsh()) return;
+  // A computed variable carries bash's att_noassign: the assignment is
+  // silently discarded (and does not fail).  `BASH_ARGC=x' reaches here rather
+  // than Shell::set, because an existing array takes the element-0 path.
+  if (noassign_var(n)) return;
   // BASH_ALIASES is the live alias table: BASH_ALIASES[name]=value defines an
   // alias, after the same name validation the alias builtin performs.
   if (n == "BASH_ALIASES" && !is_zsh()) {
@@ -1471,9 +1484,16 @@ bool Shell::set(const std::string &n_in, const std::string &v,
     std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
     return false;
   }
-  // GROUPS/FUNCNAME carry bash's att_noassign: a scalar assignment is silently
-  // discarded without error (bash family only; zsh has no such variables).
-  if ((n == "GROUPS" || n == "FUNCNAME") && !is_zsh()) return true;
+  // A computed variable carries bash's att_noassign: a scalar assignment is
+  // silently discarded without error, so `LINENO=999' succeeds and changes
+  // nothing.
+  if (noassign_var(n)) return true;
+  // $SHELLOPTS and $BASHOPTS are readonly instead: assigning to one is an
+  // error, which (having no command word) also abandons the command list.
+  if (!is_zsh() && (n == "SHELLOPTS" || n == "BASHOPTS")) {
+    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    return false;
+  }
   Variable &var = vars[n];
   if (var.readonly) {
     std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());


### PR DESCRIPTION
Fixes #495. The reproduction from the issue now matches bash exactly:

```
Before: LINENO=1 BASHPID=98673
After:  LINENO=4 BASHPID=98673
```

## What bash actually does

I checked each variable in the report against bash rather than applying one rule to all of them, because they do not behave alike:

| | bash |
|---|---|
| `LINENO` `BASHPID` `HISTCMD` `BASH_COMMAND` `BASH_ARGC` `BASH_ARGV` `EPOCHSECONDS` `EPOCHREALTIME` `BASH_MONOSECONDS` | assignment **succeeds silently** and changes nothing |
| `SHELLOPTS` `BASHOPTS` | **readonly** — reports and fails |
| `BASH_SUBSHELL` `BASH_TRAPSIG` | genuinely **overwritable** — 999 sticks |

So the issue's suggested fix (report "readonly variable" for the whole list) would have been wrong for eleven of the thirteen: bash gives most of them `att_noassign`, where the assignment is accepted and quietly discarded. Only `SHELLOPTS`/`BASHOPTS` are readonly, and two of the listed variables are not affected at all.

## The fix

Extends the rule gnash already had for `GROUPS`/`FUNCNAME`, behind a `Shell::noassign_var` predicate so the scalar and array-element paths agree. That second path matters: `BASH_ARGC=x` never reaches `Shell::set` at all, because an existing array takes the element-0 route through `array_set` — which is why a fix in `set()` alone still left `BASH_ARGC` overwritable.

`SHELLOPTS=x` now also abandons the rest of the command list, as any failed bare assignment does, which is what bash does here too.

## Verification

All thirteen variables compared against bash, plus `GROUPS`/`FUNCNAME` to confirm the existing behaviour is unchanged, and both readonly cases including the abort. ctest 22/22; run_diff all 240; full 83-suite sweep unchanged.

One thing this does not address, noticed while testing: `${BASH_ARGC}` reads empty in gnash where bash reads `0`. That is the dynamic value itself, not the assignment, and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
