### PR TITLE
fix(lexer): name the line an unterminated span opened on

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -58,6 +58,7 @@ struct Token {
   bool glued = false;           // Lparen immediately followed by `(' (for `((')
   bool lex_error = false;       // set on the Eof token if a span was unterminated
   char lex_close = 0;           // the closer we were scanning for at EOF
+  int lex_open_line = 0;        // where that span opened; 0 = report the EOF line
   // Set on the Eof token when a here-document ran to end-of-input without its
   // delimiter: the body is still attached (bash runs it with a warning), but
   // line-oriented readers treat the input as incomplete.

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -81,6 +81,12 @@ struct Lexer {
   int awaiting = -1;  // -1 none, 0 <<, 1 <<-
   bool unterminated = false;
   char unterm_close = 0;  // the closer we were looking for at EOF
+  // The line the unterminated span STARTED on.  bash's parse_matched_pair
+  // reports `start_lineno' for a quote, a backquote and `${', so an
+  // unterminated one names where it opened rather than where input ran out.
+  // Left 0 for `$(' -- bash's parse_comsub reports the end-of-input line
+  // there, which is what the Eof token already carries.
+  int unterm_line = 0;
   bool heredoc_eof = false;        // here-doc body delimited by end of input
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
@@ -153,12 +159,14 @@ struct Lexer {
 
   // -- opaque span scanners (append the span, delimiters included) ----------
   void scan_single(std::string &w) {
+    int startln = line_for(pos);
     w += in[pos++];  // '
     while (pos < n && in[pos] != '\'') w += in[pos++];
     if (pos < n) w += in[pos++];
-    else { unterminated = true; if (!unterm_close) unterm_close = '\''; }
+    else { unterminated = true; if (!unterm_close) { unterm_close = '\''; unterm_line = startln; } }
   }
   void scan_backtick(std::string &w) {
+    int startln = line_for(pos);
     w += in[pos++];  // `
     while (pos < n && in[pos] != '`') {
       if (in[pos] == '\\') {
@@ -169,7 +177,7 @@ struct Lexer {
       }
     }
     if (pos < n) w += in[pos++];
-    else { unterminated = true; if (!unterm_close) unterm_close = '`'; }
+    else { unterminated = true; if (!unterm_close) { unterm_close = '`'; unterm_line = startln; } }
   }
   void scan_paren(std::string &w, bool comsub_ctx = false) {  // pos at '('
     int depth = 0;
@@ -421,6 +429,7 @@ struct Lexer {
           comsub_carry.push_back({hd.delim, hd.strip, w.size() - 1});
   }
   void scan_brace(std::string &w, bool in_dq = false) {  // pos at '{'
+    int startln = line_for(pos);
     int depth = 0;
     // Inside ${...} only a nested `${` opens another level; a bare `{` is a
     // literal character.  This mirrors bash's parse_matched_pair called with
@@ -480,7 +489,7 @@ struct Lexer {
         pos++;
       }
     } while (pos < n && depth > 0);
-    if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = '}'; }
+    if (depth > 0) { unterminated = true; if (!unterm_close) { unterm_close = '}'; unterm_line = startln; } }
   }
   void scan_square(std::string &w) {  // pos at '[' of $[...] arithmetic
     int depth = 0;
@@ -512,6 +521,7 @@ struct Lexer {
     if (depth > 0) { unterminated = true; if (!unterm_close) unterm_close = ']'; }
   }
   void scan_double(std::string &w) {
+    int startln = line_for(pos);
     w += in[pos++];  // "
     while (pos < n && in[pos] != '"') {
       char c = in[pos];
@@ -535,9 +545,10 @@ struct Lexer {
       }
     }
     if (pos < n) w += in[pos++];
-    else { unterminated = true; if (!unterm_close) unterm_close = '"'; }
+    else { unterminated = true; if (!unterm_close) { unterm_close = '"'; unterm_line = startln; } }
   }
   void scan_dollar_single(std::string &w) {  // pos at '$', next '\''
+    int startln = line_for(pos);
     w += in[pos++];  // $
     w += in[pos++];  // '
     while (pos < n && in[pos] != '\'') {
@@ -549,7 +560,7 @@ struct Lexer {
       }
     }
     if (pos < n) w += in[pos++];
-    else { unterminated = true; if (!unterm_close) unterm_close = '\''; }
+    else { unterminated = true; if (!unterm_close) { unterm_close = '\''; unterm_line = startln; } }
   }
 
   bool is_metachar(char c) {
@@ -956,6 +967,7 @@ struct Lexer {
     eof.line = line_for(n) + ((n > 0 && in[n - 1] != '\n') ? 1 : 0);
     eof.lex_error = unterminated;
     eof.lex_close = unterm_close;
+    eof.lex_open_line = unterm_line;
     eof.heredoc_eof = heredoc_eof;
     eof.heredoc_eof_delim = heredoc_eof_delim;
     eof.heredoc_eof_line = heredoc_eof_line;

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1210,7 +1210,11 @@ struct Parser {
       char cl = toks.back().lex_close;
       res.error = cl ? std::string("unexpected EOF while looking for matching `") + cl + "'"
                      : std::string("unterminated quoted string or substitution");
-      res.error_line = toks.back().line;
+      // bash's parse_matched_pair reports `start_lineno' -- where the span
+      // OPENED -- for a quote, a backquote and `${'.  Its `$(' scanner reports
+      // where input ran out instead, and leaves lex_open_line 0 to say so.
+      res.error_line = toks.back().lex_open_line > 0 ? toks.back().lex_open_line
+                                                     : toks.back().line;
       // An unterminated span may still have a here-document pending inside
       // it; the reader needs the delimiter's quoting to decide whether a
       // trailing `\' is a line continuation (comsub4.sub).

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -390,6 +390,14 @@ fi > /nonexistent-dir-xyz/f; } 2>&1 | sed "s/^[^ ]*: //"'
 echo "L=$LINENO"
 )
 echo "L=$LINENO"'
+  # An unterminated quote, backquote or `${' names the line it OPENED on; an
+  # unterminated `$(' names where input ran out.  These run a script file (via
+  # "$0", the shell under test) because a syntax error aborts -c before any
+  # pipeline could filter the message.
+  'd=$(mktemp -d); printf "foo=bar\necho \"\${foo:-\"a}\"\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
+  'd=$(mktemp -d); printf "foo=bar\necho \`bar\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
+  'd=$(mktemp -d); printf "foo=bar\necho \"abc\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
+  'd=$(mktemp -d); printf "foo=bar\necho \$(bar\nbaz\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #524.

## Root cause

An unterminated quote, backquote or `${` named the line input ran out on
instead of the line it opened on:

```sh
foo=bar
echo "${foo:-"a}"     # bash: line 2   gnash: line 3
```

bash's `parse_matched_pair()` reports `start_lineno` for these:

```c
	      parser_error (start_lineno, _("unexpected EOF while looking for matching `%c'"), close);
```

## The exception that made this look correct

`$(` is scanned by `parse_comsub`, which reports the **end-of-input** line --
and that is what gnash was doing for *every* construct. So `echo $(bar` was
already right, which is why the bug only showed on the quote forms.

The lexer now records where the unterminated span opened next to the closer it
was hunting for. Leaving it 0 means "report the end-of-input line", so the
`$(` path keeps its behaviour by construction rather than by a special case at
the reporting end.

## Verification

- `posixexp.tests` **4 -> 2**. Full 83-suite sweep: the only change; 64
  byte-perfect, 2028 -> 2026 total.
- `ctest` 22/22; `run_diff.sh` **270/270** with 4 new cases covering `${`, a
  backquote, `"` and the `$(` exception. They run a script file through `"$0"`
  -- the shell under test -- because a syntax error aborts `-c` before any
  pipeline could filter the message.
- Nine unterminated shapes checked by hand against bash, including spans
  opening on line 1 and spans crossing lines: all match.
