### PR TITLE
fix(source): apply bash's trap-inheritance rules to sourced files

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -292,6 +292,9 @@ class Shell {
   int run_debug_trap(const std::string &cmd_text);
   void run_err_trap(int status);              // run the ERR trap after a failure
   int run_return_trap(int status);            // run the RETURN trap on func/source return
+  // Does the RETURN trap fire as the innermost frame -- a function body or a
+  // sourced file -- finishes?  See the definition for bash's rule.
+  bool return_trap_fires() const;
 
   // --- job control -------------------------------------------------------
   struct Job {
@@ -500,6 +503,8 @@ class Shell {
   // DEBUG trap the function installs for itself (the body differs from entry)
   // fires without functrace; an inherited one does not.
   std::vector<std::string> debug_frame;
+  // The same, for the RETURN trap; see return_trap_fires().
+  std::vector<std::string> return_frame;
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV
   // Call-argument stack for $BASH_ARGC/$BASH_ARGV (only maintained under

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -6558,6 +6558,22 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // DEBUG trap, and functions it defines all use the file's own lines).
         int saved_src_base = sh.lineno_base;
         sh.lineno_base = 0;
+        // A sourced file does not inherit the DEBUG trap unless functrace is
+        // set (source.def restores the default for the duration).  bash lifts
+        // the suppression in an unwind frame that runs AFTER `source_file',
+        // and `source_file' is what fires the RETURN trap -- so the RETURN
+        // trap's own body produces no DEBUG line either.  Hence the window
+        // below closes past the RETURN trap, not at the end of the file.
+        std::string hidden_debug;
+        bool hid_debug = false;
+        if (!sh.opt_functrace) {
+          auto dit = sh.traps.find("DEBUG");
+          if (dit != sh.traps.end()) {
+            hidden_debug = dit->second;
+            hid_debug = true;
+            sh.traps.erase(dit);
+          }
+        }
         sh.source_depth++;  // `return' is legal while sourcing
         st = sh.run_string(ss.str());
         sh.source_depth--;
@@ -6576,11 +6592,17 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
           // Only the RETURN trap is fired here: the DEBUG line that precedes it
           // is the one its own body produces under functrace, exactly as when a
           // function body returns.
-          auto srt = sh.traps.find("RETURN");
-          if (srt != sh.traps.end() && !srt->second.empty() && sh.opt_functrace &&
-              !sh.in_debug_trap)
-            sh.run_return_trap(st);
+          //
+          // Unlike a function, a sourced file does NOT gate this on functrace:
+          // `source_file' runs the trap unconditionally, so a `source' at top
+          // level fires it either way.  Inside a function it follows the
+          // function's own rule, because that is where bash restored the
+          // default trap.  See Shell::return_trap_fires().
+          if (sh.return_trap_fires()) sh.run_return_trap(st);
         }
+        // Restore the DEBUG trap -- but only if the sourced file did not set
+        // one of its own, which is what bash's trap_if_untrapped() amounts to.
+        if (hid_debug && !sh.traps.count("DEBUG")) sh.traps["DEBUG"] = hidden_debug;
         // Restore the caller's parameters UNLESS the sourced script ran the
         // `set' builtin at top level -- then its parameters stick (bash).
         if (set_pos) {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1559,6 +1559,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
     sh_.push_scope();
     sh_.debug_frame.push_back(sh_.traps.count("DEBUG") ? sh_.traps["DEBUG"] : std::string());
+    sh_.return_frame.push_back(sh_.traps.count("RETURN") ? sh_.traps["RETURN"] : std::string());
     sh_.persona_restore.push_back(std::nullopt);  // for `personality -L' / `emulate -L'
     // Run the body under the lineno_base captured at definition time so $LINENO
     // reports absolute source lines regardless of the caller's input block.
@@ -1578,31 +1579,20 @@ int Executor::run_simple(const SimpleCommand *c) {
                                                        : sh_.lineno_base + 1;
       sh_.run_debug_trap(to_string(fit->second));
     }
-    // Snapshot the RETURN trap so we can tell one the function installs for
-    // itself from an inherited one (only inherited under functrace).
-    auto rtit = sh_.traps.find("RETURN");
-    bool had_return = rtit != sh_.traps.end();
-    std::string return_before = had_return ? rtit->second : std::string();
     status = unwinding() ? sh_.last_status : run(fit->second);
     // Deliver a signal caught during the body while the function scope is still
     // active, so its trap runs in-context (bash): a `return' in the trap then
     // returns from THIS function rather than erroring at the outer level.
     if (!unwinding()) sh_.run_pending_traps();
     // The RETURN trap fires when the function returns, in its own scope, with $?
-    // set to the return status.  It runs when inherited (functrace) or installed
-    // inside the function.  A function invoked while the DEBUG trap is running
-    // (e.g. the DEBUG-trap handler itself) does not inherit the RETURN trap --
-    // bash restores its default at entry when signal_in_progress(DEBUG_TRAP).
+    // set to the return status; return_trap_fires() holds bash's rule for when.
     {
       // Leaving the body, bash reports the function's DEFINITION line again --
       // the same line its entry DEBUG trap named -- rather than whatever the
       // last command inside happened to set.
       auto rlit = sh_.func_def_line.find(argv[0]);
       if (rlit != sh_.func_def_line.end()) sh_.cur_lineno = rlit->second;
-      auto rt = sh_.traps.find("RETURN");
-      bool set_now = rt != sh_.traps.end() && !rt->second.empty();
-      bool set_inside = set_now && (!had_return || rt->second != return_before);
-      if (set_now && (sh_.opt_functrace || set_inside) && !sh_.in_debug_trap) {
+      if (sh_.return_trap_fires()) {
         int ret_status = sh_.returning ? sh_.exit_status : status;
         bool save_ret = sh_.returning;
         int save_es = sh_.exit_status;
@@ -1620,6 +1610,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     }
     sh_.pop_scope();
     sh_.debug_frame.pop_back();
+    sh_.return_frame.pop_back();
     if (pushed_argframe && !sh_.argframes.empty()) sh_.argframes.pop_back();
     sh_.pop_src_frame();
     sh_.call_stack.pop_back();

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -365,6 +365,23 @@ void Shell::run_err_trap(int status) {
   in_err_trap = false;
 }
 
+// Does the RETURN trap fire as the innermost frame -- a function body or a
+// sourced file -- finishes?
+//
+// bash restores the DEFAULT RETURN trap on entry to a function unless functrace
+// is set (execute_cmd.c), so a trap INHERITED from outside does not fire inside
+// one, while a trap the function installs for itself does.  A sourced file gets
+// no such treatment -- `source' does it for the DEBUG trap only, and source.def
+// says as much ("XXX - should sourced files inherit the RETURN trap?  Functions
+// don't.") -- so `source_file' runs the trap unconditionally.  At top level,
+// then, a sourced file fires it whether or not functrace is on.
+bool Shell::return_trap_fires() const {
+  auto it = traps.find("RETURN");
+  if (it == traps.end() || it->second.empty() || in_debug_trap) return false;
+  if (opt_functrace || return_frame.empty()) return true;
+  return it->second != return_frame.back();  // installed inside this function
+}
+
 int Shell::run_return_trap(int status) {
   auto it = traps.find("RETURN");
   if (it == traps.end() || it->second.empty() || in_return_trap) return 0;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -329,6 +329,14 @@ source /tmp/gnrx3.$$; rm -f /tmp/gnrx3.$$'
   # a here-document delimited by end-of-file still runs (with a warning)
   'cat <<XEOF 2>/dev/null
 line1'
+  # A sourced file fires the RETURN trap even without functrace, but does not
+  # inherit the DEBUG trap unless functrace is on.  The last case: a trap the
+  # function installs for ITSELF fires for a `source' in its body, twice --
+  # once leaving the sourced file, once leaving the function.
+  'd=$(mktemp -d); printf "echo in-sub\n" >"$d/s"; trap "echo RET" RETURN; source "$d/s"; echo after; rm -rf "$d"'
+  'd=$(mktemp -d); printf "echo one\necho two\n" >"$d/s"; trap "echo DBG" DEBUG; source "$d/s"; trap - DEBUG; rm -rf "$d"'
+  'd=$(mktemp -d); printf "echo one\n" >"$d/s"; set -T; trap "echo DBG" DEBUG; source "$d/s"; trap - DEBUG; set +T; rm -rf "$d"'
+  'd=$(mktemp -d); printf "echo in-sub\n" >"$d/s"; f() { trap "echo RET" RETURN; source "$d/s"; }; f; echo after; rm -rf "$d"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #516.

## Root cause

One block in bash's `builtins/source.def` decides both halves, and gnash
had neither:

```c
  /* Don't inherit the DEBUG trap unless function_trace_mode (overloaded)
     is set.  XXX - should sourced files inherit the RETURN trap?  Functions
     don't. */
  debug_trap = TRAP_STRING (DEBUG_TRAP);
  if (debug_trap && function_trace_mode == 0)
    {
      add_unwind_protect (uw_maybe_set_debug_trap, debug_trap);
      restore_default_signal (DEBUG_TRAP);
    }

  result = source_file (filename, (list && list->next));   /* fires RETURN */

  run_unwind_frame ("source");
```

- DEBUG is suppressed for the duration unless functrace. gnash suppressed it
  for functions but not for sourced files, so a sourced file's own commands
  were traced.
- `source_file()` ends with a bare `run_return_trap()` — no functrace test —
  so a `source` at top level fires RETURN either way. gnash gated it on
  `opt_functrace` (my own gate, from #512, copied from the function rule).

**They are one window, not two.** `run_return_trap()` is called *inside*
`source_file`, which runs *before* `run_unwind_frame ("source")` lifts the
DEBUG suppression — so the RETURN trap's own body produces no DEBUG line
either. Ungating RETURN on its own does not reduce the diff at all: it trades
the missing `return lineno: 98 main` for a spurious `debug lineno: 98 main`
in the same place. That is why this PR covers both.

The restore is `trap_if_untrapped()`, so a DEBUG trap the sourced file sets
for itself survives rather than being clobbered.

## The function case

Inside a function the RETURN trap follows the function's rule instead,
because that is where bash restored the default. A consequence gnash also got
wrong: a trap the function installs for *itself* fires for a `source` in its
body even without functrace.

```sh
f() {
  trap 'echo RETURN line=$LINENO' RETURN
  source ./sub
}
f
```

bash prints `RETURN line=3` then `RETURN line=1`; gnash 1.9.3 printed only
the second. A naive `!in_function()` gate would still have missed this.

So the rule now lives in one place — `Shell::return_trap_fires()` — shared by
the function and source paths rather than restated at each. It reads the
RETURN trap as it stood on entry to the innermost function, mirroring the
existing `debug_frame` stack; `run_function`'s open-coded version is
replaced by a call to it (equivalent by inspection: its `!had_return` case
and the empty-string entry snapshot agree).

## Verification

- `dbg-support.tests` **8 -> 4**. Only the command-substitution cluster is
  left; the whole file is down 59 -> 4 over five PRs.
- Full 83-suite sweep: no other suite changes, 62 byte-perfect.
- `ctest --test-dir build` 22/22.
- `run_diff.sh` 244/244, including **4 new cases** covering: RETURN fires for
  a top-level `source` without functrace; DEBUG is not inherited into a
  sourced file; DEBUG *is* inherited under `set -T` (the control, which
  already passed and pins the functrace path against an over-correction); and
  the function-installs-its-own-RETURN case above. Three of the four fail
  against released gnash 1.9.3.