### PR TITLE
fix(arith): an empty array subscript is diagnosed, not fatal

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -778,19 +778,29 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing 
   // result is arith-evaluated, a malformed one aborting with bash's
   // diagnostic naming the SUBSCRIPT.
   if (out.empty()) {
-    ctx.ok = false;
+    // An EMPTY subscript is reported but is NOT fatal to the expression: bash
+    // prints the diagnostic, then carries on -- a read yields 0, a write is
+    // skipped while the assignment still evaluates to its right-hand side, and
+    // the enclosing command list keeps running.  (A real syntax error, by
+    // contrast, still unwinds; see the arith_abort path in expand.cpp.)  So
+    // ctx.ok is deliberately left alone here: returning false already gives
+    // the caller both behaviours.
     if (writing) {
       // `(( a[""]=24 ))' -- an assignment target: `a[]': not a valid
       // identifier (with the command prefix).
-      ctx.full_msg = "`" + n->name + "[]': not a valid identifier";
+      // Unlike the read below, this one carries the command prefix (`((: ').
+      std::fprintf(stderr, "%s%s%s`%s[]': not a valid identifier\n",
+                   ctx.sh.err_prefix().c_str(),
+                   (ctx.cmd_name && *ctx.cmd_name) ? ctx.cmd_name : "",
+                   (ctx.cmd_name && *ctx.cmd_name) ? ": " : "", n->name.c_str());
     } else {
       // `(( y[$none] ))' -- a read: y[]: bad array subscript (bare).  bash
       // reports it TWICE: once while resolving the reference and again when
       // the arithmetic command reports the failed expression (array27.sub).
-      ctx.full_msg = n->name + "[]: bad array subscript";
-      ctx.full_msg_bare = true;
+      std::string m = n->name + "[]: bad array subscript";
+      std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), m.c_str());
       if (ctx.expand_subs == 1)
-        std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), ctx.full_msg.c_str());
+        std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), m.c_str());
     }
     return false;
   }
@@ -800,9 +810,22 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing 
     ctx.full_msg_bare = true;
     return false;
   }
+  // Double-quote CHARACTERS in an indexed subscript are removable arithmetic
+  // quoting -- EXCEPT under assoc_expand_once, whose literal-subscript rule
+  // keeps them for an indexed array too, so `let "a[\" \"]"=18' hands `" "' to
+  // the evaluator and is a syntax error rather than a write to element 0.
+  bool eo_idx = false;
+  {
+    auto eoit = ctx.sh.shopt_opts.find("assoc_expand_once");
+    eo_idx = eoit != ctx.sh.shopt_opts.end() && eoit->second;
+  }
   std::string ev;
-  for (char c : out)
-    if (c != '"') ev += c;
+  if (ctx.expand_subs == 2 && eo_idx) {
+    ev = out;
+  } else {
+    for (char c : out)
+      if (c != '"') ev += c;
+  }
   if (blank_expr(ev)) { out = "0"; return true; }
   long long k;
   if (!try_int(ev, k)) {
@@ -1032,6 +1055,10 @@ long long eval_arith_msg(Shell &sh, const std::string &expr, const char *cmd_nam
     // prints bare (no `((: ' prefix), as bash's array layer does.
     std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(),
                  ctx.full_msg_bare ? "" : prefix.c_str(), rendere(ctx.full_msg).c_str());
+    // A failure raised by the ARRAY layer while evaluating a subscript unwinds
+    // the command list, even from `let', where a failure of the top-level
+    // expression (`let "x+"') merely returns non-zero and execution continues.
+    if (ctx.full_msg_bare) sh.arith_abort = true;
   } else if (!ctx.ok && ctx.err_pos != std::string::npos && ctx.err_pos <= expr.size()) {
     std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(), prefix.c_str(),
                  rendere(format_arith_err(expr, ctx.err_msg, ctx.err_pos)).c_str());

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -406,6 +406,19 @@ echo "L=$LINENO"'
   'd=$(mktemp -d); exec 4>"$d/t"; BASH_XTRACEFD=4; set -x; echo one; unset BASH_XTRACEFD; echo two; set +x; exec 4<&-; echo "file:"; cat "$d/t"; rm -rf "$d"'
   '{ BASH_XTRACEFD=9; } 2>&1 | sed "s|^[^ ]*: ||"'
   '{ BASH_XTRACEFD=abc; } 2>&1 | sed "s|^[^ ]*: ||"'
+  # An EMPTY array subscript is diagnosed but is NOT fatal: a read yields 0, a
+  # write is skipped while the assignment still evaluates to its right-hand
+  # side, and the command list keeps running.
+  '{ declare -a a; echo $(( a[""]=2+3 )); } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ declare -a a; echo $(( 7 + a[""] )); echo AFTER; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'declare -a a; { (( a[""]=24 )); } 2>&1 | sed "s|^[^ ]*: ||"; declare -p a'
+  # ...but a subscript that fails to EVALUATE does unwind the list, even from
+  # `let'"'"', where a bad top-level expression merely returns non-zero.  Under
+  # assoc_expand_once the quotes survive into the evaluator, so this is a
+  # syntax error rather than a write to element 0.
+  'shopt -s assoc_expand_once; declare -a a; a[0]=0; { ( let "a[\" \"]"=18 ; echo AFTER ); } 2>&1 | sed "s|^[^ ]*: ||"; declare -p a'
+  'shopt -u assoc_expand_once; declare -a a; a[0]=0; { ( let "a[\" \"]"=18 ; echo AFTER ); } 2>&1 | sed "s|^[^ ]*: ||"; declare -p a'
+  '{ let "x+"; } 2>&1 | sed "s|^[^ ]*: ||"; echo AFTER'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #528. **`arith.tests` 8 -> 0 — 65 of 83 byte-perfect.**

## 1. An empty subscript was treated as fatal

```sh
declare -a a; echo $(( a[""]=2+3 )); echo AFTER
```

bash prints `` `a[]': not a valid identifier `` and then **continues**, giving
`5` and `AFTER`. gnash printed the diagnostic and abandoned the rest of the
command list.

The satisfying part: nothing structural was needed. The read path already
returned 0 and the write path already skipped the store while the assignment
kept its right-hand side as the expression's value — so the only change was to
stop setting `ok = false` and to print the diagnostic where it is raised
instead of relying on the abort path to print it. A genuine syntax error
(`$((x+))`) still unwinds, which was already correct.

## 2. `assoc_expand_once` was not applied to indexed subscripts

```sh
shopt -s assoc_expand_once; declare -a a; a[0]=0; let "a[\" \"]"=18
```

bash: `" ": arithmetic syntax error: operand expected`. gnash silently wrote
`a[0]=18`. Double-quote characters in an indexed subscript are removable
arithmetic quoting *except* under this option, whose literal-subscript rule
keeps them — gnash already had that rule for associative keys.

Fixing it exposed the last piece: a subscript that fails to **evaluate**
unwinds the command list even from `let`, where a bad *top-level* expression
(`let "x+"`) merely returns non-zero and execution continues. `full_msg_bare`
already marked exactly the failures raised by the array layer, so that is the
condition.

## Verification

- `arith.tests` **8 -> 0**. Full 83-suite sweep: the only change; 64 -> **65**
  byte-perfect, 2015 -> 2007 total lines. `array.tests` stays at 0.
- `ctest` 22/22; `run_diff.sh` **280/280** with 6 new cases: the non-fatal read
  and write, `(( ))` rc and resulting array, and the `let` subscript error with
  `assoc_expand_once` both set and unset, plus `let "x+"` to pin that a
  top-level `let` error still does *not* unwind.
