### PR TITLE
fix(declare): attribute a readonly failure to whoever assigned

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -149,7 +149,11 @@ std::string mb_capitalize(const std::string &s);
 
 // Apply a NAME=VALUE / NAME[i]=VALUE / NAME=(...) assignment word to the shell
 // (used by declare/local/readonly for array and scalar values).
-void apply_assignment_word(Shell &sh, const std::string &word);
+// Apply a NAME=... / NAME=(...) word.  CTX names whoever is answerable for a
+// failure: a builtin's own name, "" for no attribution, or null to let the
+// enclosing function answer -- which is what a compound assignment WORD does,
+// since bash performs it before the builtin is entered.
+void apply_assignment_word(Shell &sh, const std::string &word, const char *ctx = nullptr);
 
 }  // namespace gnash::core
 

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -625,6 +625,13 @@ class Shell {
   struct RawArg {
     std::string text;
     bool quoted = false;
+    // A COMPOUND assignment word: `NAME=(' with both the `=' and the `(' outside
+    // any quoting, as written in the source.  bash processes such a word as the
+    // command's own assignment, before the builtin it is an argument to runs --
+    // which is why a failure names the enclosing function rather than the
+    // builtin.  `NAME='(...)'' and `'NAME=(...)'' are ordinary words the builtin
+    // assigns for itself, and are false here.
+    bool compound_assign = false;
   };
   std::vector<RawArg> raw_args;
   // bash valid_alias_name: no shell metacharacters, blanks, quoting

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3256,6 +3256,17 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
                        a.substr(nend, (append ? eq - 1 : eq) - nend).c_str(), ev.c_str());
       }
       if (exval_compound) {
+        // A QUOTED compound reaches here rather than the assignment-word path
+        // above, and it IS this builtin's own assignment, so the builtin
+        // answers for it.  Checked here because array_assign cannot know who
+        // called it and must stay bare for the command machinery's own path.
+        auto rok = sh.vars.find(sh.deref(name));
+        if (rok != sh.vars.end() && rok->second.readonly) {
+          std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
+                       argv[0].c_str(), name.c_str());
+          ret = 1;
+          continue;
+        }
         Expander pex2(sh);
         auto elems2 = parse_array_elems(sh, pex2, name, integer, append, exval);
         auto ivk = sh.vars.find(name);
@@ -3284,7 +3295,20 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // compound (`declare -n array='(...)'`) is instead a nameref-target value
         // -- the unwrap above is gated on !nameref so it falls to the branch
         // below and is rejected as an invalid target.
-        apply_assignment_word(sh, a);  // NAME=(...) or NAME[i]=...
+        // A compound assignment WORD is the command's own -- bash performs it
+        // before this builtin is entered, so a failure names the enclosing
+        // function.  Otherwise the builtin is assigning for itself: it names
+        // itself when an explicit -a/-A asked for an array, and reports bare
+        // for the plain `readonly "a=(3)"' form.
+        // Without an explicit -a/-A there is no attribution at all.  With one,
+        // a compound assignment WORD is the command's own -- bash performs it
+        // before this builtin is entered, so the enclosing function answers --
+        // while a quoted compound is the builtin assigning for itself.
+        bool word_assign = i < sh.raw_args.size() && sh.raw_args[i].compound_assign;
+        const char *who = !(mk_array || mk_assoc) ? ""
+                          : word_assign           ? nullptr
+                                                  : argv[0].c_str();
+        apply_assignment_word(sh, a, who);  // NAME=(...) or NAME[i]=...
       } else if (nameref) {
         // `declare -n ref=target': store the target NAME as ref's own value.
         // Bypass Shell::set's deref so retargeting an existing nameref rewrites

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -629,7 +629,8 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
 
 namespace {
 
-void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
+void apply_array_assign(Shell &sh, Expander &ex, const Assign &a,
+                        const char *ctx = nullptr) {
   // Assigning to any part of a readonly array is an error (bash names the array,
   // not the element).  For an ELEMENT assignment the subscript validates
   // FIRST: `readonly -a c; c[-2]=4' is the bad-subscript error, so let
@@ -637,8 +638,11 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a) {
   {
     auto rit = sh.vars.find(sh.deref(a.name));
     if (!a.sub && rit != sh.vars.end() && rit->second.readonly) {
-      std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
-                   a.name.c_str());
+      const std::string &fn =
+          sh.call_stack.empty() ? std::string() : sh.call_stack.back().func;
+      std::string who = ctx ? std::string(ctx) : fn;
+      std::fprintf(stderr, "%s%s%s%s: readonly variable\n", sh.err_prefix().c_str(),
+                   who.c_str(), who.empty() ? "" : ": ", a.name.c_str());
       sh.last_status = 1;
       return;
     }
@@ -753,18 +757,32 @@ bool is_assignment_word_text(const std::string &w) {
   return i < w.size() && w[i] == '=';
 }
 
+// Is WORD a compound assignment as WRITTEN -- `NAME=(' with the `=' and the
+// `(' both outside quoting?  See Shell::RawArg::compound_assign.
+bool is_compound_assignment_source(const std::string &w) {
+  char q = 0;
+  for (size_t i = 0; i < w.size(); i++) {
+    char c = w[i];
+    if (q) { if (c == q) q = 0; else if (c == '\\' && q == '"') i++; continue; }
+    if (c == '\'' || c == '"') { q = c; continue; }
+    if (c == '\\') { i++; continue; }
+    if (c == '=') return i + 1 < w.size() && w[i + 1] == '(';
+  }
+  return false;
+}
+
 bool is_assignment_builtin(const std::string &cmd) {
   return cmd == "declare" || cmd == "typeset" || cmd == "local" ||
          cmd == "readonly" || cmd == "export";
 }
 }  // namespace
 
-void apply_assignment_word(Shell &sh, const std::string &word) {
+void apply_assignment_word(Shell &sh, const std::string &word, const char *ctx) {
   Expander ex(sh);
   Assign a;
   if (!parse_assign(word, a)) return;
   if (a.sub || a.is_array)
-    apply_array_assign(sh, ex, a);
+    apply_array_assign(sh, ex, a, ctx);
   else
     sh.set(a.name, ex.expand_assignment(a.value));
 }
@@ -1329,7 +1347,8 @@ int Executor::run_simple(const SimpleCommand *c) {
       // and parses it itself.
       if (!argv.empty() && is_assignment_builtin(argv[0]) && is_assignment_word_text(w.text)) {
         argv.push_back(w.text);
-        raw_prov.push_back({w.text, (w.flags & W_QUOTED) != 0});
+        raw_prov.push_back({w.text, (w.flags & W_QUOTED) != 0,
+                            is_compound_assignment_source(w.text)});
       } else {
         size_t before = argv.size();
         for (const std::string &f : ex.expand_args({w})) argv.push_back(f);

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -463,6 +463,16 @@ echo "L=$LINENO"'
   '{ OLDPWD=/tmp/cd-notthere; cd -; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
   'cd /tmp; cd /usr; cd -; echo "rc=$?"; pwd'
   '{ unset OLDPWD; cd -; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  # Who a readonly failure names depends on WHO performed the assignment.  With
+  # an explicit -a, an unquoted compound is the command'"'"'s own assignment word
+  # (the enclosing function answers) while a quoted one is the builtin'"'"'s own
+  # (it names itself).  Without -a there is no attribution at all.
+  '{ a=(x); readonly a; f() { readonly -a a=(2); }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ a=(x); readonly a; f() { readonly -a "a=(4)"; }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ a=(x); readonly a; f() { readonly a=(4); }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ a=(x); readonly a; f() { readonly "a=(5)"; }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ a=(x); readonly a; readonly -a a=(2); } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ a=x; readonly a; f() { readonly a=9; }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #540. **`attr.tests` 10 -> 2.**

## The rule

A failed assignment through an assignment builtin always reported
`NAME: readonly variable` bare. bash names **whoever performed the
assignment**, and that depends on how the word was written:

| form | who answers |
|---|---|
| `readonly -a a=(2)` unquoted, in a function | the **function** |
| `readonly -a 'a=(4)'` quoted | the **builtin** |
| `readonly -a a=(2)` unquoted, top level | nobody |
| `readonly a=(4)` / `readonly 'a=(5)'` — no `-a` | nobody |

An unquoted `NAME=(...)` is a compound assignment **word of the command**: bash
performs it before entering the builtin, while `this_command_name` still holds
the enclosing function's name. A quoted compound is an ordinary argument the
builtin assigns for itself. Without an explicit `-a`/`-A` there is no
attribution either way.

## Why it had to move to the executor

The distinction is a property of the **source**, not of the expanded string, and
three attempts to recover it inside `bi_declare` failed (recorded on #540):

- `Shell::raw_args[i].quoted` is true for an unquoted `a=(2)` as well — it
  records a quoted *substring*, which compound elements routinely have;
- `arraylit` is true for both forms;
- the `exval_compound` pre-check alone reaches only one of the four shapes.

So it is classified where the information still exists — in `run_simple`, beside
the existing `is_assignment_builtin()` test — by scanning the raw word for an
`=` immediately followed by `(` with both **outside quoting**, and carried on
`RawArg`. `'a=(4)'` has no unquoted `=` at all; `a='(4)'` has one but the `(` is
quoted; only `a=(2)` qualifies.

The quoted form takes a different branch (`exval_compound` → `array_assign`)
which cannot know its caller, so it is checked there rather than threading a
context parameter through that path.

## Verification

- `attr.tests` **10 -> 2**; the remainder is an unrelated value difference
  (`c=([0]="(PID)")` vs `"3"`).
- Full 83-suite sweep: **the only change**; 66 byte-perfect, 1987 -> 1979 lines.
- `ctest` 22/22; `run_diff.sh` **314/314** with a 6-shape matrix covering every
  cell of the table above, including the two that must stay **bare** — those are
  the ones earlier attempts silently regressed.

## Correcting my own earlier report

I claimed on #540 that the function-name default alone scored 8. It does not —
measured in isolation it scores 10, and the 8 came from pairing it with the
`exval_compound` check while regressing two previously-correct lines. Neither
partial was worth landing; the full classification is, because nothing regresses.
