### PR TITLE
fix(echo): report a failed write

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -150,6 +150,16 @@ int bi_echo(Shell &sh, const std::vector<std::string> &argv) {
   }
   std::fwrite(out.data(), 1, out.size(), stdout);
   if (newline && !stop) std::fputc('\n', stdout);  // \c suppresses everything after
+  // bash's echo flushes and reports a failed write (echo.def -> sh_wrerror()).
+  // It matters for more than full disks: `exec 3</etc/passwd; echo hi >&3'
+  // fails only HERE, because duplicating a read-only descriptor onto stdout
+  // succeeds and only the write itself gets EBADF.
+  if (std::fflush(stdout) != 0 || std::ferror(stdout)) {
+    std::fprintf(stderr, "%secho: write error: %s\n", sh.err_prefix().c_str(),
+                 std::strerror(errno));
+    std::clearerr(stdout);
+    return 1;
+  }
   return 0;
 }
 

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -454,6 +454,11 @@ echo "L=$LINENO"'
   # A signal ignored when the shell started can be neither trapped nor reset.
   'trap "" USR2; "$0" -c '"'"'trap "echo USR2" USR2; trap -p USR2'"'"''
   'trap "echo U" USR2; trap -p USR2; trap - USR2; trap -p USR2; echo end'
+  # `echo'"'"' reports a failed write.  Duplicating a READ-ONLY descriptor onto
+  # stdout succeeds, so `>&3'"'"' below fails only when the write happens.
+  '{ exec 3</etc/passwd; echo hi >&3; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  'exec 3>/dev/null; echo hi >&3; echo "rc=$?"'
+  'echo normal; echo "rc=$?"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #536. **`redir.tests` 3 -> 1.**

## Root cause

`echo` never checked whether its write succeeded:

```sh
exec 3</etc/passwd
echo hi >&3            # gnash: rc=0, silent.  bash: echo: write error: Bad file descriptor, rc=1
```

fd 3 is open for **reading**. Duplicating it onto stdout succeeds — `dup2` does
not care about direction — so the *redirection* reports nothing, and the failure
surfaces only when the write happens. gnash discarded it. bash's `echo.def`
ends with a flush, a `ferror` check, `sh_wrerror()`, `clearerr` and
`EXECUTION_FAILURE`.

## How it was found

This is what `redir11.sub`'s `redir11 bad 3` / `bad 4` checks were catching, and
the diagnosis took a detour worth recording: **`redir11.sub` passes standalone**,
and the two failing commands match bash when run in isolation. The failure only
exists in a full `redir.tests` run, because that file does `exec 3</etc/passwd`
at line 62 and never closes it — line 88 cleans up 4, 5 and 6 only. So a
`>&$(foo)` resolving to fd 3 inherits a read-only descriptor and must fail on
write. Chasing it as a temporary-environment or fd-leak bug (which is what the
sub-script's own comments are about) would have been the wrong tree.

## Verification

- `redir.tests` **3 -> 1**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1990 -> 1988 total lines. Nothing else moved, which matters here
  because the fix adds an `fflush` to every `echo`.
- `ctest` 22/22; `run_diff.sh` **305/305** with 3 new cases: the read-only
  descriptor, a writable one that must still succeed, and a plain `echo`.

## Remaining

One line: gnash emits an extra `grep: (standard input): Bad file descriptor`,
which looks like the same read-only fd 3 reaching a child's stdin rather than
an `echo` write.
