### PR TITLE
fix(expand): `${}' is a bad substitution

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1200,6 +1200,20 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
                                /*squote_literal=*/dq && sh_.opt_posix);
     if (end != std::string::npos) {
       std::string body = t.substr(i + 2, end - (i + 2));
+      // `${}' names no parameter at all -- bash's `bad substitution'.  Note
+      // that `${ }' is a DIFFERENT construct: whitespace after the brace makes
+      // it a function substitution with an empty body, which is valid and
+      // expands to nothing.  Only the empty body is an error.
+      if (body.empty()) {
+        std::fprintf(stderr, "%s${}: bad substitution\n", sh_.err_prefix().c_str());
+        // arith_error alone, as every other bad substitution here does: bash
+        // abandons the command list for some of these and not others (not in a
+        // here-document body, for one), and gnash does not model that split
+        // yet.  Reporting and failing the command is the part that matters.
+        sh_.arith_error = true;
+        i = end + 1;
+        return;
+      }
 
       // ${@} / ${*}: a bare positional list, identical to $@ / $*.  Handle it
       // here so `"${@}"' keeps its per-parameter field structure rather than


### PR DESCRIPTION
Fixes #490. The reproduction from the issue is byte-identical to bash.

```
echo ${}          bash: ${}: bad substitution, status 1     was: empty, status 0
```

## The one thing to be careful of

`${ }` is a **different construct**. Whitespace after the brace makes it a function substitution with an empty body, and bash accepts it:

```
echo ${ }          # bash: empty output, status 0
echo ${  }         # likewise
echo ${ echo hi; } # hi
```

So the check is on the body being *empty*, not blank — an easy thing to get wrong by trimming first, which would have broken funsubs.

## What I did not change, and why

I first also made every `bad substitution` in this file abandon the rest of the command list, since `echo ${} ; echo AFTER` skips `AFTER` in bash. That regressed `posixexp` 4 -> 5: bash does **not** abandon the list when the bad substitution is in a here-document body, and posixexp7.sub covers exactly that, expecting three diagnostics where the abort produced one.

Rather than guess at the rule, `${}` now behaves like every other bad substitution here — report and fail the command, no unwind. That leaves one known difference: `echo ${} ; echo AFTER` still runs `AFTER`. It is pre-existing, shared by all the bad-substitution sites, and wants its own investigation into which contexts unwind; I have noted it in the code rather than half-implementing it.

## Verification

The forms above plus `"${}"`, `${#}`, `${v}`, `eval` (which the issue uses), and the here-document context. ctest 22/22; run_diff all 240; full 83-suite sweep unchanged at 61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
