### PR TITLE
fix(source): fire the RETURN trap when a sourced file finishes (dbg-support 43 -> 32)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -6552,6 +6552,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // resolved path (bash records the PATH-found path, not the bare name),
         // so ${BASH_SOURCE[0]} lets a script locate itself.  The call line is
         // where `source' appears in the current file.
+        int src_call_line = sh.cur_lineno;  // where `source' appears; see below
         sh.push_src_frame("source", path, sh.cur_lineno, false);
         // A sourced file has its own line numbering starting at 1 ($LINENO, the
         // DEBUG trap, and functions it defines all use the file's own lines).
@@ -6566,6 +6567,20 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // shell (bash semantics; e.g. /etc/bashrc does `[ -z "$PS1" ] && return').
         if (sh.returning) { sh.returning = false; st = sh.exit_status; }
         sh.pop_src_frame();
+        // A sourced file is a FUNCTION FRAME to bash: leaving it fires the
+        // DEBUG and RETURN traps, reporting the line `source' was called on --
+        // exactly as leaving a function body re-reports its definition line.
+        // The frame is already popped, so $FUNCNAME names the caller.
+        {
+          sh.cur_lineno = src_call_line;
+          // Only the RETURN trap is fired here: the DEBUG line that precedes it
+          // is the one its own body produces under functrace, exactly as when a
+          // function body returns.
+          auto srt = sh.traps.find("RETURN");
+          if (srt != sh.traps.end() && !srt->second.empty() && sh.opt_functrace &&
+              !sh.in_debug_trap)
+            sh.run_return_trap(st);
+        }
         // Restore the caller's parameters UNLESS the sourced script ran the
         // `set' builtin at top level -- then its parameters stick (bash).
         if (set_pos) {


### PR DESCRIPTION
**dbg-support.tests 43 -> 32.**

bash treats a sourced file as a **function frame**: leaving it runs the RETURN trap, reporting the line `source` was called on — just as leaving a function body re-reports its definition line. gnash ran the file and returned silently, so a script tracing its own control flow lost every `source` boundary.

```
set -o functrace
trap 'echo "R: $LINENO ${FUNCNAME[0]:-main}"' RETURN
trap 'echo "D: $LINENO ${FUNCNAME[0]:-main}"' DEBUG
source ./s.sub
```

```
bash:  ... R: 3 sourced_fn / D: 4 main / R: 4 main
was:   ... R: 3 sourced_fn            (nothing further)
```

Two details worth recording, because both looked like the opposite at first:

- **Only the RETURN trap is fired here.** My first cut also fired DEBUG explicitly, which produced a duplicate `D: 4 main` — bash's DEBUG line is the one the RETURN trap's *own body* emits under functrace. That is also why the function-exit case in #511 needed no explicit DEBUG.
- **The frame is popped first**, so `$FUNCNAME` inside the trap names the caller (`main`), which is what bash prints.

Verified with the reproduction above, and with functrace off (neither shell fires). ctest 22/22; run_diff all 240; full sweep shows `dbg-support: 43 -> 32` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
