### PR TITLE
fix(xtrace): repeat PS4's first character per nesting level

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -287,6 +287,14 @@ class Shell {
   // Where `set -x' output goes.  stderr unless $BASH_XTRACEFD names an open
   // file descriptor; see apply_xtracefd().
   std::FILE *xtrace_out() const { return xtrace_fp ? xtrace_fp : stderr; }
+  // The `set -x' line prefix: $PS4 expanded, with its FIRST character repeated
+  // once per nesting level (bash's indirection_level_string).
+  std::string xtrace_prefix();
+  // bash's indirection_level: 1 while the top-level reader runs a command, and
+  // one more for each nested parse_and_execute -- an `eval', a command
+  // substitution, a sourced file, a trap action.  NOT a function call or a
+  // plain subshell.  Shell::run_string is the analogue, so it owns the count.
+  int indirection_level = 0;
   // Re-read $BASH_XTRACEFD after it is assigned or unset.  Returns false (with
   // bash's diagnostic already printed) when the value is not an open fd.
   bool apply_xtracefd(const char *value);

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7222,9 +7222,7 @@ struct CondEval {
   void xtrace_term(const std::string &op, const std::string &a1, const std::string &a2,
                    bool binary, bool invert) {
     if (noeval || !sh.opt_xtrace) return;
-    std::string ps4 = sh.is_set("PS4") ? sh.get("PS4") : "+ ";
-    Expander xex(sh);
-    std::string pfx = xex.expand_no_split(expand_prompt(sh, ps4), false, false);
+    std::string pfx = sh.xtrace_prefix();
     auto shown = [](const std::string &v) { return v.empty() ? std::string("''") : v; };
     std::string body = binary ? shown(a1) + " " + op + " " + shown(a2)
                               : op + " " + shown(a1);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1370,10 +1370,9 @@ int Executor::run_simple(const SimpleCommand *c) {
 
   if (sh_.opt_xtrace) {
     // bash's xtrace prefix is $PS4 (default `+ '), decoded for prompt escapes
-    // then word-expanded, so `$LINENO' and friends resolve for the traced line.
-    std::string ps4 = sh_.is_set("PS4") ? sh_.get("PS4") : "+ ";
-    Expander xex(sh_);
-    std::string xt_prefix = xex.expand_no_split(expand_prompt(sh_, ps4), false, false);
+    // then word-expanded, so `$LINENO' and friends resolve for the traced line;
+    // its first character repeats once per nesting level.
+    std::string xt_prefix = sh_.xtrace_prefix();
     // bash traces each temporary/standalone assignment on its own line, then the
     // command word list (if any) on a separate line.  Assignment lines were
     // pre-formatted in source order (scalar values and command words are quoted

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -462,6 +462,19 @@ bool Shell::apply_xtracefd(const char *value) {
   return true;
 }
 
+// bash's indirection_level_string(): expand $PS4, then emit its FIRST character
+// repeated indirection_level times followed by the REST of the expanded string.
+// So a trace from inside a trap action or an `eval' -- one level deeper than the
+// command that triggered it -- reads `++ ' rather than `+ '.
+std::string Shell::xtrace_prefix() {
+  std::string ps4 = is_set("PS4") ? get("PS4") : "+ ";
+  Expander xex(*this);
+  std::string p = xex.expand_no_split(expand_prompt(*this, ps4), false, false);
+  if (p.empty()) return p;
+  int n = indirection_level > 0 ? indirection_level : 1;
+  return std::string(static_cast<size_t>(n), p[0]) + p.substr(1);
+}
+
 void Shell::note_child_reaped() {
   // bash runs the SIGCHLD trap once for each terminated child; only count while
   // such a trap is installed.
@@ -2447,6 +2460,13 @@ bool Shell::aliases_active() const {
 
 int Shell::run_string(const std::string &script, const std::vector<int> *cont_lines) {
   if (is_csh()) return run_csh(*this, script);  // csh is a different language
+  // Each nested run_string is one of bash's nested parse_and_execute levels;
+  // see Shell::indirection_level.
+  struct LevelGuard {
+    Shell &sh;
+    explicit LevelGuard(Shell &s) : sh(s) { sh.indirection_level++; }
+    ~LevelGuard() { sh.indirection_level--; }
+  } lvl(*this);
   had_parse_error = false;
   ParseResult r = aliases_active()
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases,

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -433,6 +433,15 @@ echo "L=$LINENO"'
   'setexit() { return "$1"; }; trap "setexit 111; return" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "dollar=$?"'
   'setexit() { return "$1"; }; trap "setexit 111; return 7" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "dollar=$?"'
   'setexit() { return "$1"; }; handler() { setexit 111; return; }; trap "handler; stat=\$?; return" USR1; invoke() { kill -USR1 $$; return 222; }; invoke; echo "stat=$stat"'
+  # xtrace repeats PS4'"'"'s FIRST character once per nesting level, so a trace from
+  # inside an `eval'"'"' or a trap action reads `++'"'"'.  A function call and a plain
+  # subshell do NOT nest; a command substitution does.
+  'PS4="+ "; set -x; eval "echo hi"'
+  'PS4="- "; set -x; eval "echo hi"'
+  'PS4="+ "; set -x; f(){ echo in; }; f'
+  'PS4="+ "; set -x; (echo sub)'
+  'PS4="+ "; set -x; x=$(echo cs); echo "$x"'
+  'PS4=""; set -x; echo empty'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #532. **`trap.tests` 10 -> 8.**

## Root cause

`set -x` emitted `$PS4` verbatim, so a trace from inside a trap action or an
`eval` was indistinguishable from one at the top level:

```sh
PS4="+ "; set -x; eval "echo hi"
+ eval 'echo hi'
+ echo hi                       # bash: ++ echo hi
```

bash's `indirection_level_string()` (print_cmd.c) expands `$PS4`, then emits its
**first character** repeated `indirection_level` times followed by the **rest**
of the expanded string. That distinction matters: `PS4="+[$LINENO] "` at level 2
gives `++[$LINENO] `, not the whole prefix twice.

## Which constructs nest

`indirection_level` starts at 1 for the top-level reader (`eval.c`) and gains
one per nested `parse_and_execute` (`builtins/evalstring.c`). I checked each
case against bash rather than assuming:

| construct | nests? |
|---|---|
| `eval` | yes |
| command substitution | yes |
| sourced file | yes |
| trap action | yes |
| **function call** | **no** |
| **plain subshell** | **no** |

`Shell::run_string` is the direct `parse_and_execute` analogue and reproduces
that split exactly, so it owns the count — no per-construct bookkeeping.

## Verification

- `trap.tests` **10 -> 8**. Full 83-suite sweep: the only change; 65
  byte-perfect, 2000 -> 1998 total lines. The suites that depend most on trace
  output all hold: `set-x` 3, `dbg-support` 0, `cond` 0, `comsub` 0.
- `ctest` 22/22; `run_diff.sh` **294/294** with 6 new cases covering a nesting
  and a non-nesting construct each, a non-`+` PS4 (to prove the repeated
  character is taken from PS4 rather than hard-coded), and an empty PS4.

## Remaining in this suite

Two clusters, 8 lines. `declare -ft func2` should set the function's **trace**
attribute — making it inherit the DEBUG trap without `set -T`, bash's
`trace_p(var)` check — where gnash does not recognise `-t` and so falls through
to `declare -f` and prints the function body. And a `trap - debug` / SIGUSR2
listing difference where bash shows the signal as ignored (`''`) and gnash
still shows the handler.
