### PR TITLE
fix(arith): report an invalid operator as bash does

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -69,6 +69,21 @@ constexpr const char *kRecursion = "expression recursion level exceeded";
 constexpr const char *kBadOp = "arithmetic syntax error: invalid arithmetic operator";
 }  // namespace arith_err
 
+// The characters bash's is_arithop() accepts as operator tokens -- the
+// single-character operators, plus `?', `:' and `,' (which its own comment
+// calls "questionable").  Multi-character operators all begin with one of
+// these, so testing the first character is enough.
+bool arith_op_char(char c) {
+  return c != '\0' && std::strchr("=><+-*/%!()&|^~?:,", c) != nullptr;
+}
+
+// What bash's readtok() will consume as an operand: a digit (NUM) or a
+// variable starter (STR).  Anything else falls through to its operator
+// classification.
+bool arith_operand_start(char c) {
+  unsigned char u = static_cast<unsigned char>(c);
+  return std::isalnum(u) || c == '_';
+}
 
 NodeP mk(K k) { auto n = std::make_unique<Node>(); n->k = k; return n; }
 
@@ -578,8 +593,15 @@ Parsed parse_cached(const std::string &expr) {
              std::strchr("+-*/%&^|", expr[q]) && expr.compare(q, 2, "&&") != 0 &&
              expr.compare(q, 2, "||") != 0)
       p.note(arith_err::kNonVar, q);  // +=, -=, ...: assign to non-lvalue
-    else if (expr[q] == ']')
-      p.note(arith_err::kBadOp, q);  // a stray `]': bash's invalid-operator error
+    // bash's readtok() splits the leftover into two diagnostics.  A character
+    // that could begin an OPERAND (a digit, or a variable starter) is read as a
+    // token, and it is the grammar that then rejects it -- "syntax error in
+    // expression".  A character that is neither an operand starter nor one of
+    // the operator characters is rejected by the tokenizer itself, and since
+    // what precedes it here is a complete expression (so bash's `curtok' is an
+    // operand rather than an operator), that is "invalid arithmetic operator".
+    else if (!arith_operand_start(expr[q]) && !arith_op_char(expr[q]))
+      p.note(arith_err::kBadOp, q);
     else
       p.note(arith_err::kExpr, q);
   }

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -351,6 +351,17 @@ line1'
   # trap, which gnash fires in the child rather than the parent.
   'trap "echo DBG" DEBUG; echo a | cat'
   'trap "echo DBG" DEBUG; echo a & wait'
+  # Arithmetic: a character that cannot begin an operand and is not an operator
+  # is the tokenizer'"'"'s "invalid arithmetic operator"; one that can begin an
+  # operand is read as a token and rejected by the grammar instead.
+  'echo $(( x@y )) 2>&1'
+  'echo $(( 1 @ 2 )) 2>&1'
+  'echo $(( 1 ] )) 2>&1'
+  'echo $(( x y )) 2>&1'
+  'echo $(( 1 2 3 )) 2>&1'
+  'echo $(( x!!y )) 2>&1'
+  'echo $(( 1+ )) 2>&1'
+  'echo $(( x= )) 2>&1'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #520.

## Root cause

`$(( x@y ))` reported the generic "syntax error in expression" where bash
reports "invalid arithmetic operator". bash splits the two in `readtok()`:

```c
      else if (is_arithop (c) == 0)
	{
	  cp--;
	  if (curtok == 0 || is_arithop (curtok) || is_multiop (curtok))
	    evalerror (_("arithmetic syntax error: operand expected"));
	  else
	    evalerror (_("arithmetic syntax error: invalid arithmetic operator"));
	}
```

A character that can begin an **operand** (digit or variable starter) is read
as a token and rejected by the *grammar* — so `$(( x y ))`, `$(( 1 2 ))` and
`$(( x!!y ))` keep the generic message. A character outside `is_arithop()`'s
set (`= > < + - * / % ! ( ) & | ^ ~ ? : ,`) is rejected by the *tokenizer*,
and since what precedes it here is a complete expression — bash's `curtok` is
an operand, not an operator — that is the invalid-operator error.

gnash already had the message but used it only for a hard-coded stray `]`,
which the general rule subsumes.

## Verification

14 expressions compared against bash covering both classes and the
`operand expected` path; 12 now match, and the 2 that do not are unrelated
pre-existing issues (`$(( 1 #2 ))` comment handling and a backquote line
number), unchanged by this PR.

- `ctest --test-dir build` 22/22.
- `run_diff.sh` 261/261, with 8 new cases pinning both classes.
- Full 83-suite sweep: **no suite changed**, 63 byte-perfect, 2046 total lines.

## This does not move the scoreboard, deliberately

`exp.tests` still differs on its one arithmetic line for a separate reason. In
the compound array assignment `array=( [$'x\001y\177z']=foo )`, bash loses the
`\001` from the subscript before evaluating it — it collides with bash's
internal CTLESC marker — so bash reports the expression as `xy^?z` with error
token `^?z` while gnash reports `x^Ay^?z` / `^Ay^?z`. The message class was
only one of the three differences on that line. Filed as part of #520's notes;
worth doing separately, since it is bug-compatibility with a bash internal
representation rather than a rule.