### PR TITLE
fix(cond): report conditional syntax errors the way bash does (cond 51 -> 23)

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -53,8 +53,12 @@ std::string tok_to_text(const Token &t) {
   return tok_name(t.type);
 }
 
+// bash's test_unop(): the exact set, not "a dash and any letter".  `-Q' is not
+// one, so `[[ -Q 7 ]]' reads `-Q' as the left operand and then complains that
+// `7' is not a binary operator.
 bool is_cond_unary(const std::string &w) {
-  return w.size() == 2 && w[0] == '-' && std::isalpha(static_cast<unsigned char>(w[1]));
+  return w.size() == 2 && w[0] == '-' && w[1] != '\0' &&
+         std::strchr("abcdefghknoprstuvwxzGLOSNR", w[1]) != nullptr;
 }
 
 bool is_cond_binop_word(const std::string &w) {
@@ -858,6 +862,16 @@ struct Parser {
 
   bool at_cond_end() const { return reserved("]]"); }
 
+  // bash reports a conditional-expression error in three lines: a diagnostic
+  // naming what went wrong, then `syntax error near `TOKEN'', then the source
+  // line.  The first is emitted verbatim -- the printer leaves the conditional
+  // diagnostics unadorned rather than prefixing them with `syntax error:'.
+  void cond_fail(const std::string &diag) {
+    fail(diag + "\nnear `" + tok_to_text(cur()) + "'");
+  }
+  // The token as bash names it in those diagnostics.
+  std::string cond_tok() const { return tok_to_text(cur()); }
+
   void cond_primary(std::string &e) {
     if (err) return;
     NestGuard g(*this);
@@ -869,20 +883,25 @@ struct Parser {
       if (is(Tok::Rparen)) {
         e += " )";
         advance();
+      } else if (is(Tok::Eof)) {
+        // At end of input the grammar reports the unterminated `[[' as well,
+        // so this line stands alone.
+        fail("unexpected token `EOF', expected `)'");
       } else {
-        fail("expected `)' in conditional");
+        cond_fail("unexpected token `" + cond_tok() + "', expected `)'");
       }
       return;
     }
     if (cur().type != Tok::Word || at_cond_end()) {
-      fail("expected conditional expression");
+      cond_fail("unexpected token `" + cond_tok() + "' in conditional command");
       return;
     }
     std::string w1 = cur().text;
     if (is_cond_unary(w1)) {
       advance();
       if (cur().type != Tok::Word || at_cond_end()) {
-        fail("expected operand after unary operator");
+        cond_fail("unexpected argument `" + cond_tok() +
+                  "' to conditional unary operator");
         return;
       }
       e += w1;
@@ -903,7 +922,8 @@ struct Parser {
         // the original source, gluing tokens that were not separated by
         // whitespace (so `([0-9]+)-([0-9]+)' stays one pattern).
         if (at_cond_end() || is(Tok::Eof)) {
-          fail("expected operand after operator");
+          cond_fail("unexpected argument `" + cond_tok() +
+                    "' to conditional binary operator");
           return;
         }
         // Whitespace normally ends the regex, but not while inside an unclosed
@@ -939,7 +959,8 @@ struct Parser {
         return;
       }
       if (cur().type != Tok::Word || at_cond_end()) {
-        fail("expected operand after operator");
+        cond_fail("unexpected argument `" + cond_tok() +
+                  "' to conditional binary operator");
         return;
       }
       e += ' ';
@@ -947,6 +968,13 @@ struct Parser {
       e += ' ';
       e += cur().text;
       advance();
+    } else if (!at_cond_end() && !is(Tok::Eof) && !is(Tok::AndAnd) &&
+               !is(Tok::OrOr) && !is(Tok::Rparen)) {
+      // `[[ x ]]' is `[[ -n x ]]', but only when the expression really ends
+      // here: anything else in operator position is bash's complaint that it
+      // wanted a binary operator (`[[ 4 & ]]', `[[ -Q 7 ]]').
+      cond_fail("unexpected token `" + cond_tok() +
+                "', conditional binary operator expected");
     }
   }
 
@@ -988,6 +1016,11 @@ struct Parser {
     auto n = std::make_unique<CondCommand>();
     std::string expr;
     cond_or(expr);
+    if (!err && !at_cond_end()) {
+      if (is(Tok::Eof)) fail("unexpected EOF while looking for `]]'");
+      else cond_fail("syntax error in conditional expression: unexpected token `" +
+                     cond_tok() + "'");
+    }
     expect_reserved("]]");
     n->expression = trim(expr);
     n->line = cond_line;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2376,7 +2376,18 @@ int Shell::run_string(const std::string &script) {
       if (cp != std::string::npos && lineno_base > 0)
         line = line.substr(0, cp + 18) +
                std::to_string(lineno_base + std::atoi(line.c_str() + cp + 18));
-      if (line.compare(0, 14, "unexpected EOF") == 0) {
+      // bash prints its conditional-expression diagnostics, and the
+      // unterminated-EOF ones, without a `syntax error' prefix -- they are
+      // complete sentences already, and a `syntax error near ...' line follows.
+      auto starts = [&line](const char *pfx2) {
+        return line.rfind(pfx2, 0) == 0;
+      };
+      auto bare = [&starts]() {
+        return starts("unexpected EOF") || starts("unexpected token `") ||
+               starts("unexpected argument `") ||
+               starts("syntax error in conditional expression");
+      };
+      if (bare()) {
         std::fprintf(stderr, "%s%s\n", pfx.c_str(), line.c_str());  // no `syntax error'
       } else {
         const char *sep = line.compare(0, 5, "near ") == 0 ? " " : ": ";
@@ -2385,7 +2396,11 @@ int Shell::run_string(const std::string &script) {
       if (nl == std::string::npos) break;
       p0 = nl + 1;
     }
-    if (r.error.compare(0, 5, "near ") == 0 && r.error_line > 0) {
+    // Echo the offending source line whenever a `near ...' line was printed --
+    // it may be the second line of a conditional-expression report.
+    bool has_near = r.error.compare(0, 5, "near ") == 0 ||
+                    r.error.find("\nnear ") != std::string::npos;
+    if (has_near && r.error_line > 0) {
       // Echo the offending source line, as bash does.
       size_t start = 0;
       for (int k = 1; k < r.error_line && start != std::string::npos; k++) {


### PR DESCRIPTION
**cond.tests 51 -> 23.** All nine of cond-error1.sub's non-EOF cases are now byte-identical to bash.

A malformed `[[ ]]` produced gnash's own one-line diagnostics where bash names what it found and why, in three lines — the diagnostic, `syntax error near 'TOKEN'`, and the offending source line:

```
$ gnash -c '[[ -n & ]]'
was:  syntax error: expected operand after unary operator
now:  unexpected argument `&' to conditional unary operator
      syntax error near `&'
      `[[ -n & ]]'
```

Ported the full set from `parse.y`'s `cond_term`: the two `unexpected argument ... to conditional {unary,binary} operator` forms, `unexpected token 'X', conditional binary operator expected`, `unexpected token 'X' in conditional command`, `unexpected token 'X', expected ')'`, and `syntax error in conditional expression: unexpected token 'X'`. The printer leaves these unadorned — they are complete sentences already.

## Two rules the messages depended on

Getting the text right was not enough; two of the cases needed behaviour changes to reach the right message at all.

- **After a lone left operand, only an end token may follow.** `[[ x ]]` is `[[ -n x ]]` just as in `test`, but only when the expression really ends there. Anything else is the missing-binary-operator complaint, which is what makes `[[ 4 & ]]` report.
- **`is_cond_unary` accepted a dash and any letter.** bash's `test_unop` is a fixed set, so `-Q` is *not* an operator — `[[ -Q 7 ]]` reads it as the left operand and then rejects `7`. gnash accepted the whole expression silently and printed nothing at all.

## What is left

The two end-of-input cases (`[[ ( -n xx` and `[[ ( -n xx )`) still differ. bash pairs its diagnostic with the grammar-level `unexpected end of file from '[[' command on line 1`, and those two lines carry *different* line numbers — line 1 and line 2. gnash's error printer computes one prefix per report, so mixed line numbers need a change there rather than in the conditional parser. Worth its own PR; it is the last ~5 lines of that file.

## Verification

All eleven cases from cond-error1.sub compared against bash byte for byte (nine matching, two documented above). ctest 22/22; run_diff all 240; full sweep shows `cond: 51 -> 23` as the only change — notably the `is_cond_unary` tightening moved nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
