### PR TITLE
fix(comsub): end the word when an alias supplies the closing `)'

### DIFF
--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -299,6 +299,11 @@ struct Lexer {
         word_plain = false;
       } else if (c == ';' || c == '&' || c == '|' || c == '\n') {
         boundary();
+        // The splice in boundary() can supply the closing `)' from an alias
+        // body (`alias short="echo ok 8 )"').  The span is finished at that
+        // point, so this delimiter belongs to the text AFTER it -- consuming it
+        // would pull the next command into the substitution's word.
+        if (depth == 0) break;
         after_pipe = (c == '|');
         bool was_nl = c == '\n';
         w += c;
@@ -351,6 +356,7 @@ struct Lexer {
         }
       } else if (c == ' ' || c == '\t') {
         boundary();
+        if (depth == 0) break;  // an alias body supplied the closer (see above)
         w += c;
         pos++;
       } else if (c == '#' && !saw_word) {


### PR DESCRIPTION
Fixes #453. **comsub.tests 2 -> 0**, comsub5.sub byte-clean, and the suite total goes to **61 of 83**.

## What it actually was

Not the expansion path I guessed at twice in the issue comments. When an alias body carries the substitution's closer, the splice in `scan_paren`'s `boundary()` brings the paren depth to 0 — correctly. But `boundary()` is called *from* the delimiter branches, and those go on to consume the delimiter before the loop re-checks the depth. The span was already over, so the newline and whatever followed got pulled into the substitution's word:

```sh
alias short="echo ok 8 )"
echo $( short
echo MARKER
```

tokenized as the single word `$( echo ok 8 )\necho`, printing `echo MARKER` instead of running it. In comsub5.sub that shows up as line 45 swallowing line 46 — which reads as a *quoting* failure in the diff, which is what sent me looking in the wrong place.

The fix is two lines: stop at the delimiter when `boundary()` closed the span. It belongs to the text after the substitution, exactly where bash's spliced `)` leaves it. The depth can only be 0 in those branches through a splice, since the loop runs while it is positive.

## Verification

Beyond the suites: a purpose-built file covering the splice against every delimiter that can trigger it — newline, `;`, space, tab — plus the quoted form, a balanced-body alias (which must still be left for the runtime parse to expand once), the unbalanced-open `alias nest="("` case, and the `DO`/`DONE` brace aliases. All byte-identical to bash.

ctest 22/22; run_diff all 240; full sweep shows `comsub: 2 -> 0` as the only change.

Closes the last of #453 — both numbered clusters were already done, and this is the "aliases whose expansion contains unbalanced parentheses" tail noted at the bottom of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
