### PR TITLE
fix(arith): raise the recursion bound and report when it is hit

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -141,19 +141,43 @@ struct Parser {
     ok = false;
   }
 
-  // Bound recursion so a deeply nested expression -- e.g. thousands of nested
-  // parentheses or unary operators in $(( ... )) -- fails to parse instead of
-  // overflowing the call stack and crashing the shell.  Far above any real use.
+  // Bound recursion so a deeply nested expression -- thousands of nested
+  // parentheses or unary operators in $(( ... )) -- fails cleanly instead of
+  // overflowing the call stack and crashing the shell.
+  //
+  // The bound is NOT bash's MAX_EXPR_RECURSION_LEVEL (1024): that counts nested
+  // EVALUATION CONTEXTS -- a variable whose value is another expression -- not
+  // descent through the precedence chain, which is why bash evaluates 20000
+  // nested unary minuses in a single expression happily.  (That limit is
+  // modelled separately, and is what `x=x; echo $((x))' reports.)
+  //
+  // So size this one against the stack instead.  Measured on this parser, the
+  // descent survives 50000 frames and dies before 60000; 25000 keeps a 2x
+  // margin under that while still accepting far deeper expressions than bash
+  // itself manages -- it takes 50000 unary minuses to reach, and bash crashes
+  // well before that.
+  // Levels are CHARGED by what they cost the stack, because the shapes differ
+  // by nearly an order of magnitude: one more unary operator is a single extra
+  // frame, while one more parenthesis re-descends the whole precedence chain.
+  // Measured here, the descent survives ~50000 unary levels but only ~4500
+  // parenthesised ones, so a flat count safe for the first would crash on the
+  // second.  kParenCost keeps both inside the same budget.
   int rec_depth = 0;
-  static constexpr int kMaxDepth = 1000;
+  static constexpr int kMaxDepth = 25000;
+  static constexpr int kParenCost = 7;
   struct DepthGuard {
     Parser &p;
+    int cost;
     bool allowed;
-    explicit DepthGuard(Parser &pp) : p(pp) {
-      allowed = (++p.rec_depth <= kMaxDepth);
-      if (!allowed) p.ok = false;
+    explicit DepthGuard(Parser &pp, int c = 1) : p(pp), cost(c) {
+      p.rec_depth += cost;
+      allowed = p.rec_depth <= kMaxDepth;
+      // Say why.  Without a note the failure surfaces as a syntax error about
+      // whatever token the abandoned parse left behind, which describes the
+      // symptom and not the cause.
+      if (!allowed) p.note(arith_err::kRecursion, p.pos);
     }
-    ~DepthGuard() { --p.rec_depth; }
+    ~DepthGuard() { p.rec_depth -= cost; }
   };
 
   void skip() { while (pos < s.size() && std::isspace(static_cast<unsigned char>(s[pos]))) pos++; }
@@ -456,6 +480,8 @@ struct Parser {
   NodeP primary() {
     skip();
     if (peek() == '(') {
+      DepthGuard g(*this, kParenCost);
+      if (!g.allowed) return mk(K::Num);
       mark_op(); pos++;
       NodeP v = comma();
       skip();


### PR DESCRIPTION
Fixes #499. The reproduction from the issue is now byte-identical to bash.

## Why the limit was wrong, not just its message

The issue proposes adding a diagnostic to the depth guard. That is half of it — but bash *succeeds* on the reported input, so a clearer error would still be the wrong answer. The bound itself was misplaced.

It was modelled on bash's `MAX_EXPR_RECURSION_LEVEL` (1024), but that constant counts nested **evaluation contexts** — a variable whose value is another expression — not descent through the precedence chain. That is why bash evaluates 20000 nested unary minuses in one expression happily. gnash already models that limit separately and correctly; `x=x; echo $((x))` reports `expression recursion level exceeded (error token is "x")` exactly as bash does, and this change does not touch it.

This guard only needs to keep the parser off the end of the stack, so it is now sized against the stack.

## Levels are charged by what they cost

Measuring the two shapes separately turned out to matter. One more unary operator is a single extra frame; one more parenthesis re-descends the whole chain. This parser survives ~50000 unary levels but only ~4500 parenthesised ones — so a flat count safe for the first **crashes** on the second. Raising the old flat 1000 without noticing that would have turned a bogus error into a silent stack overflow at 5000 parens.

`kParenCost` charges parenthesised levels seven times, keeping both inside one budget.

| | bash | gnash before | gnash now |
|---|---|---|---|
| 2000 unary (the report) | `1` | bogus syntax error | `1` |
| 40000 unary | `1` | bogus syntax error | `1` |
| 60000 unary | crashes | — | reports cleanly |
| 3000 parens | `1` | error at 1000 | `1` |
| 6000 parens | `1` | error at 1000 | reports cleanly |

## The remaining difference, stated plainly

Between roughly 3000 and 8000 nested parentheses bash still succeeds where gnash now reports the limit. gnash's per-level stack cost is simply higher, and I would rather stop with a diagnostic than crash — which is what unguarded raising would do here. Deep unary nesting, the shape actually reported, matches or exceeds bash.

## Verification

Both shapes across the full range, the four self-reference forms (`$(( ))`, `(( ))`, `let`, and a two-variable cycle) to confirm the context limit is untouched, and ordinary expressions. ctest 22/22; run_diff all 240; full 83-suite sweep unchanged at 61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
