### PR TITLE
fix(lineno): attribute a diagnostic to the line bash names

### DIFF
--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -33,6 +33,12 @@ struct ParseResult {
   bool ok = true;
   std::string error;    // set when ok == false (may be multiple lines)
   int error_line = 0;   // 1-based source line of the failure
+  // The last source line this parse consumed.  bash leaves `line_number' here
+  // when it hands a command to the executor, and compound commands that do not
+  // install a line of their own (`while', `if', `case', `{ }', a function
+  // definition) report diagnostics against it -- so a redirection error on a
+  // multi-line `while ... done > f' names the `done' line, not the `while'.
+  int end_line = 0;
   bool incomplete = false;  // input ended mid-construct (needs more lines)
   bool assign_error = false;  // a compound-assignment syntax error (`a=(x & y)'): $?=1, not 2
   // A here-document body was delimited by end of input: ok stays true and the

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -860,8 +860,30 @@ int Executor::run(const Command *c) {
 
   sh_.run_pending_traps();  // deliver any signals received between commands
 
-  // $LINENO / error line for compound commands (run_simple sets its own).
-  if (c->line > 0 && !dynamic_cast<const SimpleCommand *>(c))
+  // $LINENO / error line.  bash installs a command's line for only a FEW
+  // command types -- SET_LINE_NUMBER() appears in execute_cmd.c for the simple
+  // command (run_simple sets its own, below), the subshell, `(( ))' and
+  // `[[ ]]', and `for'/`select' set it directly.  `while', `until', `if',
+  // `case', a `{ }' group and a function definition deliberately do NOT: they
+  // leave line_number wherever it already was, which is why a diagnostic from
+  // inside e.g. `(...)' reports the subshell's closing line rather than the
+  // line of the command that produced it.  Matching that set matters --
+  // updating it for every compound made redirection errors inside a subshell
+  // report the wrong line all through redir12.sub.
+  // ...and it is SCOPED: bash saves line_number, installs the command's, and
+  // restores it when the command finishes (the "simple_lineno" unwind frame).
+  // So the line in force is always the innermost enclosing construct that set
+  // one, not whatever the last command to run happened to leave behind.
+  struct LineGuard {
+    Shell &sh; int saved;
+    explicit LineGuard(Shell &s) : sh(s), saved(s.cur_lineno) {}
+    ~LineGuard() { sh.cur_lineno = saved; }
+  } lg(sh_);
+  // A subshell installs its line BEFORE its redirections, which bash applies in
+  // the forked child; the others install theirs only once redirections have
+  // succeeded, so a redirection error on `for ... done > f' inside a subshell
+  // still reports the subshell's line rather than the `for'.
+  if (c->line > 0 && dynamic_cast<const Subshell *>(c))
     sh_.cur_lineno = sh_.lineno_base + c->line;
 
   // A negated command (`! cmd') never triggers errexit, and neither do the
@@ -893,6 +915,10 @@ int Executor::run(const Command *c) {
     }
     return sh_.last_status;
   }
+  if (c->line > 0 && (dynamic_cast<const ArithCommand *>(c) ||
+                      dynamic_cast<const CondCommand *>(c) ||
+                      dynamic_cast<const ForCommand *>(c)))
+    sh_.cur_lineno = sh_.lineno_base + c->line;
   int st = sh_.last_status;
   if (auto *pa = dynamic_cast<const Subshell *>(c)) st = run_subshell(pa);
   else if (auto *pb = dynamic_cast<const Group *>(c)) st = run_group(pb);

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -614,6 +614,13 @@ struct Parser {
     expect(Tok::Lparen, "(");
     auto s = std::make_unique<Subshell>();
     s->body = parse_list({});
+    // bash's make_subshell_command() records `line_number' as it reduces
+    // `( compound_list )', so a subshell's line is the line of its CLOSING
+    // paren, not its opening one.  It is the only compound command whose line
+    // the executor installs, so this is what a diagnostic from anywhere inside
+    // the subshell reports.
+    s->line = i > 0 ? toks[i - 1].line : cur().line;
+    if (is(Tok::Rparen)) s->line = cur().line;
     expect(Tok::Rparen, ")");
     pop_open();
     parse_redirect_list(s->redirects);
@@ -1218,6 +1225,11 @@ struct Parser {
     newline_list();
     if (is(Tok::Eof)) return res;
     res.command = parse_list({});
+    // Where the parse ended: bash leaves `line_number' on the last line it
+    // consumed, and that is what a compound command which installs no line of
+    // its own reports.  Take it before newline_list() eats the trailing
+    // newlines, so a command ending at `done' names the `done' line.
+    res.end_line = i > 0 ? toks[i - 1].line : 0;
     newline_list();
     if (!err && !is(Tok::Eof))
       fail(is(Tok::Eof) ? std::string("unexpected end of file")

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2512,6 +2512,9 @@ int Shell::run_string(const std::string &script, const std::vector<int> *cont_li
     cur_lineno = save_ln;
   }
   if (!r.command) { subshell_leaf = false; return last_status; }
+  // The line the parser stopped on is the one in force for anything that does
+  // not install its own -- see ParseResult::end_line.
+  if (r.end_line > 0) cur_lineno = lineno_base + r.end_line;
   const Command *c = r.command.get();
   retained.push_back(std::move(r.command));
   // A disposable subshell child (command substitution) whose whole body is a

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -362,6 +362,34 @@ line1'
   'echo $(( x!!y )) 2>&1'
   'echo $(( 1+ )) 2>&1'
   'echo $(( x= )) 2>&1'
+  # The line a diagnostic reports.  A command that installs no line of its own
+  # -- `while'"'"', `if'"'"', a function definition -- is reported against the line the
+  # PARSER stopped on, so a redirection error on a multi-line `while ... done > f'"'"'
+  # names the `done'"'"'.  Inside a subshell that line is the subshell'"'"'s closing
+  # paren, which is why the `for'"'"' and the posix funcdef below both report it
+  # rather than their own line.  (These pipe stderr through sed because the
+  # harness compares stdout only, and the two shells name themselves.)
+  '{ d=$(mktemp -d); cd "$d"; touch nw; chmod a-w nw; while [ -z x ]; do
+ y=4
+done > nw
+cd /; rm -rf "$d"; } 2>&1 | sed "s/^[^ ]*: //"'
+  '{ d=$(mktemp -d); cd "$d"; touch nw; chmod a-w nw; (set -e
+for f in 1 2; do y=4; done > nw
+echo after: $?)
+cd /; rm -rf "$d"; } 2>&1 | sed "s/^[^ ]*: //"'
+  '{ set -o posix; ( break()
+{
+ :
+}
+); } 2>&1 | sed "s/^[^ ]*: //"'
+  '{ if true; then
+ y=1
+fi > /nonexistent-dir-xyz/f; } 2>&1 | sed "s/^[^ ]*: //"'
+  # $LINENO itself is unaffected: each simple command still reports its own line.
+  '( echo "L=$LINENO"
+echo "L=$LINENO"
+)
+echo "L=$LINENO"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #522. **`redir.tests` 19 -> 3, `func.tests` 2 -> 0 — 64 of 83 byte-perfect.**

## Root cause

gnash installed a command's line for *every* compound command and never restored
it, so a diagnostic bash does not attribute to a line of its own reported
whichever command last ran.

Three rules from `execute_cmd.c`, none of which gnash had:

1. **Only a few types install a line.** `SET_LINE_NUMBER()` appears for the
   simple command, the subshell, `(( ))` and `[[ ]]`; `for`/`select` set it
   directly. `while`, `until`, `if`, `case`, `{ }` and a function definition
   deliberately do not.
2. **It is scoped, not sticky:**
   ```c
	save_line_number = line_number;
	SET_LINE_NUMBER (command->value.Simple->line);
	exec_result = execute_simple_command (...);
	line_number = save_line_number;
   ```
   The line in force is always the innermost enclosing construct that set one.
3. **The ambient comes from the parser** — whatever it last consumed. That is
   why a multi-line `while ... done > f` names the `done`, and it is the half
   that makes category 1 work at all; `ParseResult` now carries it.

## The ordering detail

A subshell's line is its **closing** paren (`make_subshell_command()` records
`line_number` as it reduces `( compound_list )`), and it is installed *before*
its redirections — which bash applies in the forked child — while
`for`/`[[ ]]`/`(( ))` install theirs only *after* redirections succeed. That is
what makes a redirection error on `for ... done > f` inside a subshell report
the subshell's closing line rather than the `for`, and it accounts for the last
two redir12.sub lines.

## Verification

- `redir.tests` **19 -> 3** — all eight line-number lines gone; the remaining
  three are genuine fd bugs (`Bad file descriptor`, `redir11 bad 3/4`).
- `func.tests` **2 -> 0**.
- Full 83-suite sweep: those two are the **only** changes. 63 -> **64**
  byte-perfect, 2046 -> 2028 total differing lines.
- `ctest` 22/22; `run_diff.sh` 266/266 with 5 new cases — the multi-line
  `while`, the `for` inside a subshell, a posix funcdef in a subshell, a
  multi-line `if`, and a `$LINENO` case pinning that per-command reporting is
  unchanged.

## Not covered

`errors.tests` still reports 60 where bash says 59 for a `select` inside a
function body: bash builds `for`/`select` with `word_lineno[word_top]`, the
line the enclosing word context began on, which is a separate mechanism from
the three above. Left for its own change.