### PR TITLE
feat(xtrace): implement $BASH_XTRACEFD

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -284,6 +284,12 @@ class Shell {
   void end_interruptible_wait();
   int pending_trapped_signal();               // a pending signal that has a trap, or 0
   void note_child_reaped();                   // count a reaped child for the SIGCHLD trap
+  // Where `set -x' output goes.  stderr unless $BASH_XTRACEFD names an open
+  // file descriptor; see apply_xtracefd().
+  std::FILE *xtrace_out() const { return xtrace_fp ? xtrace_fp : stderr; }
+  // Re-read $BASH_XTRACEFD after it is assigned or unset.  Returns false (with
+  // bash's diagnostic already printed) when the value is not an open fd.
+  bool apply_xtracefd(const char *value);
   // Drop the traps a child process does not inherit; call in every forked
   // child (subshell, pipeline stage, background job, coproc, comsub).
   void drop_child_traps();
@@ -508,6 +514,8 @@ class Shell {
   std::vector<std::string> debug_frame;
   // The same, for the RETURN trap; see return_trap_fires().
   std::vector<std::string> return_frame;
+  std::FILE *xtrace_fp = nullptr;  // $BASH_XTRACEFD's stream; null = stderr
+  int xtrace_fd = -1;              // the fd it was opened on
   int command_number = 1;     // \# prompt escape: commands entered this session
   bool opt_extdebug = false;  // `shopt -s extdebug': enables BASH_ARGC/BASH_ARGV
   // Call-argument stack for $BASH_ARGC/$BASH_ARGV (only maintained under

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7198,7 +7198,7 @@ struct CondEval {
     auto shown = [](const std::string &v) { return v.empty() ? std::string("''") : v; };
     std::string body = binary ? shown(a1) + " " + op + " " + shown(a2)
                               : op + " " + shown(a1);
-    std::fprintf(stderr, "%s[[ %s%s ]]\n", pfx.c_str(), invert ? "! " : "", body.c_str());
+    std::fprintf(sh.xtrace_out(), "%s[[ %s%s ]]\n", pfx.c_str(), invert ? "! " : "", body.c_str());
   }
   // A `=~' right-hand side is a REGEX.  Undo the parser's transport encoding
   // first -- those characters were never quoted by the user -- then expand,

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1379,7 +1379,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     // pre-formatted in source order (scalar values and command words are quoted
     // as bash's sh_single_quote/ANSI-C xtrace conventions require).
     for (const auto &a : xtrace_lines)
-      std::fprintf(stderr, "%s%s\n", xt_prefix.c_str(), a.c_str());
+      std::fprintf(sh_.xtrace_out(), "%s%s\n", xt_prefix.c_str(), a.c_str());
     if (!argv.empty()) {
       std::string line = xt_prefix;
       bool first = true;
@@ -1388,7 +1388,7 @@ int Executor::run_simple(const SimpleCommand *c) {
         line += xtrace_quote_word(a);
         first = false;
       }
-      std::fprintf(stderr, "%s\n", line.c_str());
+      std::fprintf(sh_.xtrace_out(), "%s\n", line.c_str());
     }
   }
 
@@ -2096,7 +2096,7 @@ int Executor::run_for(const ForCommand *c) {
         auto ed = sh_.shopt_opts.find("extdebug");
         if (tst != 0 && ed != sh_.shopt_opts.end() && ed->second) return 0LL;
       }
-      if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", e.c_str());
+      if (sh_.opt_xtrace) std::fprintf(sh_.xtrace_out(), "+ (( %s ))\n", e.c_str());
       // Report an arithmetic error with bash's `((: EXPR: ...' diagnostic (the
       // loop-abort above then stops the loop), rather than failing silently.
       return static_cast<long long>(eval_arith_msg(sh_, aex.expand_no_split(e), "((", &ok));
@@ -2144,7 +2144,7 @@ int Executor::run_for(const ForCommand *c) {
   sh_.loop_depth++;
   for (const std::string &item : items) {
     if (!debug_trap_for(c, c->line)) break;  // the loop header, once per pass
-    if (sh_.opt_xtrace) std::fprintf(stderr, "%s\n", xtrace_line.c_str());
+    if (sh_.opt_xtrace) std::fprintf(sh_.xtrace_out(), "%s\n", xtrace_line.c_str());
     // A nameref loop variable is special: each iteration *retargets* the
     // reference to name ITEM rather than writing ITEM through to its current
     // target (bash treats `for ref in a b c' like successive `declare -n
@@ -2322,7 +2322,7 @@ int Executor::run_case(const CaseCommand *c) {
   Expander ex(sh_);
   std::string word = ex.expand_no_split(c->word.text);
   if (sh_.arith_error) { sh_.arith_error = false; return (sh_.last_status = 1); }
-  if (sh_.opt_xtrace) std::fprintf(stderr, "+ case %s in\n", word.c_str());
+  if (sh_.opt_xtrace) std::fprintf(sh_.xtrace_out(), "+ case %s in\n", word.c_str());
   int st = 0;
   size_t i = 0;
   while (i < c->clauses.size()) {
@@ -2437,7 +2437,7 @@ int Executor::run_arith(const ArithCommand *c) {
   std::string e = ex.expand_arith(c->expression);
   // xtrace prints the POST-EXPANSION expression (`(( $var ))' traces as
   // `+ ((  42  ))'), as bash does.
-  if (sh_.opt_xtrace) std::fprintf(stderr, "+ (( %s ))\n", e.c_str());
+  if (sh_.opt_xtrace) std::fprintf(sh_.xtrace_out(), "+ (( %s ))\n", e.c_str());
   // The `(( ))' command reports an arithmetic error (bad token, division by
   // zero) with bash's `((: EXPR: ...' diagnostic, unlike bare $(( )).
   long long v = eval_arith_msg(sh_, e, "((", &ok, /*expand_subs=*/1);

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -15,6 +15,8 @@
 #include <ctime>
 #include <time.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <climits>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/wait.h>
@@ -422,6 +424,42 @@ void Shell::drop_child_traps() {
     traps.erase("RETURN");
     traps.erase("ERR");  // bash gates this on errtrace (-E); gnash folds -E into -T
   }
+}
+
+// $BASH_XTRACEFD: send `set -x' output to a file descriptor other than stderr.
+// bash's sv_xtracefd(): unset or empty resets to stderr; a value that parses
+// wholly as an integer naming an OPEN fd is adopted; anything else is an error
+// and leaves the current destination alone.
+bool Shell::apply_xtracefd(const char *value) {
+  auto reset = [&] {
+    if (xtrace_fp) { std::fclose(xtrace_fp); xtrace_fp = nullptr; xtrace_fd = -1; }
+  };
+  if (!value || !*value) { reset(); return true; }  // unset or empty: back to stderr
+  std::string v(value);
+  char *end = nullptr;
+  long fd = std::strtol(v.c_str(), &end, 10);
+  // bash requires the whole value to be the number AND the fd to be open.
+  if (end == v.c_str() || *end != '\0' || fd < 0 || fd > INT_MAX ||
+      fcntl(static_cast<int>(fd), F_GETFD) == -1) {
+    std::fprintf(stderr, "%sBASH_XTRACEFD: %s: invalid value for trace file descriptor\n",
+                 err_prefix().c_str(), v.c_str());
+    return false;
+  }
+  if (xtrace_fd == static_cast<int>(fd)) return true;  // already there
+  reset();
+  std::FILE *fp = fdopen(static_cast<int>(fd), "w");
+  if (!fp) {
+    std::fprintf(stderr, "%sBASH_XTRACEFD: %s: cannot open as FILE\n",
+                 err_prefix().c_str(), v.c_str());
+    return false;
+  }
+  // Unbuffered: a script commonly writes the trace to a file and reads it back
+  // in the same run (`exec 4>f; BASH_XTRACEFD=4; ...; cat f'), so buffered
+  // output would still be sitting in the FILE when the reader ran.
+  std::setvbuf(fp, nullptr, _IONBF, 0);
+  xtrace_fp = fp;
+  xtrace_fd = static_cast<int>(fd);
+  return true;
 }
 
 void Shell::note_child_reaped() {
@@ -1592,6 +1630,9 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   // bash reports errors against the source file, not the mutable $0.  $0 already
   // resolves through arg0; still stored so `$BASH_ARGV0' reads back the value.
   if (n == "BASH_ARGV0") { arg0 = v; }
+  // $BASH_XTRACEFD redirects `set -x' output; the value is stored either way,
+  // as bash does, but an unusable fd is reported and the destination unchanged.
+  if (n == "BASH_XTRACEFD") apply_xtracefd(v.c_str());
   // Assigning to a dynamic variable seeds/rebases it rather than storing.
   if (n == "RANDOM") {
     rand_seed = static_cast<unsigned long>(std::strtoul(v.c_str(), nullptr, 10));
@@ -1682,6 +1723,7 @@ void Shell::export_name(const std::string &n) {
 
 void Shell::unset(const std::string &n_in, bool force, bool noref) {
   if (n_in == "HISTSIZE" && history_loaded) unstifle_history();
+  if (n_in == "BASH_XTRACEFD") apply_xtracefd(nullptr);  // trace output back to stderr
   // `unset name' on a nameref removes the target; `unset -n name' (NOREF)
   // removes the nameref variable itself.  Following the ref matches common
   // usage.  FORCE mirrors bash's unbind_variable_noref: remove the named

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -398,6 +398,14 @@ echo "L=$LINENO"'
   'd=$(mktemp -d); printf "foo=bar\necho \`bar\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
   'd=$(mktemp -d); printf "foo=bar\necho \"abc\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
   'd=$(mktemp -d); printf "foo=bar\necho \$(bar\nbaz\n" > "$d/s"; "$0" "$d/s" 2>&1 | sed "s|^[^ ]*: ||"; rm -rf "$d"'
+  # $BASH_XTRACEFD sends `set -x'"'"' output to a descriptor other than stderr; a
+  # value that is not an open fd is an error and leaves the destination alone.
+  # `unset'"'"' puts it back on stderr -- note the trace of the `unset'"'"' itself is
+  # the last line still written to the file.
+  'd=$(mktemp -d); exec 4>"$d/t"; BASH_XTRACEFD=4; set -x; echo one; set +x; exec 4<&-; echo "file:"; cat "$d/t"; rm -rf "$d"'
+  'd=$(mktemp -d); exec 4>"$d/t"; BASH_XTRACEFD=4; set -x; echo one; unset BASH_XTRACEFD; echo two; set +x; exec 4<&-; echo "file:"; cat "$d/t"; rm -rf "$d"'
+  '{ BASH_XTRACEFD=9; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ BASH_XTRACEFD=abc; } 2>&1 | sed "s|^[^ ]*: ||"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #526. **`set-x.tests` 14 -> 3.**

## Root cause

`$BASH_XTRACEFD` was not implemented at all — `set -x` output always went to
stderr, and an unusable value was accepted silently.

Following bash's `sv_xtracefd()` (variables.c), the variable is now re-read on
every assignment and on unset:

- unset or empty -> trace output resets to stderr;
- a value that parses **wholly** as an integer naming an **open** descriptor ->
  `fdopen` it and trace there;
- anything else -> `BASH_XTRACEFD: 9: invalid value for trace file descriptor`,
  leaving the current destination unchanged.

## Two details worth flagging

**The stream is unbuffered.** The idiomatic use writes the trace to a file and
reads it back in the same run (`exec 4>f; BASH_XTRACEFD=4; ...; cat f`), so
buffered output would still be sitting in the `FILE` when the reader ran — the
suite does exactly this, and it is why the first cut scored 13 instead of 3.

**Seven sites, not six.** The main command-word trace writes its line through a
separate `fprintf` from the assignment-prefix loop, and my first pass missed it
because it names neither the prefix variable nor a `+` literal. Every trace
writer now goes through `Shell::xtrace_out()`; grepping `opt_xtrace` confirms
none is left naming stderr.

## Verification

- `set-x.tests` **14 -> 3**. Full 83-suite sweep: the only change; 64
  byte-perfect, 2026 -> 2015 total lines.
- `ctest` 22/22; `run_diff.sh` **274/274** with 4 new cases: redirect-and-read
  back, `unset` restoring stderr (the `unset`'s own trace is the last line in
  the file), a closed fd, and a non-numeric value.

## Not covered

The remaining three `set-x` lines are a different gap: bash xtraces an array
assignment (`+ metas=(\| \& ...)`, `+ n=($@)`) and gnash does not. There is
already a `NOTE` in `executor.cpp` about it.
