### PR TITLE
fix(lexer): keep line numbers right across a spliced continuation (dbg-support 32 -> 20)

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -93,8 +93,14 @@ std::size_t comsub_span_end(const std::string &text, std::size_t open_pos);
 std::size_t comsub_span_end_aliased(const std::string &text, std::size_t open_pos,
                                     const std::map<std::string, std::string> &aliases);
 
+// CONT_LINES lists the line numbers of INPUT at which a `\'-newline line
+// continuation was spliced away before parsing.  Each one makes every later
+// line of the source one higher than the text shows, so token line numbers add
+// them back.  Without it a continued line inside a compound command shifts the
+// whole rest of the body (`$LINENO', the DEBUG trap, BASH_LINENO).
 std::vector<Token> tokenize(const std::string &input, bool posix_mode = false,
-                            const std::map<std::string, std::string> *span_aliases = nullptr);
+                            const std::map<std::string, std::string> *span_aliases = nullptr,
+                            const std::vector<int> *cont_lines = nullptr);
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -49,7 +49,10 @@ struct ParseResult {
 };
 
 // Parse a complete program.
-ParseResult parse(const std::string &input, bool posix_mode = false);
+// CONT_LINES: see tokenize() in lexer.hpp -- the lines whose `\'-newline
+// continuation was spliced away, so token lines can add them back.
+ParseResult parse(const std::string &input, bool posix_mode = false,
+                  const std::vector<int> *cont_lines = nullptr);
 
 // Parse with alias expansion applied first: regular aliases in command position,
 // zsh global aliases (`alias -g') anywhere, and zsh suffix aliases (`alias -s').
@@ -58,7 +61,8 @@ ParseResult parse_with_aliases(const std::string &input,
                                const std::map<std::string, std::string> &aliases,
                                const std::map<std::string, std::string> &global_aliases = {},
                                const std::map<std::string, std::string> &suffix_aliases = {},
-                               bool posix_mode = false);
+                               bool posix_mode = false,
+                               const std::vector<int> *cont_lines = nullptr);
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -555,7 +555,11 @@ class Shell {
   std::vector<std::string> environ_block() const;  // NAME=value for exported
 
   // Parse and execute a script; returns the final exit status.
-  int run_string(const std::string &script);
+  // CONT_LINES: see tokenize() in lexer.hpp.  Passed only by the line reader,
+  // which is the one caller that knows where continuations were spliced away;
+  // nested runs (traps, eval, source) parse their own text and must not
+  // inherit it.
+  int run_string(const std::string &script, const std::vector<int> *cont_lines = nullptr);
   // Whether run_string's OWN parse of its input failed (nested runs -- eval,
   // source, traps -- do not leak theirs).  A non-interactive line reader stops
   // reading its input when set, as bash does after a top-level syntax error.

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -87,6 +87,8 @@ struct Lexer {
   bool heredoc_eof_quoted = false;  // that here-doc's delimiter was quoted
   std::size_t line_scanned = 0;  // bytes already counted for line numbering
   int cur_line = 1;              // 1-based line at line_scanned
+  // Lines at which a spliced-away line continuation sat; see lexer.hpp.
+  const std::vector<int> *cont_lines = nullptr;
 
   // Line number of the byte at `start` (pos advances monotonically).
   int line_for(std::size_t start) {
@@ -94,7 +96,16 @@ struct Lexer {
       if (in[line_scanned] == '\n') cur_line++;
       line_scanned++;
     }
-    return cur_line;
+    if (!cont_lines) return cur_line;
+    // Every continuation that joined an EARLIER line pushed this one down by
+    // one physical line; a token on the joining line itself keeps that line,
+    // which is where bash reports the command as starting.
+    int extra = 0;
+    for (int c : *cont_lines) {
+      if (c >= cur_line) break;
+      extra++;
+    }
+    return cur_line + extra;
   }
 
   static bool is_assignment_prefix(const std::string &w) {
@@ -980,10 +991,12 @@ std::size_t comsub_span_end_aliased(const std::string &text, std::size_t open_po
 
 
 std::vector<Token> tokenize(const std::string &input, bool posix_mode,
-                            const std::map<std::string, std::string> *span_aliases) {
+                            const std::map<std::string, std::string> *span_aliases,
+                            const std::vector<int> *cont_lines) {
   Lexer lx(input);
   lx.posix = posix_mode;
   lx.span_aliases = span_aliases;
+  lx.cont_lines = cont_lines;
   lx.run();
   return std::move(lx.out);
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1549,7 +1549,7 @@ ParseResult parse_with_aliases(const std::string &input,
                                const std::map<std::string, std::string> &aliases,
                                const std::map<std::string, std::string> &global_aliases,
                                const std::map<std::string, std::string> &suffix_aliases,
-                               bool posix_mode);
+                               bool posix_mode, const std::vector<int> *cont_lines);
 
 struct AliasTables {
   const std::map<std::string, std::string> *aliases;
@@ -1606,8 +1606,9 @@ static bool validate_comsubs(const std::vector<Token> &toks, bool posix_mode,
   return true;
 }
 
-ParseResult parse(const std::string &input, bool posix_mode) {
-  Parser p(tokenize(input, posix_mode));
+ParseResult parse(const std::string &input, bool posix_mode,
+                  const std::vector<int> *cont_lines) {
+  Parser p(tokenize(input, posix_mode, nullptr, cont_lines));
   // Substitution content validates FIRST, as bash's recursive parser would:
   // its diagnosis wins over any knock-on error in the outer grammar.
   ParseResult pre;
@@ -1619,12 +1620,12 @@ ParseResult parse_with_aliases(const std::string &input,
                                const std::map<std::string, std::string> &aliases,
                                const std::map<std::string, std::string> &global_aliases,
                                const std::map<std::string, std::string> &suffix_aliases,
-                               bool posix_mode) {
+                               bool posix_mode, const std::vector<int> *cont_lines) {
   AliasExpansion ax =
       alias_splice_text(input, aliases, global_aliases, suffix_aliases, posix_mode);
   // The substitution scanner resolves `case'/`esac' through one alias level,
   // so a `$( switch x in y) ...;; esac )' span ends at the right `)'.
-  std::vector<Token> toks = tokenize(ax.text, posix_mode, &aliases);
+  std::vector<Token> toks = tokenize(ax.text, posix_mode, &aliases, cont_lines);
   if (ax.changed) {
     // Tokens report the line of the byte they start at: original bytes keep
     // their physical line, spliced bytes the invoking word's line.  The Eof

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2171,6 +2171,11 @@ int Shell::run_script_lines(const std::string &text) {
   int lineno = 0;        // 1-based physical line being read
   int pending_line = 1;  // first line of the accumulating command
   std::string pending;
+  // Lines of `pending' (1-based, in the SPLICED text) where a `\'-newline
+  // continuation was removed.  The text handed to the parser has to stay
+  // spliced -- the lexer, here-documents and substitution scanning all rely on
+  // it -- so the missing physical lines travel alongside instead.
+  std::vector<int> cont_lines;
   bool cont_bslash = false;  // previous line ended in a line continuation
   bool first_line_saved = false;  // this command's first line is in the history
   bool in_heredoc = false;   // the pending command has an open here-document
@@ -2183,6 +2188,7 @@ int Shell::run_script_lines(const std::string &text) {
     in_heredoc = false;
     if (pending.find_first_not_of(" \t\n") == std::string::npos) {
       pending.clear();
+      cont_lines.clear();
       return;
     }
     lineno_base = pending_line - 1;
@@ -2197,10 +2203,11 @@ int Shell::run_script_lines(const std::string &text) {
       while (tb < pending.size() && pending[pending.size() - 1 - tb] == '\\') tb++;
       if (pending.back() != '\n' && tb % 2 == 0) pending += '\n';
     }
-    st = run_string(pending);
+    st = run_string(pending, cont_lines.empty() ? nullptr : &cont_lines);
     lineno_base = 0;
     hist_cur_cmd_index = -1;
     pending.clear();
+    cont_lines.clear();
   };
 
   while (pos < text.size() && !exiting && !stdin_source_changed) {
@@ -2298,6 +2305,10 @@ int Shell::run_script_lines(const std::string &text) {
     if (nbs % 2 == 1 && line_had_newline && !squote_backslash_literal(pending) &&
         !ends_in_comment(pending) && !hd_quoted_now) {
       pending.pop_back();
+      // The join lands on this line of the spliced text; every later line of
+      // the source is one higher than the text will show.
+      cont_lines.push_back(
+          1 + static_cast<int>(std::count(pending.begin(), pending.end(), '\n')));
       cont_bslash = true;
       continue;
     }
@@ -2347,13 +2358,13 @@ bool Shell::aliases_active() const {
          (!aliases.empty() || !global_aliases.empty() || !suffix_aliases.empty());
 }
 
-int Shell::run_string(const std::string &script) {
+int Shell::run_string(const std::string &script, const std::vector<int> *cont_lines) {
   if (is_csh()) return run_csh(*this, script);  // csh is a different language
   had_parse_error = false;
   ParseResult r = aliases_active()
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases,
-                                           opt_posix)
-                      : parse(script, opt_posix);
+                                           opt_posix, cont_lines)
+                      : parse(script, opt_posix, cont_lines);
   if (!r.ok) {
     // bash's format: `NAME: [CONTEXT: ][-c: ]line N: syntax error...' per
     // message line; "near unexpected token" joins without a colon, and the


### PR DESCRIPTION
**dbg-support.tests 32 -> 20.**

A `\`-newline continuation inside a **compound** command shifted every line after it up by one:

```sh
f() {
  echo "a" \
      "b"
  echo "F=$LINENO"     # bash: 5   gnash: 4
}
```

Reproduces in a function body and in a `{ }` group, but not at top level — each top-level command gets its own `lineno_base`, while a compound command's whole body shares one. This is what made dbg-support report `source` on line 58 instead of 59: `fn3` has a continued `echo` two lines above it. Isolating `source` never reproduced it, because `source` was never the problem.

## Why the obvious fixes do not work

The reader splices a continuation by dropping the backslash and joining the two physical lines, so the parser's text is a line short. The tempting fix is to stop doing that — but **the text has to stay spliced**. I tried both spellings:

1. Keep the `\`+newline in `pending`.
2. Keep `pending` spliced for the completeness checks and execute from a parallel copy that preserves continuations.

Both produce *identical* regressions: comsub 0->5, quote 0->12, posixexp2 0->9, heredoc 17->25. The second rules out the completeness logic — it is `run_string` itself, the lexer, here-document handling and substitution scanning, that requires the spliced form.

## What this does instead

Carry the missing lines *alongside* the text. The reader records which lines of the spliced text a continuation was removed from; `Lexer::line_for` adds back the count of continuations that joined an earlier line. A token on the joining line keeps that line, which is where bash reports the command as starting.

Only the line reader passes the map. A nested run — a trap body, `eval`, a sourced file — parses its own text and must not inherit it, so it is a parameter rather than shell state.

## Verification

The five line-number reproductions (top level, group, function, and the two shapes from the suite), and specifically the four suites both earlier attempts broke — all still at baseline. ctest 22/22; run_diff all 240; full sweep shows `dbg-support: 32 -> 20` as the only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
