### PR TITLE
fix(cond): implement -nt, -ot and -ef in `[[ ]]' (cond 23 -> 19)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7248,8 +7248,9 @@ struct CondEval {
     // binary operator
     if (t[i].type == Tok::Word || t[i].type == Tok::Less || t[i].type == Tok::Great) {
       std::string op = (t[i].type == Tok::Word) ? t[i].text : std::string(tok_name(t[i].type));
-      static const char *bops[] = {"==", "=", "!=", "=~", "-eq", "-ne", "-lt",
-                                   "-le", "-gt", "-ge", "<", ">", nullptr};
+      static const char *bops[] = {"==", "=",   "!=",  "=~",  "-eq", "-ne", "-lt",
+                                   "-le", "-gt", "-ge", "-nt", "-ot", "-ef",
+                                   "<",   ">",   nullptr};
       bool isb = false;
       for (int k = 0; bops[k]; k++) if (op == bops[k]) isb = true;
       if (isb) {
@@ -7292,6 +7293,14 @@ struct CondEval {
           }
           return matched;
         }
+        // The file comparisons, shared with `test': an unstattable file is
+        // older than one that exists, and `-ef' needs both to exist.  These
+        // were accepted by the parser but never evaluated here, so every
+        // `[[ a -ef b ]]' fell through to the one-argument "non-empty is true"
+        // rule and answered true.
+        if (op == "-nt") return file_comp(lhs, expand(rhs_raw), 'n');
+        if (op == "-ot") return file_comp(lhs, expand(rhs_raw), 'o');
+        if (op == "-ef") return file_comp(lhs, expand(rhs_raw), 'f');
         if (op == "<") return lhs < expand(rhs_raw);
         if (op == ">") return lhs > expand(rhs_raw);
         // The [[ ]] arithmetic comparators evaluate each side as an arithmetic


### PR DESCRIPTION
**cond.tests 23 -> 19.**

`[[ ]]` never implemented `-nt`, `-ot` or `-ef`. The conditional *parser* accepted them, but the evaluator's operator table had no case, so they fell through to the one-argument "a non-empty string is true" rule:

```
[[ /tmp/nope -ef /tmp/alsonope ]]   bash: 1    was: 0
[[ old -nt new ]]                   bash: 1    was: 0
```

Every file comparison in a conditional answered **true** — whatever the files were, or whether they existed at all.

That is what the two remaining `returns:` mismatches in cond.tests came down to: `[[ -n $TDIR && -n $UNSET || $TDIR -ef . ]]` took the `||` arm as true where bash takes it as false. The diff read as a precedence problem, which is where I would have looked; it was a missing operator.

Routed through the same `file_comp` the `test` builtin uses, so the two agree: a file that cannot be stat'd is older than one that can (`noexist -ot f` is true), and `-ef` compares device and inode.

Verified against bash across eight cases — hard-linked files, distinct files, back-dated pairs, and non-existent operands on either side — plus the two cond.tests expressions. ctest 22/22; run_diff all 240; full sweep shows `cond: 23 -> 19` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
