### PR TITLE
feat(declare): -ft marks a function traced, so it inherits DEBUG

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -531,6 +531,19 @@ class Shell {
   std::vector<std::string> debug_frame;
   // The same, for the RETURN trap; see return_trap_fires().
   std::vector<std::string> return_frame;
+  // Functions marked with `declare -ft'.  bash's trace attribute (trace_p) is
+  // a per-function functrace: such a function inherits the DEBUG and RETURN
+  // traps even when `set -T' is off.  traced_frame records, for each active
+  // call, whether THAT function is traced.
+  // Signals inherited as SIG_IGN at startup: bash's SIG_HARD_IGNORE.  They keep
+  // that disposition for the life of the shell -- `trap' can neither install a
+  // handler for one nor reset it, and does so silently.
+  std::set<std::string> hard_ignored;
+  std::set<std::string> traced_functions;
+  std::vector<bool> traced_frame;
+  bool in_traced_function() const {
+    return !traced_frame.empty() && traced_frame.back();
+  }
   std::FILE *xtrace_fp = nullptr;  // $BASH_XTRACEFD's stream; null = stderr
   int xtrace_fd = -1;              // the fd it was opened on
   int command_number = 1;     // \# prompt escape: commands entered this session

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2583,6 +2583,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   bool lcase = false, ucase = false;  // -l lowercase / -u uppercase attribute
   bool capcase = false;               // -c capitalize-first attribute
   bool funcs = false, funcnames = false;  // -f (definitions) / -F (names)
+  bool trace = false, rm_trace = false;  // -t / +t (bash's trace attribute)
   bool fp = false;                        // -p (display reproducibly)
   bool force_inherit = false;             // -I: inherit a surrounding value/attrs
   size_t i = 1;
@@ -2637,6 +2638,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // the same name for this local, as `shopt -s localvar_inherit' does
           // globally.
           case 'I': force_inherit = true; break;
+          case 't': (add ? trace : rm_trace) = true; break;
           default: break;
         }
       }
@@ -2752,6 +2754,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         }
       } else {
         sh.readonly_functions.insert(fn);
+      }
+    }
+    return st;
+  }
+  // `declare -ft NAME' SETS the trace attribute rather than displaying the
+  // function: a traced function inherits the DEBUG and RETURN traps with no
+  // `set -T', which is bash's per-function functrace (trace_p).
+  if (funcs && (trace || rm_trace) && i < argv.size()) {
+    int st = 0;
+    for (; i < argv.size(); i++) {
+      const std::string &fn = argv[i];
+      // A missing function fails SILENTLY here -- unlike `readonly -f', which
+      // reports it; bash's declare returns 1 with no diagnostic.
+      if (!sh.functions.count(fn)) {
+        st = 1;
+      } else if (rm_trace) {
+        sh.traced_functions.erase(fn);
+      } else {
+        sh.traced_functions.insert(fn);
       }
     }
     return st;
@@ -4023,7 +4044,7 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
     std::string pseudo = trap_pseudo(only);
     if (!pseudo.empty()) {
       sh.traps.erase(pseudo);
-    } else {
+    } else if (!sh.hard_ignored.count(trap_key_for_spec(only))) {
       sh.traps.erase(trap_key_for_spec(only));
       sh.set_signal_trap(signame_to_num(only), false);
     }
@@ -4050,6 +4071,9 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
     }
     int signo = signame_to_num(spec);
     std::string key = trap_key_for_spec(spec);
+    // A signal ignored when the shell started keeps that disposition: bash
+    // silently refuses to trap or reset it (trap1.sub).
+    if (sh.hard_ignored.count(key)) continue;
     if (reset) {
       sh.traps.erase(key);
       sh.set_signal_trap(signo, false);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1591,6 +1591,9 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.push_scope();
     sh_.debug_frame.push_back(sh_.traps.count("DEBUG") ? sh_.traps["DEBUG"] : std::string());
     sh_.return_frame.push_back(sh_.traps.count("RETURN") ? sh_.traps["RETURN"] : std::string());
+    // `declare -ft NAME' traces this function specifically: it inherits the
+    // DEBUG and RETURN traps as though functrace were on.
+    sh_.traced_frame.push_back(sh_.traced_functions.count(argv[0]) > 0);
     sh_.persona_restore.push_back(std::nullopt);  // for `personality -L' / `emulate -L'
     // Run the body under the lineno_base captured at definition time so $LINENO
     // reports absolute source lines regardless of the caller's input block.
@@ -1603,7 +1606,8 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.loop_depth = 0;
     // Under functrace, bash fires the DEBUG trap once for the function body as a
     // whole on entry, before the per-command traps inside it.
-    if (sh_.opt_functrace && sh_.traps.count("DEBUG") && !sh_.in_debug_trap) {
+    if ((sh_.opt_functrace || sh_.in_traced_function()) && sh_.traps.count("DEBUG") &&
+        !sh_.in_debug_trap) {
       // The whole-body DEBUG trap reports the function's definition line.
       auto dlit = sh_.func_def_line.find(argv[0]);
       sh_.cur_lineno = dlit != sh_.func_def_line.end() ? dlit->second
@@ -1642,6 +1646,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.pop_scope();
     sh_.debug_frame.pop_back();
     sh_.return_frame.pop_back();
+    sh_.traced_frame.pop_back();
     if (pushed_argframe && !sh_.argframes.empty()) sh_.argframes.pop_back();
     sh_.pop_src_frame();
     sh_.call_stack.pop_back();

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -87,7 +87,10 @@ Shell::Shell() {
     const char *nm = signum_to_trapname(s);
     if (!nm) continue;
     struct sigaction cur;
-    if (sigaction(s, nullptr, &cur) == 0 && cur.sa_handler == SIG_IGN) traps[nm] = "";
+    if (sigaction(s, nullptr, &cur) == 0 && cur.sa_handler == SIG_IGN) {
+      traps[nm] = "";
+      hard_ignored.insert(nm);  // and it can never be trapped or reset
+    }
   }
 }
 
@@ -327,7 +330,7 @@ int Shell::run_debug_trap(const std::string &cmd_text) {
   // Without functrace a function does not inherit the DEBUG trap: inside one it
   // fires only if the function installed its own (the body differs from what it
   // was when the innermost function was entered).
-  if (!opt_functrace && in_function() &&
+  if (!opt_functrace && !in_traced_function() && in_function() &&
       (debug_frame.empty() || it->second == debug_frame.back()))
     return 0;
   in_debug_trap = true;
@@ -380,7 +383,7 @@ void Shell::run_err_trap(int status) {
 bool Shell::return_trap_fires() const {
   auto it = traps.find("RETURN");
   if (it == traps.end() || it->second.empty() || in_debug_trap) return false;
-  if (opt_functrace || return_frame.empty()) return true;
+  if (opt_functrace || in_traced_function() || return_frame.empty()) return true;
   return it->second != return_frame.back();  // installed inside this function
 }
 

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -442,6 +442,18 @@ echo "L=$LINENO"'
   'PS4="+ "; set -x; (echo sub)'
   'PS4="+ "; set -x; x=$(echo cs); echo "$x"'
   'PS4=""; set -x; echo empty'
+  # `declare -ft NAME'"'"' sets the TRACE attribute: that function inherits the DEBUG
+  # and RETURN traps with no `set -T'"'"'.  It sets rather than displays, and a
+  # missing function fails silently (unlike `readonly -f'"'"').
+  'f(){ echo in; }; declare -ft f; trap "echo D" DEBUG; f; trap "" DEBUG'
+  'f(){ echo in; }; trap "echo D" DEBUG; f; trap "" DEBUG'
+  'f(){ echo in; }; declare -ft f; trap "echo R" RETURN; f; trap - RETURN'
+  'f(){ :; }; declare -ft f; declare -F f'
+  'f(){ :; }; declare -ft f; declare +t f; echo "rc=$?"'
+  '{ declare -ft nosuch; } 2>&1; echo "rc=$?"'
+  # A signal ignored when the shell started can be neither trapped nor reset.
+  'trap "" USR2; "$0" -c '"'"'trap "echo USR2" USR2; trap -p USR2'"'"''
+  'trap "echo U" USR2; trap -p USR2; trap - USR2; trap -p USR2; echo end'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #534. **`trap.tests` 8 -> 0 — 66 of 83 byte-perfect.**

## 1. `declare -ft` was not recognised

The option was dropped, so the command fell through to `declare -f` and
*printed* the function instead of setting an attribute on it.

bash's trace attribute is a **per-function functrace**: such a function inherits
the DEBUG and RETURN traps with `set -T` off, gated on `trace_p (var)` right
beside the `function_trace_mode` test in `execute_cmd.c`:

```c
  if (debug_trap && ((trace_p (var) == 0) && function_trace_mode == 0))
    ...restore_default_signal (DEBUG_TRAP);
```

So `declare -ft func2; func2` with a DEBUG trap installed should trace the
function's body — gnash traced nothing.

The attribute is recorded per function but pushed **per call**, alongside the
existing `debug_frame`/`return_frame` stacks, so a nested call to an *untraced*
function does not inherit the tracing. The three places that gate trap
inheritance on functrace now accept it too.

One behaviour I checked rather than copied from the adjacent code: `declare -ft`
on a missing function returns 1 **silently**, whereas `readonly -f` reports
`not a function`. Both reach the same code path in gnash, so the block I added
had to differ deliberately from the `readonly` block next to it.

## 2. A signal ignored at startup could still be trapped

`trap1.sub`'s premise — "signals ignored at shell startup cannot be trapped or
reset" — is bash's `SIG_HARD_IGNORE`. A signal inherited as `SIG_IGN` keeps that
disposition for the life of the shell, and `trap` silently refuses both to
install a handler for it and to reset it.

gnash already recorded such signals at startup, so the `trap` *listing* was
correct; it just let a later `trap` overwrite them. Both the normal set/reset
loop and the one-operand revert form added in #530 now honour it.

## Verification

- `trap.tests` **8 -> 0**. Full 83-suite sweep: the only change; 65 -> **66**
  byte-perfect, 1998 -> 1990 total lines.
- `ctest` 22/22; `run_diff.sh` **302/302** with 8 new cases: traced vs untraced
  DEBUG, traced RETURN, `declare -ft` not displaying, `+t` clearing it, the
  silent missing-function status, the hard-ignore inherited through a child
  shell, and a *non*-ignored USR2 still trapping and resetting normally.
