### PR TITLE
fix(expand): a negative substring length counts from the end

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -767,6 +767,15 @@ static bool slice_ref(const std::string &body, std::string &name, char &sel,
   return true;
 }
 
+// A negative length in an ARRAY slice is a hard error in bash (only a scalar
+// substring reads one as an offset from the end).  Report it and abort the
+// command, as any other expansion error does.
+static void slice_len_error(Shell &sh, long long len) {
+  std::fprintf(stderr, "%s%lld: substring expression < 0\n", sh.err_prefix().c_str(), len);
+  sh.arith_error = true;
+  sh.arith_abort = true;  // bash unwinds the whole command list, not just this word
+}
+
 // Detect NAME[@]OP / NAME[*]OP where OP is a defaulting/alternative/error
 // operator (`-` `:-` `=` `:=` `+` `:+` `?` `:?`) applied to the array as a
 // whole.  Must be tried before slice_ref, which would otherwise misread
@@ -1794,7 +1803,10 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (shaslen) {
             long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
             if (!ok) len = 0;
-            count = (len < 0) ? (maxidx + 1 + len - off) : len;
+            // Unlike a scalar substring, an array slice has no "from the end"
+            // reading: bash rejects any negative length outright.
+            if (len < 0) slice_len_error(sh_, len);
+            count = len < 0 ? 0 : len;  // the error already abandons the list
           } else {
             count = static_cast<long long>(keys.size());
           }
@@ -1817,7 +1829,8 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (shaslen) {
             long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
             if (!ok) len = 0;
-            count = (len < 0) ? (n + len - off) : len;  // negative len = offset from end
+            if (len < 0) slice_len_error(sh_, len);
+            count = len < 0 ? 0 : len;  // the error already abandons the list
           } else {
             count = n - off;
           }
@@ -2693,8 +2706,9 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     // (`${#:%}' -> `#: %: arithmetic syntax error ...').
     long long off =
         eval_arith_msg(sh, ex.expand_arith(offtxt), name.c_str(), &ok, /*expand_subs=*/1);
-    long long len = -1;
-    if (ok && colon2 != std::string::npos)
+    long long len = 0;
+    bool haslen = colon2 != std::string::npos;
+    if (ok && haslen)
       len = eval_arith_msg(sh, ex.expand_arith(args.substr(colon2 + 1)), name.c_str(), &ok,
                            /*expand_subs=*/1);
     // A failed offset/length aborts the command, as any expansion error does.
@@ -2708,9 +2722,26 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (off < 0) off += n;
     if (off < 0) off = 0;
     if (off > n) off = n;
+    // The slice runs from OFF up to END, both character indices into the whole
+    // value.  A NEGATIVE length is not a count but an end offset measured from
+    // the end of the value, so `${v:0:-5}' drops its last five characters and
+    // `${v:6:-2}' ends two from the end regardless of where it started.
+    long long end = n;
+    if (haslen) {
+      end = (len < 0) ? n + len : (off > n - len ? n : off + len);
+      if (end < off) {
+        std::fprintf(stderr, "%s%lld: substring expression < 0\n", sh.err_prefix().c_str(),
+                     len);
+        sh.arith_error = true;
+        sh.arith_abort = true;  // bash unwinds the whole command list
+        return std::string();
+      }
+      if (end > n) end = n;
+    }
     std::string res = val.substr(mb_byteoff(val, static_cast<size_t>(off)));
-    if (len >= 0 && len < static_cast<long long>(mb_charlen(res)))
-      res = res.substr(0, mb_byteoff(res, static_cast<size_t>(len)));
+    long long take = end - off;
+    if (take < static_cast<long long>(mb_charlen(res)))
+      res = res.substr(0, mb_byteoff(res, static_cast<size_t>(take)));
     return res;
   }
 


### PR DESCRIPTION
Fixes #492.

```
v="hello world"; echo "${v:0:-5}"
  bash: hello       was: hello world
```

A negative length was treated as "no length given", because `-1` doubled as the sentinel for *absent*. Tracking that separately fixes the reported case — but the semantics have two wrinkles the report doesn't mention, and I checked both against bash rather than implementing the suggested `total - |len|` directly.

## It is an end offset, not a length

The suggestion in the issue — compute `mb_charlen(res) + len` from the *offset-adjusted* string — gives the wrong answer whenever the offset is non-zero. bash measures from the end of the **whole** value:

```
v="hello world"; echo "${v:6:-2}"      bash: wor      (not "wo")
v="hello world"; echo "${v:3:-3}"      bash: lo wo
v="héllo wörld"; echo "${v:2:-2}"      bash: llo wör  (characters, not bytes)
```

So the slice runs from `offset` up to `n + length`, both character indices into the whole value.

## When the end lands before the offset, it is an error

```
v="hello world"; echo "${v:0:-20}"; echo AFTER
  bash: -20: substring expression < 0     (AFTER does not run)
```

`${v:0:-11}` is fine — end 0, offset 0, empty result — but `${v:8:-5}` errors even though the end is positive, because 6 < 8. The error abandons the rest of the command list while the next line still runs, which is the same unwind gnash already uses for failed bare assignments.

## Arrays reject a negative length outright

This is the part worth flagging: gnash was *already* implementing "offset from the end" for array and positional slices, and that is wrong — bash has no such reading there.

```
set -- a b c d e; echo "${@:1:-1}"      bash: -1: substring expression < 0     was: a b c d
a=(a b c d e);    echo "${a[@]:1:-1}"   bash: -1: substring expression < 0     was: b c d
```

Indexed arrays, associative arrays and the positional forms all now report it.

## Verification

Seven script-file cases covering both shells end to end — the scalar forms above, multibyte, the two error shapes with their abort scope, all three array spellings, and the ordinary positive-length and no-length paths to confirm nothing else moved. ctest 22/22; run_diff all 240; full 83-suite sweep unchanged.

One thing this does not touch, noticed while testing: `${v: -99}` on a 5-character value gives `hello` in gnash where bash gives empty — an over-negative *offset* is clamped where bash gives up. Separate from the length handling; not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
