### PR TITLE
fix(cond): report an unterminated `[[' at end of input as bash does (cond -> 0)

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -866,6 +866,24 @@ struct Parser {
   // naming what went wrong, then `syntax error near `TOKEN'', then the source
   // line.  The first is emitted verbatim -- the printer leaves the conditional
   // diagnostics unadorned rather than prefixing them with `syntax error:'.
+  int cond_open_line = 0;  // line of the `[[' currently being parsed
+  // True when nothing but blank lines remains: bash calls that EOF, and names
+  // the token `EOF' rather than the NEWLINE that happens to be sitting there.
+  bool at_input_end() const {
+    for (std::size_t k = i; k < toks.size(); k++) {
+      if (toks[k].type == Tok::Eof) return true;
+      if (toks[k].type != Tok::Newline) return false;
+    }
+    return true;
+  }
+  // At end of input bash pairs the conditional diagnostic with the
+  // grammar-level report, on the following line -- and no `near'/source echo.
+  void cond_eof_fail(const std::string &diag) {
+    incomplete = true;
+    fail(diag + "\nunexpected end of file from `[[' command on line " +
+         std::to_string(cond_open_line));
+  }
+
   void cond_fail(const std::string &diag) {
     fail(diag + "\nnear `" + tok_to_text(cur()) + "'");
   }
@@ -883,10 +901,8 @@ struct Parser {
       if (is(Tok::Rparen)) {
         e += " )";
         advance();
-      } else if (is(Tok::Eof)) {
-        // At end of input the grammar reports the unterminated `[[' as well,
-        // so this line stands alone.
-        fail("unexpected token `EOF', expected `)'");
+      } else if (at_input_end()) {
+        cond_eof_fail("unexpected token `EOF', expected `)'");
       } else {
         cond_fail("unexpected token `" + cond_tok() + "', expected `)'");
       }
@@ -1012,12 +1028,13 @@ struct Parser {
 
   CommandPtr parse_cond() {
     int cond_line = cur().line;  // $LINENO / error line of the `[[' command
+    cond_open_line = cond_line;
     advance();  // [[
     auto n = std::make_unique<CondCommand>();
     std::string expr;
     cond_or(expr);
     if (!err && !at_cond_end()) {
-      if (is(Tok::Eof)) fail("unexpected EOF while looking for `]]'");
+      if (at_input_end()) cond_eof_fail("unexpected EOF while looking for `]]'");
       else cond_fail("syntax error in conditional expression: unexpected token `" +
                      cond_tok() + "'");
     }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2389,7 +2389,16 @@ int Shell::run_string(const std::string &script) {
                starts("unexpected argument `") ||
                starts("syntax error in conditional expression");
       };
-      if (bare()) {
+      // A grammar-level end-of-file report that FOLLOWS another line carries
+      // its own line number: EOF lands after the last content, while the
+      // diagnostic above it named the line the trouble was on.
+      if (p0 > 0 && starts("unexpected end of file from `")) {
+        std::string pfx2 = pfx;
+        size_t lp = pfx2.rfind("line ");
+        if (lp != std::string::npos)
+          pfx2 = pfx2.substr(0, lp + 5) + std::to_string(r.error_line + 1) + ": ";
+        std::fprintf(stderr, "%ssyntax error: %s\n", pfx2.c_str(), line.c_str());
+      } else if (bare()) {
         std::fprintf(stderr, "%s%s\n", pfx.c_str(), line.c_str());  // no `syntax error'
       } else {
         const char *sep = line.compare(0, 5, "near ") == 0 ? " " : ": ";


### PR DESCRIPTION
**cond.tests 10 -> 0.** The suite is byte-perfect, taking the board to **62 of 83**.

Running out of input inside a conditional was reported against the NEWLINE that happened to be sitting there, complete with a `near`/source echo:

```
was:  line 1: unexpected token `NEWLINE', expected `)'
      line 1: syntax error near `NEWLINE'
      line 1: `[[ ( -n xx'

bash:  line 1: unexpected token `EOF', expected `)'
       line 2: syntax error: unexpected end of file from `[[' command on line 1
```

Three parts:

- **Detect end of input, not the Eof token.** With a trailing newline the parser is looking at a NEWLINE, so testing `is(Tok::Eof)` never fired. `at_input_end()` asks whether anything but blank lines remains.
- **Pair the diagnostic with the grammar-level report** of the unterminated `[[`, naming the line the `[[` opened on, and drop the `near`/source echo that bash does not print here.
- **Let that second line carry its own line number.** This was the blocker I flagged earlier: the printer computed one prefix per report, and these two lines need lines 1 and 2 — EOF lands after the last content, while the diagnostic names where the trouble was. A grammar-level end-of-file report that *follows* another line now gets `error_line + 1`; the standalone case (`{ echo hi`, which already reports line 2 on its own) is untouched.

## Verification

All eleven cases in cond-error1.sub, which now matches byte for byte, plus the surrounding suite. ctest 22/22; run_diff all 240; full sweep shows `cond: 10 -> 0` as the only change.

That finishes cond: 70 -> 0 over six PRs today. Along the way it turned up four bugs that were not about error text at all — `[[ ]]` never implementing `-nt`/`-ot`/`-ef`, `&&`/`||` not short-circuiting, `is_cond_unary` accepting any `-X`, and the ERR trap never firing for a failed conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
