### PR TITLE
fix(cd): echo the destination of cd - only on success

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1048,6 +1048,7 @@ int change_dir(Shell &sh, const std::string &dir, bool physical, const char *cal
 }
 
 int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
+  bool print_target = false;  // `cd -' echoes where it went, on success only
   if (sh.opt_restricted) {
     std::fprintf(stderr, "%scd: restricted\n", sh.err_prefix().c_str());
     return 1;
@@ -1072,12 +1073,15 @@ int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
     }
     dir = sh.get("HOME");
   } else if (argv[i] == "-") {
+    print_target = true;  // set below, once the destination is known to be good
     if (!sh.is_set("OLDPWD")) {
       std::fprintf(stderr, "%scd: OLDPWD not set\n", sh.err_prefix().c_str());
       return 1;
     }
     dir = sh.get("OLDPWD");
-    std::printf("%s\n", dir.c_str());
+    // bash echoes the destination only once the chdir SUCCEEDS: a `cd -' to a
+    // directory that has since vanished reports the error and nothing else.
+    print_target = true;
   } else {
     dir = argv[i];
   }
@@ -1108,7 +1112,9 @@ int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
       start = e + 1;
     }
   }
-  return change_dir(sh, dir, physical);
+  int r = change_dir(sh, dir, physical);
+  if (r == 0 && print_target) std::printf("%s\n", logical_pwd(sh).c_str());
+  return r;
 }
 
 int bi_pwd(Shell &sh, const std::vector<std::string> &argv) {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -459,6 +459,10 @@ echo "L=$LINENO"'
   '{ exec 3</etc/passwd; echo hi >&3; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
   'exec 3>/dev/null; echo hi >&3; echo "rc=$?"'
   'echo normal; echo "rc=$?"'
+  # `cd -'"'"' echoes where it went, but only once the chdir SUCCEEDS.
+  '{ OLDPWD=/tmp/cd-notthere; cd -; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  'cd /tmp; cd /usr; cd -; echo "rc=$?"; pwd'
+  '{ unset OLDPWD; cd -; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #538. **`errors.tests` 3 -> 2.**

## Root cause

`cd -` printed `$OLDPWD` as soon as it resolved it, so a `cd -` to a directory
that had since vanished reported the error *and* printed the name:

```sh
OLDPWD=/tmp/cd-notthere
cd -            # diagnostic, then `/tmp/cd-notthere', then rc=1
```

The echo belongs to `cd -` **succeeding**, not to resolving `$OLDPWD`. It now
happens after the chdir returns 0 — the same place the CDPATH form already
prints from — and reports the resulting logical `$PWD` rather than the
requested name.

## Verification

- `errors.tests` **3 -> 2**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1988 -> 1987 total lines.
- `ctest` 22/22; `run_diff.sh` **308/308** with 3 new cases: the failing `cd -`,
  a successful one (which must still echo, and land in the right directory),
  and `cd -` with `$OLDPWD` unset.

## Note on the other `errors` line

The remaining difference is a `select` inside a function body reported against
line 59 by bash and 60 by gnash. I chased the rule and it does not reduce to
one: bash builds `for`/`select` with `compoundcmd_lineno[compoundcmd_top]`, and
the grammar decrements that stack a different number of times per production,
so `select` lands on its own line at top level, on the enclosing `{` inside a
function, and on the **closing** `}` inside a brace group. `for` in the same
positions reports its own line throughout. Reproducing that means emulating
bash's per-production push/pop bookkeeping rather than a stateable rule, so I
have left it — it is one line, and the machinery would be far more fragile than
what it buys.
