### PR TITLE
fix(trap): don't inherit DEBUG/RETURN traps into a child process

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -284,6 +284,9 @@ class Shell {
   void end_interruptible_wait();
   int pending_trapped_signal();               // a pending signal that has a trap, or 0
   void note_child_reaped();                   // count a reaped child for the SIGCHLD trap
+  // Drop the traps a child process does not inherit; call in every forked
+  // child (subshell, pipeline stage, background job, coproc, comsub).
+  void drop_child_traps();
   int pending_sigchld = 0;                     // children reaped, awaiting the CHLD trap
   // Run the DEBUG trap (if set) before a command, with $BASH_COMMAND set to
   // CMD_TEXT.  Only fires inside functions when functrace (-T) is enabled.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -969,6 +969,10 @@ int Executor::run_connection(const Connection *c) {
         sh_.job_control = false;  // background: descendants must not touch the tty
         sh_.subshell_level++;
         sh_.traps.erase("CHLD");  // the parent fires CHLD when it reaps this job
+        // Only ERR here, not drop_child_traps(): gnash fires a background job's
+        // own DEBUG trap in the CHILD, where bash fires it in the parent before
+        // forking.  Dropping DEBUG here would lose that trap altogether rather
+        // than merely stop it being inherited.
         if (!sh_.opt_functrace) sh_.traps.erase("ERR");  // not inherited without -E
         sh_.pending_sigchld = 0;
         Executor ex(sh_);
@@ -1045,6 +1049,8 @@ int Executor::run_pipeline(const Connection *c) {
       // A pipeline stage is a subshell: without errtrace it does not inherit the
       // ERR trap (the whole pipeline fires it once in the parent instead), and
       // it never inherits the parent's EXIT trap -- only one it sets itself runs.
+      // Not drop_child_traps(): as for a background job, gnash fires a stage's
+      // own DEBUG trap in the child, so dropping DEBUG here would lose it.
       if (!sh_.opt_functrace) sh_.traps.erase("ERR");
       sh_.traps.erase("EXIT");
       sh_.traps.erase("CHLD");  // the parent fires CHLD for the stage as a whole
@@ -1959,7 +1965,7 @@ int Executor::run_subshell(const Subshell *c) {
     // itself runs when it exits.
     sh_.traps.erase("EXIT");
     sh_.traps.erase("CHLD");  // the parent fires CHLD for the subshell as a whole
-    if (!sh_.opt_functrace) sh_.traps.erase("ERR");  // not inherited without -E
+    sh_.drop_child_traps();
     sh_.pending_sigchld = 0;
     // (external): a lone simple command can exec in place, no second fork.
     if (dynamic_cast<const SimpleCommand *>(c->body.get())) sh_.can_exec_replace = true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -403,6 +403,27 @@ int Shell::run_return_trap(int status) {
   return st;
 }
 
+// The traps a child process does not inherit.  bash does this in ONE place --
+// trap.c's reset_or_restore_signal_handlers(), reached whenever it builds a
+// "subshell environment" -- with the comment:
+//
+//   Command substitution and other child processes don't inherit the debug,
+//   error, or return traps.  If we're in the debugger, and the `functrace' or
+//   `errtrace' options have been set, then let command substitutions inherit
+//   them.
+//
+// So without functrace a command substitution runs none of the DEBUG traps its
+// body would otherwise fire, and -- because a comsub's stdout is the capture
+// pipe -- their output would otherwise land in the substituted VALUE rather
+// than on the terminal.
+void Shell::drop_child_traps() {
+  if (!opt_functrace) {
+    traps.erase("DEBUG");
+    traps.erase("RETURN");
+    traps.erase("ERR");  // bash gates this on errtrace (-E); gnash folds -E into -T
+  }
+}
+
 void Shell::note_child_reaped() {
   // bash runs the SIGCHLD trap once for each terminated child; only count while
   // such a trap is installed.
@@ -2646,7 +2667,7 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
     no_current_job = true;  // bash resets the current job in the subshell
     subshell_level++;  // $BASH_SUBSHELL
     traps.erase("CHLD");  // the parent fires CHLD for the substitution as a whole
-    if (!opt_functrace) traps.erase("ERR");  // ERR is not inherited without -E
+    drop_child_traps();
     pending_sigchld = 0;
     subshell_leaf = true;  // a lone external here can exec in place (no 2nd fork)
     // Command substitution unsets errexit in the subshell unless the caller has

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -337,6 +337,20 @@ line1'
   'd=$(mktemp -d); printf "echo one\necho two\n" >"$d/s"; trap "echo DBG" DEBUG; source "$d/s"; trap - DEBUG; rm -rf "$d"'
   'd=$(mktemp -d); printf "echo one\n" >"$d/s"; set -T; trap "echo DBG" DEBUG; source "$d/s"; trap - DEBUG; set +T; rm -rf "$d"'
   'd=$(mktemp -d); printf "echo in-sub\n" >"$d/s"; f() { trap "echo RET" RETURN; source "$d/s"; }; f; echo after; rm -rf "$d"'
+  # A child process does not inherit the DEBUG/RETURN traps without functrace.
+  # For a command substitution that is visible in the VALUE: the trap would
+  # write into the capture pipe, so `x=$(echo hi)' would come back as "DBG hi".
+  'trap "echo DBG" DEBUG; x=$(echo hi; echo there); echo "x=[$x]"'
+  'trap "echo DBG" DEBUG; x=`echo hi`; echo "x=[$x]"'
+  'f(){ echo F; }; trap "echo DBG" DEBUG; x=$(f); echo "x=[$x]"'
+  'set -T; f(){ echo F; }; trap "echo DBG" DEBUG; x=$(f); echo "x=[$x]"'
+  'trap "echo RET" RETURN; f(){ echo F; }; x=$(f); echo "x=[$x]"'
+  'trap "echo DBG" DEBUG; (echo sub); echo after'
+  'set -T; trap "echo DBG" DEBUG; (echo sub); echo after'
+  # ...but a pipeline stage and a background job still report their own DEBUG
+  # trap, which gnash fires in the child rather than the parent.
+  'trap "echo DBG" DEBUG; echo a | cat'
+  'trap "echo DBG" DEBUG; echo a & wait'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #518. **`dbg-support.tests` reaches 0 — 63 of 83 suites byte-perfect.**

## Root cause

A command substitution ran the DEBUG traps its body triggered, and since a
comsub's stdout *is* the capture pipe, the trap output landed in the
substituted **value**:

```sh
trap "echo DBG" DEBUG
x=$(echo hi; echo there)     # x was "DBG hi DBG there"
```

A plain `( )` subshell had the same inheritance, visible as an extra trap line
rather than a corrupted value.

bash clears these in one place — `trap.c`, `reset_or_restore_signal_handlers()`,
reached whenever it builds a subshell environment:

```c
  /* Command substitution and other child processes don't inherit the
     debug, error, or return traps.  If we're in the debugger, and the
     `functrace' or `errtrace' options have been set, then let command
     substitutions inherit them. */
  if (function_trace_mode == 0)
    {
      sigmodes[DEBUG_TRAP] &= ~SIG_TRAPPED;
      sigmodes[RETURN_TRAP] &= ~SIG_TRAPPED;
    }
```

gnash already dropped `ERR` in its forked children; `DEBUG` and `RETURN` now go
with it, via `Shell::drop_child_traps()` so the rule has one home. Under
functrace they are still inherited — gnash already matched there, including
`x=$(f)` firing three traps (the command, the function body, the body's `echo`).

## Two sites deliberately excluded

Pipeline stages and background jobs keep the ERR-only behaviour. gnash fires
*their* own DEBUG trap in the **child**, where bash fires it in the **parent**
before forking — so dropping DEBUG there loses the trap altogether rather than
merely un-inheriting it. Applying the helper to all five fork sites cost both
lines of `echo a | cat` and one of `echo a & wait`; those cases are now pinned
in `run_diff.sh` so a future tidy-up cannot silently break them. The underlying
wrong-side firing is noted in the code and in #518 as follow-up.

## Verification

- **`dbg-support.tests` 4 -> 0**, and 8 -> 0 counting #517. Full sweep: that is
  the *only* changed suite; **63 of 83 byte-perfect**, 2050 -> 2046 total lines.
- `ctest --test-dir build` 22/22.
- `run_diff.sh` 253/253, with 9 new cases: comsub with two commands, backquote
  form, function call, the `set -T` control, RETURN in a comsub, `( )` with and
  without functrace, plus the pipeline and background cases above.