### PR TITLE
feat(personality): add strict-bash, driven by $BASHLY_CORRECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ defaults to **100**; bash fixes the equivalent limit at 8, so setting it to 8
 reproduces bash exactly. A missing, malformed or non-positive value falls back
 to the default.
 
+`$BASHLY_CORRECT` is the opt-in to bash's exact limits, in the spirit of
+`$POSIXLY_CORRECT`. Setting it to `true` saves the current
+`$GNASH_NAMEREF_MAX` and pins the limit to bash's 8; setting it to anything
+else -- or unsetting it -- puts the saved value back, including restoring "it
+was unset". Only a change of state does anything, so assigning `true` twice
+cannot lose the saved value.
+
+The `strict-bash` personality is exactly that switch: it selects the `bash`
+personality (so `$GNASH_PERSONALITY` reads `bash` and bash's startup files are
+used) and sets `$BASHLY_CORRECT=true`.
+
+```console
+$ gnash --personality=strict-bash -c 'echo $GNASH_PERSONALITY $BASHLY_CORRECT $GNASH_NAMEREF_MAX'
+bash true 8
+```
+
 
 ## Design
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -71,6 +71,15 @@ class Shell {
   // defaults to 100 and lets $GNASH_NAMEREF_MAX change it, so setting that to 8
   // reproduces bash exactly.
   int nameref_max() const;
+
+  // $BASHLY_CORRECT: gnash's opt-in to bash's exact limits, in the spirit of
+  // $POSIXLY_CORRECT.  It is edge-triggered -- turning it on saves whatever
+  // $GNASH_NAMEREF_MAX held (including "it was unset") and pins the limit to
+  // bash's 8; turning it off puts that state back.  The `strict-bash'
+  // personality is just the bash personality with this switched on.
+  bool bashly_correct = false;
+  std::optional<std::string> saved_nameref_max;  // nullopt: it had been unset
+  void apply_bashly_correct(bool on);
   // The global (pre-function) binding of NAME: when a local scope has shadowed
   // NAME, the saved outer Variable; otherwise the entry in `vars'.  bash
   // resolves a circular nameref to global scope, so a write through one lands

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4538,7 +4538,7 @@ static const BuiltinHelp kBuiltinHelp[] = {
     {"enable", "enable [-a] [-dnps] [-f filename] [name ...]", "Enable and disable shell builtins."},
     {"caller", "caller [expr]", "Return the context of the current subroutine call."},
     {"alias", "alias [-p] [name[=value] ... ]", "Define or display aliases."},
-    {"personality", "personality [-lLR] [{bash|zsh|sh|ksh|csh} [-c command]]", "Switch the shell's personality at runtime (zsh `emulate' syntax)."},
+    {"personality", "personality [-lLR] [{bash|strict-bash|zsh|sh|ksh|csh} [-c command]]", "Switch the shell's personality at runtime (zsh `emulate' syntax)."},
     {"unalias", "unalias [-a] name [name ...]", "Remove each NAME from the list of defined aliases."},
     {"history", "history [-c] [-d offset] [n] or history -anrw [filename] or history -ps arg [arg...]", "Display or manipulate the history list."},
     {"fc", "fc [-e ename] [-lnr] [first] [last] or fc -s [pat=rep] [command]", "Display or execute commands from the history list."},
@@ -6211,8 +6211,8 @@ std::vector<std::string> command_completions(Shell &sh, const std::string &prefi
 // are accepted (a personality switch is already a full reconfiguration).
 int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
   static const std::set<std::string> kNames = {
-      "bash", "zsh",   "sh",    "dash",  "ash",  "ksh",
-      "ksh93", "mksh", "pdksh", "rksh",  "csh",  "tcsh"};
+      "bash", "strict-bash", "zsh",  "sh",    "dash", "ash",
+      "ksh",  "ksh93",       "mksh", "pdksh", "rksh", "csh", "tcsh"};
   bool opt_l = false, opt_L = false, opt_R = false;
   size_t i = 1;
   for (; i < argv.size(); i++) {
@@ -6252,9 +6252,15 @@ int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
 
   if (have_c) {  // run under MODE, then restore
     std::string saved = sh.personality_name;
+    // `strict-bash' leaves $BASHLY_CORRECT on, and restoring the personality
+    // name alone would not undo that -- so put the switch back as well.
+    bool had_bc = sh.is_set("BASHLY_CORRECT");
+    std::string saved_bc = sh.get("BASHLY_CORRECT");
     sh.set_personality(mode);
     int st = sh.run_string(cmd);
     sh.set_personality(saved);
+    if (had_bc) sh.set("BASHLY_CORRECT", saved_bc);
+    else sh.unset("BASHLY_CORRECT");
     return st;
   }
   if (opt_L && !sh.persona_restore.empty() && !sh.persona_restore.back())

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -48,6 +48,7 @@ Shell::Shell() {
   }
   if (!is_set("IFS")) set("IFS", " \t\n");
   if (is_set("POSIXLY_CORRECT")) opt_posix = true;  // inherited from the environment
+  if (get("BASHLY_CORRECT") == "true") apply_bashly_correct(true);  // likewise
   set("OPTIND", "1");  // bash initializes getopts state at startup
   set("PPID", std::to_string(static_cast<long>(getppid())));
   set("$", std::to_string(static_cast<long>(getpid())));
@@ -443,6 +444,34 @@ int Shell::nameref_max() const {
   long v = std::strtol(it->second.value.c_str(), &end, 10);
   if (end == it->second.value.c_str() || *end != '\0' || v < 1) return kDefault;
   return static_cast<int>(v);
+}
+
+// Turning $BASHLY_CORRECT on pins $GNASH_NAMEREF_MAX to bash's 8, remembering
+// what was there so turning it off restores it -- including restoring "unset".
+// Nothing happens unless the state actually changes, so repeated assignments of
+// the same value cannot lose the saved value.  The writes go straight to `vars'
+// to avoid recursing back through Shell::set.
+void Shell::apply_bashly_correct(bool on) {
+  if (on == bashly_correct) return;
+  bashly_correct = on;
+  if (on) {
+    auto it = vars.find("GNASH_NAMEREF_MAX");
+    saved_nameref_max = (it == vars.end() || it->second.invisible)
+                            ? std::nullopt
+                            : std::optional<std::string>(it->second.value);
+    Variable &v = vars["GNASH_NAMEREF_MAX"];
+    v.value = "8";
+    v.invisible = false;
+    return;
+  }
+  if (saved_nameref_max) {
+    Variable &v = vars["GNASH_NAMEREF_MAX"];
+    v.value = *saved_nameref_max;
+    v.invisible = false;
+  } else {
+    vars.erase("GNASH_NAMEREF_MAX");
+  }
+  saved_nameref_max.reset();
 }
 
 std::string Shell::deref(const std::string &n) const {
@@ -1552,6 +1581,9 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   if (opt_allexport) var.exported = true;
   // Setting POSIXLY_CORRECT (to any value) enables POSIX mode, as in bash.
   if (n == "POSIXLY_CORRECT") opt_posix = true;
+  // BASHLY_CORRECT is a switch rather than a flag: only the exact value `true'
+  // turns it on, and anything else turns it back off.
+  if (n == "BASHLY_CORRECT") apply_bashly_correct(v == "true");
   // A locale assignment re-applies LC_CTYPE so multibyte handling follows it.
   if (is_locale_var(n)) apply_ctype_locale(*this);
   // `declare -u' / `-l' / `-c' fold the value's case on every assignment.
@@ -1582,6 +1614,7 @@ void Shell::set_exported(const std::string &n_in, const std::string &v) {
   var.exported = true;
   var.invisible = false;  // an assignment makes a declared-but-unset scalar visible
   if (n == "POSIXLY_CORRECT") opt_posix = true;
+  if (n == "BASHLY_CORRECT") apply_bashly_correct(v == "true");
   if (is_locale_var(n)) apply_ctype_locale(*this);
 }
 
@@ -1616,6 +1649,8 @@ void Shell::unset(const std::string &n_in, bool force, bool noref) {
     }
   }
   if (n == "POSIXLY_CORRECT") opt_posix = false;  // unsetting leaves POSIX mode
+  // Unsetting it is "any other value": the saved nameref limit comes back.
+  if (n == "BASHLY_CORRECT") apply_bashly_correct(false);
   auto it = vars.find(n);
   if (it != vars.end() && (force || !it->second.readonly)) {
     // Unsetting a variable that is local to the CURRENT function scope leaves
@@ -1740,15 +1775,26 @@ void Shell::import_env_functions() {
 }
 
 void Shell::set_personality(const std::string &name) {
-  personality_name = name;
-  if (name == "zsh") persona = Persona::Zsh;
-  else if (name == "ash" || name == "dash" || name == "sh") persona = Persona::Ash;
-  else if (name == "ksh" || name == "ksh93" || name == "mksh" || name == "pdksh" ||
-           name == "rksh")
+  // `strict-bash' is not a shell of its own: it is the bash personality with
+  // $BASHLY_CORRECT turned on, so the shell identifies itself as bash and picks
+  // up bash's startup files while the stricter limits apply.  Selecting any
+  // other personality turns the switch back off.
+  bool strict = name == "strict-bash";
+  personality_name = strict ? "bash" : name;
+  const std::string &nm = personality_name;
+  if (nm == "zsh") persona = Persona::Zsh;
+  else if (nm == "ash" || nm == "dash" || nm == "sh") persona = Persona::Ash;
+  else if (nm == "ksh" || nm == "ksh93" || nm == "mksh" || nm == "pdksh" ||
+           nm == "rksh")
     persona = Persona::Ksh;
-  else if (name == "csh" || name == "tcsh") persona = Persona::Csh;
+  else if (nm == "csh" || nm == "tcsh") persona = Persona::Csh;
   else persona = Persona::Bash;
-  set("GNASH_PERSONALITY", name);
+  set("GNASH_PERSONALITY", nm);
+  // Only `strict-bash' touches the switch.  Switching to another personality
+  // leaves it alone: it is an ordinary variable the user may have set on
+  // purpose (or inherited from the environment), and assigning to it is how you
+  // turn it off.
+  if (strict) set("BASHLY_CORRECT", "true");
 
   // Per-shell identity variables.  These are additive (as zsh's emulate is):
   // switching does not unset another shell's version variable.


### PR DESCRIPTION
Adds the `strict-bash` personality target and the `$BASHLY_CORRECT` switch behind it, as sketched on #494.

```console
$ gnash --personality=strict-bash -c 'echo $GNASH_PERSONALITY $BASHLY_CORRECT $GNASH_NAMEREF_MAX'
bash true 8
```

`strict-bash` is not a shell of its own — it selects the **bash** personality, so `$GNASH_PERSONALITY` reads `bash` and bash's startup files are used, and sets `$BASHLY_CORRECT=true`.

## The switch

`$BASHLY_CORRECT` is edge-triggered, in the spirit of `$POSIXLY_CORRECT`. Turning it on saves the current `$GNASH_NAMEREF_MAX` and pins the limit to bash's 8; turning it off puts the saved value back:

| | `$GNASH_NAMEREF_MAX` |
|---|---|
| `GNASH_NAMEREF_MAX=42; BASHLY_CORRECT=true` | `8` |
| then `BASHLY_CORRECT=no` | `42` |
| `BASHLY_CORRECT=true` with none set before | `8` |
| then `BASHLY_CORRECT=x` | back to **unset**, not empty |
| `BASHLY_CORRECT=true` twice, then off | `42` — a repeat cannot lose the saved value |
| `unset BASHLY_CORRECT` | restores, same as any other value |

Only the exact string `true` turns it on. It is honoured from the environment at startup as well, like `POSIXLY_CORRECT`.

## Two judgement calls worth your eye

**Switching to another personality leaves the switch alone.** My first cut had every personality switch write `BASHLY_CORRECT=false`, which clobbered a value inherited from the environment (the personality is configured *after* the environment is imported, so `BASHLY_CORRECT=true gnash` would have been silently undone). It is an ordinary variable the user may have set on purpose; assigning to it is how you turn it off.

**`personality NAME -c CMD` is the exception.** It promises to restore, and restoring the personality name alone would have left the shell strict afterwards — so it saves and restores the switch too, including the unset case.

## Verification

Every row of the table above, both entry points (`--personality=strict-bash` and the runtime `personality strict-bash`), the `-c` restore, and rejection of unknown names. End to end, the nameref-depth reproduction from #494 under `strict-bash` is byte-identical to bash — warning text, line number and exit status.

ctest 22/22; run_diff all 240; full 83-suite sweep unchanged. README documents both the variable and the personality under Tunables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
