### PR TITLE
feat(nameref): bound chain depth, configurably via $GNASH_NAMEREF_MAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Choose a personality by the binary's name -- e.g. a `zsh` symlink to `gnash`, or
 
 Run it as `build/core/gnash` (interactive), `gnash -c 'CMD'`, or `gnash SCRIPT`.
 
+### Tunables
+
+`$GNASH_NAMEREF_MAX` bounds how many links a nameref chain may follow before it
+resolves to nothing, with a `maximum nameref depth (N) exceeded` warning. It
+defaults to **100**; bash fixes the equivalent limit at 8, so setting it to 8
+reproduces bash exactly. A missing, malformed or non-positive value falls back
+to the default.
+
 
 ## Design
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -63,7 +63,14 @@ class Shell {
   // reference `v->v' or a longer loop).  On a cycle it returns the last name
   // walked before the loop closed; the warning-issuing caller uses the
   // original NAME for the diagnostic, matching bash's find_variable_nameref.
-  std::string deref_ex(const std::string &n, bool &circular) const;
+  // Resolve NAME through its nameref chain.  Sets `circular' on a loop, and
+  // `too_deep' (when given) once the chain is longer than nameref_max().
+  std::string deref_ex(const std::string &n, bool &circular,
+                       bool *too_deep = nullptr) const;
+  // How many nameref links a chain may follow.  bash fixes this at 8; gnash
+  // defaults to 100 and lets $GNASH_NAMEREF_MAX change it, so setting that to 8
+  // reproduces bash exactly.
+  int nameref_max() const;
   // The global (pre-function) binding of NAME: when a local scope has shadowed
   // NAME, the saved outer Variable; otherwise the entry in `vars'.  bash
   // resolves a circular nameref to global scope, so a write through one lands

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1140,9 +1140,11 @@ std::string temp_assign_name(Shell &sh, const std::string &name) {
   // the assignment reports the cycle against it (`v->w->x->v; x=4' warns about
   // `x'), rather than against whichever link a bounded walk happened to stop
   // on.
-  bool circular = false;
-  std::string t = sh.deref_ex(name, circular);
-  if (circular || t == name || t.find('[') != std::string::npos) return name;
+  bool circular = false, too_deep = false;
+  std::string t = sh.deref_ex(name, circular, &too_deep);
+  // A chain that is circular or too long has no target to bind: keep the name
+  // as written so Shell::set reports it against what the user actually wrote.
+  if (circular || too_deep || t == name || t.find('[') != std::string::npos) return name;
   return t;
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -430,9 +430,25 @@ void Shell::reap_procsubs(size_t from) {
   if (from < procsubs.size()) procsubs.resize(from);
 }
 
+// bash caps nameref chains at NAMEREF_MAX (8) links.  gnash allows more by
+// default -- a long chain is a legitimate, if unusual, thing to build -- and
+// exposes the limit as $GNASH_NAMEREF_MAX so a script that wants bash's exact
+// behaviour can set it to 8.  A missing, malformed or non-positive value falls
+// back to the default.
+int Shell::nameref_max() const {
+  constexpr int kDefault = 100;
+  auto it = vars.find("GNASH_NAMEREF_MAX");
+  if (it == vars.end()) return kDefault;
+  char *end = nullptr;
+  long v = std::strtol(it->second.value.c_str(), &end, 10);
+  if (end == it->second.value.c_str() || *end != '\0' || v < 1) return kDefault;
+  return static_cast<int>(v);
+}
+
 std::string Shell::deref(const std::string &n) const {
   std::string cur = n;
-  for (int guard = 0; guard < 100; guard++) {
+  const int max_links = nameref_max();
+  for (int guard = 0; guard < max_links; guard++) {
     auto it = vars.find(cur);
     if (it == vars.end() || !it->second.nameref) return cur;
     const std::string &tgt = it->second.value;
@@ -442,17 +458,25 @@ std::string Shell::deref(const std::string &n) const {
   return cur;
 }
 
-std::string Shell::deref_ex(const std::string &n, bool &circular) const {
+std::string Shell::deref_ex(const std::string &n, bool &circular, bool *too_deep) const {
   circular = false;
+  if (too_deep) *too_deep = false;
   std::string cur = n;
   std::set<std::string> seen;
-  for (;;) {
+  const int max_links = nameref_max();
+  for (int links = 0;; links++) {
     auto it = vars.find(cur);
     if (it == vars.end() || !it->second.nameref) return cur;
     const std::string &tgt = it->second.value;
     if (tgt.empty()) return cur;  // untargeted nameref: not circular
     if (tgt == cur || seen.count(tgt)) {  // self reference or a longer loop
       circular = true;
+      return cur;
+    }
+    // One link too many.  The chain is not circular -- it simply runs deeper
+    // than the shell is willing to follow -- so it resolves to nothing.
+    if (links >= max_links) {
+      if (too_deep) *too_deep = true;
       return cur;
     }
     seen.insert(cur);
@@ -550,8 +574,15 @@ static std::string scalar_of(const Variable &v) {
 std::string Shell::get(const std::string &n_in) const {
   std::string base, sub;
   if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
-  bool circular = false;
-  std::string n = deref_ex(n_in, circular);
+  bool circular = false, too_deep = false;
+  std::string n = deref_ex(n_in, circular, &too_deep);
+  // A chain longer than nameref_max() resolves to nothing, with bash's warning
+  // naming the limit actually in force.
+  if (too_deep) {
+    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
+                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    return std::string();
+  }
   if (circular) {
     // bash warns and, at function scope, resolves the reference at global
     // scope (find_variable_nameref); at global scope it resolves to nothing.
@@ -567,8 +598,9 @@ std::string Shell::get(const std::string &n_in) const {
 std::string Shell::get_quiet(const std::string &n_in) const {
   std::string base, sub;
   if (nameref_elt(n_in, base, sub)) return array_get(base, sub);
-  bool circular = false;
-  std::string n = deref_ex(n_in, circular);
+  bool circular = false, too_deep = false;
+  std::string n = deref_ex(n_in, circular, &too_deep);
+  if (too_deep) return std::string();  // as get(), but this one never reports
   if (circular) {
     const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
     return g ? scalar_of(*g) : std::string();
@@ -1272,8 +1304,15 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
     out = array_get(base, sub);
     return true;
   }
-  bool circular = false;
-  std::string n = deref_ex(n_in, circular);
+  bool circular = false, too_deep = false;
+  std::string n = deref_ex(n_in, circular, &too_deep);
+  // A chain longer than nameref_max() resolves to nothing, with bash's warning
+  // naming the limit actually in force.
+  if (too_deep) {
+    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
+                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    return false;
+  }
   if (circular) {
     // Same resolution as get(): warn, and at function scope fall through to the
     // global binding; a global-scope cycle resolves to nothing (unset).
@@ -1415,7 +1454,15 @@ bool Shell::set(const std::string &n_in, const std::string &v,
     }
   }
   bool circular = false;
-  std::string n = deref_ex(n_in, circular);
+  bool too_deep = false;
+  std::string n = deref_ex(n_in, circular, &too_deep);
+  // Too long a chain has no variable at the end to assign to: bash warns and
+  // fails the assignment, which (with no command word) abandons the list.
+  if (too_deep) {
+    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
+                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    return false;
+  }
   // A circular nameref (self reference `v->v' or a longer loop).  At function
   // scope bash reports the loop as exceeding the max nameref depth and binds
   // the value at global scope; at global scope it warns and the assignment has


### PR DESCRIPTION
Fixes #494, following your comment on the issue rather than its original suggestion: the limit is now a tunable, `$GNASH_NAMEREF_MAX`, defaulting to **100**.

## What was actually broken

The 100 was not a limit, it was a loop guard. On a longer chain the walk just stopped and returned whichever name it had reached, so the result was silently wrong with no diagnostic at all — and nothing anywhere reported a depth problem. The "maximum nameref depth (8) exceeded" message that already existed belongs to *circular* chains, which gnash detects by cycle detection, not by depth; that path is untouched.

## What it does now

Exceeding the limit resolves to nothing and warns `maximum nameref depth (N) exceeded`, naming the limit actually in force — which is the issue's second point. Reads report and yield empty; an assignment fails and, having no command word, abandons the command list. Both match what bash does at its own limit.

`GNASH_NAMEREF_MAX=8` reproduces bash exactly, boundary for boundary:

| chain | bash | gnash (default 100) | gnash with `GNASH_NAMEREF_MAX=8` |
|---|---|---|---|
| 9 links | resolves | resolves | resolves |
| 10 links | warns, empty | resolves | warns, empty |
| 101 links | warns, empty | warns, empty | warns, empty |

The issue's reproduction script, run under `GNASH_NAMEREF_MAX=8`, is byte-identical to bash including the warning text and line number.

## On the default

Keeping 100 means the headline symptom in the report — a 20-deep chain resolving where bash gives up — still differs by default. That is the call you made on the issue, and it is easy to flip if you change your mind: one constant in `Shell::nameref_max`. There is no strict-bash personality to hang it on, so I did not invent one; the variable is the whole mechanism, documented in the README under Tunables.

A malformed or non-positive value falls back to the default rather than erroring, so a stray `GNASH_NAMEREF_MAX=abc` cannot wedge nameref resolution.

## Verification

Depth boundaries 8/9/10/11 against bash with the limit at 8, the 101-link case at the default, the assignment path, and `nameref8.sub` to confirm the circular diagnostic is unchanged. ctest 22/22; run_diff all 240; full 83-suite sweep unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
