### PR TITLE
fix(trap): $LINENO in a RETURN trap, and at a function exit (dbg-support 59 -> 43)

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1594,6 +1594,11 @@ int Executor::run_simple(const SimpleCommand *c) {
     // (e.g. the DEBUG-trap handler itself) does not inherit the RETURN trap --
     // bash restores its default at entry when signal_in_progress(DEBUG_TRAP).
     {
+      // Leaving the body, bash reports the function's DEFINITION line again --
+      // the same line its entry DEBUG trap named -- rather than whatever the
+      // last command inside happened to set.
+      auto rlit = sh_.func_def_line.find(argv[0]);
+      if (rlit != sh_.func_def_line.end()) sh_.cur_lineno = rlit->second;
       auto rt = sh_.traps.find("RETURN");
       bool set_now = rt != sh_.traps.end() && !rt->second.empty();
       bool set_inside = set_now && (!had_return || rt->second != return_before);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -371,9 +371,17 @@ int Shell::run_return_trap(int status) {
   in_return_trap = true;
   int saved = last_status;
   last_status = status;  // $? inside the RETURN trap is the function's return status
+  // As for the DEBUG trap: the body runs without resetting the line counter, so
+  // $LINENO on its first line reports the line that triggered the trap rather
+  // than restarting at 1.
+  int saved_line = cur_lineno;
+  int saved_base = lineno_base;
+  lineno_base = cur_lineno - 1;
   std::string body = it->second;
   int st = run_string(body);
   last_status = saved;
+  cur_lineno = saved_line;
+  lineno_base = saved_base;
   in_return_trap = false;
   return st;
 }


### PR DESCRIPTION
**dbg-support.tests 59 -> 43.** First cut at the suite; two line-number defects around leaving a function body.

```
set -o functrace
trap 'echo "R: $LINENO ${FUNCNAME[0]:-main}"' RETURN
trap 'echo "D: $LINENO ${FUNCNAME[0]:-main}"' DEBUG
source ./s.sub          # defines sourced_fn on line 3, calls it
```

```
bash:  ... D: 3 sourced_fn / R: 3 sourced_fn
was:   ... D: 1 sourced_fn / R: 1 sourced_fn
```

- **The RETURN trap body restarted the line counter**, so `$LINENO` on its first line reported 1 instead of the line that triggered it. The DEBUG trap already handled this — bash runs neither with `SEVAL_RESETLINE` — so RETURN now saves and rebases the same way.
- **The traps fired at the end of a body reported whatever line the last command inside had set.** bash names the function's *definition* line again, the same one its entry DEBUG trap reports.

Both show up as `lineno: 1` for a function defined in a sourced file, which is what made this look like a sourcing bug. It is not: the same thing happens for a function defined inline, it is just less visible because the definition line is nearer.

## Note on my earlier characterisation

I had recorded this cluster as "`$LINENO` inside a sourced function reports 1", guessing at a frame whose line base is never set. That was wrong — the entry DEBUG trap always reported the right line; only the *exit* traps did not, and the RETURN body's own `$LINENO` was a separate bug on top. The minimal reproduction above is what separated them.

## Verification

The reproduction above, plus inline functions, nested calls and `functrace` off. ctest 22/22; run_diff all 240; full sweep shows `dbg-support: 59 -> 43` as the only change.

Still open in that suite: `source` does not fire DEBUG/RETURN traps of its own (bash treats a sourced file as a function frame — `D: 4 main` / `R: 4 main` in the reproduction), and an off-by-one on `source`'s recorded call line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
