### PR TITLE
fix(trap): revert a lone signal operand; reject a lone action

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -508,6 +508,15 @@ class Shell {
   bool in_debug_trap = false; // guard: don't fire the DEBUG trap within itself
   bool in_err_trap = false;   // guard: don't fire the ERR trap within itself
   bool in_return_trap = false;// guard: don't fire the RETURN trap within itself
+  // POSIX interp 1602: a bare `return' (or `exit') inside a SIGNAL trap action
+  // yields $? as it stood when the trap was entered -- the trap cannot change
+  // it -- unless the action has called a shell function we are still inside.
+  // trap_ret_depth is the function/source nesting at trap entry; -1 means no
+  // signal trap is running.  The DEBUG trap is excluded: changing $? is part
+  // of why it exists.
+  int trap_saved_status = 0;
+  int trap_ret_depth = -1;
+  int nest_depth() const { return static_cast<int>(call_stack.size()) + source_depth; }
   // The DEBUG trap body as it stood when each active function was entered.  A
   // DEBUG trap the function installs for itself (the body differs from entry)
   // fires without functrace; an inherited one does not.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4006,6 +4006,29 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
 
   // Otherwise set/reset/ignore: the first operand is the action, the rest are
   // the signals it applies to.
+  //
+  // With a SINGLE operand, bash's historical one-argument form applies: if it
+  // names a signal it REVERTS that signal (`trap USR1').  Anything else is an
+  // action with no signal to apply it to --
+  // `trap ""', `trap 512', `trap "echo hi"' -- and that is a usage error, not
+  // the silent no-op it used to be here.
+  if (i + 1 == argv.size()) {
+    const std::string &only = argv[i];
+    bool names_signal = !only.empty() && only != "-" &&
+                        (!trap_pseudo(only).empty() || valid_signal_spec(only));
+    if (!names_signal) {
+      std::fprintf(stderr, "%s\n", kUsage);  // bare, as bash's builtin_usage()
+      return 2;
+    }
+    std::string pseudo = trap_pseudo(only);
+    if (!pseudo.empty()) {
+      sh.traps.erase(pseudo);
+    } else {
+      sh.traps.erase(trap_key_for_spec(only));
+      sh.set_signal_trap(signame_to_num(only), false);
+    }
+    return 0;
+  }
   std::string cmd = argv[i];
   bool reset = (cmd == "-");
   bool ignore = cmd.empty();
@@ -6394,7 +6417,14 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       sh.posix_special_builtin_error(st);  // special builtin: fatal in posix
     } else {
       sh.returning = true;
-      sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : sh.last_status;
+      // A BARE `return' inside a signal trap action reports $? from before the
+      // trap ran -- the action cannot change it (posix interp 1602) -- unless
+      // the action called a function we are still inside.  An explicit
+      // argument always wins.
+      int bare = (sh.trap_ret_depth >= 0 && sh.nest_depth() == sh.trap_ret_depth)
+                     ? sh.trap_saved_status
+                     : sh.last_status;
+      sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : bare;
       st = sh.exit_status;
     }
   } else if (cmd == "break" || cmd == "continue") {

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -493,8 +493,15 @@ void Shell::run_pending_traps() {
     int saved = last_status;  // the interrupted command's $?
     int saved_sig = trap_sig;
     trap_sig = s;             // $BASH_TRAPSIG names the delivering signal
+    // A bare `return' in the action reports THIS status, not one the action
+    // sets (posix interp 1602); see Shell::trap_saved_status.
+    int prev_status = trap_saved_status, prev_depth = trap_ret_depth;
+    trap_saved_status = saved;
+    trap_ret_depth = nest_depth();
     std::string cmd = it->second;
     run_string(cmd);
+    trap_saved_status = prev_status;
+    trap_ret_depth = prev_depth;
     trap_sig = saved_sig;
     last_status = saved;
     in_trap = false;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -419,6 +419,20 @@ echo "L=$LINENO"'
   'shopt -s assoc_expand_once; declare -a a; a[0]=0; { ( let "a[\" \"]"=18 ; echo AFTER ); } 2>&1 | sed "s|^[^ ]*: ||"; declare -p a'
   'shopt -u assoc_expand_once; declare -a a; a[0]=0; { ( let "a[\" \"]"=18 ; echo AFTER ); } 2>&1 | sed "s|^[^ ]*: ||"; declare -p a'
   '{ let "x+"; } 2>&1 | sed "s|^[^ ]*: ||"; echo AFTER'
+  # `trap SIGSPEC' with a single operand REVERTS that signal; a single operand
+  # that names no signal is an ACTION with nothing to apply it to, which is a
+  # usage error (status 2), not a silent no-op.
+  'trap "echo hi" USR1; trap USR1; trap -p | grep -c USR1'
+  '{ trap ""; } 2>&1; echo "rc=$?"'
+  '{ trap 512; } 2>&1; echo "rc=$?"'
+  '{ trap foo; } 2>&1; echo "rc=$?"'
+  'trap 15; echo "rc=$?"'
+  # posix interp 1602: a BARE `return' in a signal trap action reports $? from
+  # before the trap ran -- the action cannot change it.  An explicit argument
+  # still wins, and a function called BY the action reports its own status.
+  'setexit() { return "$1"; }; trap "setexit 111; return" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "dollar=$?"'
+  'setexit() { return "$1"; }; trap "setexit 111; return 7" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "dollar=$?"'
+  'setexit() { return "$1"; }; handler() { setexit 111; return; }; trap "handler; stat=\$?; return" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "stat=$stat"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #530. **`trap.tests` 17 -> 10.**

## 1. A single operand is neither reverted nor rejected

`trap USR1` is bash's historical one-argument form and **reverts** that signal.
gnash took the operand as an action, found no signals to apply it to, and
returned 0 having done nothing — the trap stayed installed.

A single operand that names no signal (`trap ""`, `trap 512`, `trap foo`) is an
action with nothing to apply it to, which bash reports as a **usage error with
status 2**. Two details from `trap.def` worth noting: the usage line is printed
bare, with no `file: line N:` prefix (`builtin_usage()`), and `trap 0` is fine
because `0` names EXIT.

One thing I did **not** carry over: bash's source gates the revert on
`posixly_correct == 0`, but `bash -c 'set -o posix; trap 15'` still reverts and
returns 0, so the condition is not reachable the way the comment implies. I
matched observed behaviour rather than the source comment.

## 2. Bare `return` in a trap action (POSIX interp 1602)

```sh
setexit() { return "$1"; }
trap 'setexit 111; return' USR1
invoke() { kill -USR1 $$; return 222; }
invoke; echo "dollar=$?"       # bash: 0    gnash was: 111
```

A bare `return` inside a signal trap action reports `$?` as it stood when the
trap was **entered** — the action cannot change it. `return N` still wins, and
the rule lapses while the action is inside a shell function it called itself
(bash gates on `trap_return_context == funcnest + sourcenest`; gnash compares
`call_stack.size() + source_depth` at trap entry). The DEBUG trap is excluded,
since changing `$?` is part of why it exists.

## Verification

- `trap.tests` **17 -> 10**. Full 83-suite sweep: the only change; 65
  byte-perfect, 2007 -> 2000 total lines.
- `ctest` 22/22; `run_diff.sh` **288/288** with 8 new cases — the revert, three
  usage-error forms, `trap 15`, and all three interp-1602 shapes including the
  `return N` and called-function cases that must *not* change.

## Remaining in this suite

Three clusters, 10 lines: `declare -ft` should set a function's trace attribute
(so it inherits the DEBUG trap without `set -T`) rather than printing the
function; a `trap - debug` / USR2 listing difference; and xtrace's indirection
level — bash repeats PS4's first character once per nested `parse_and_execute`,
so a trap body traces as `++` where gnash prints `+`.
