### PR TITLE
fix(unset): -n on a variable that is not a nameref does nothing

### DIFF
--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1751,6 +1751,15 @@ void Shell::unset(const std::string &n_in, bool force, bool noref) {
   // removes the nameref variable itself.  Following the ref matches common
   // usage.  FORCE mirrors bash's unbind_variable_noref: remove the named
   // variable itself (no nameref following) even when it is readonly.
+  // `unset -n' names a NAMEREF to remove.  Applied to a variable that is not
+  // one, bash does nothing at all -- it does not fall back to unsetting it, as
+  // plain `unset' would.  gnash used to remove it, which quietly destroyed the
+  // variable and, in nameref11.sub, made a later `typeset -n' on it succeed
+  // where bash rejects the value it still holds.
+  if (noref && !force) {
+    auto nit = vars.find(n_in);
+    if (nit != vars.end() && !nit->second.nameref) return;
+  }
   std::string n = (force || noref) ? n_in : deref(n_in);
   // A nameref aimed at an array ELEMENT unsets that element, not a variable
   // literally named `v[1]' (`declare -n n=v[1]; unset n' -- nameref15.sub).

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -473,6 +473,13 @@ echo "L=$LINENO"'
   '{ a=(x); readonly a; f() { readonly "a=(5)"; }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
   '{ a=(x); readonly a; readonly -a a=(2); } 2>&1 | sed "s|^[^ ]*: ||"'
   '{ a=x; readonly a; f() { readonly a=9; }; f; } 2>&1 | sed "s|^[^ ]*: ||"'
+  # `unset -n'"'"' names a NAMEREF to remove; applied to a variable that is not one
+  # it does NOTHING, rather than falling back to unsetting it.
+  'y=2; unset -n y; declare -p y'
+  'declare -n r=t; t=5; unset -n r; { declare -p r; } 2>&1 | sed "s|^[^ ]*: ||"; declare -p t'
+  '{ y=2; unset y; declare -p y; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'unset -n nosuch; echo "rc=$?"'
+  '{ y=2; typeset -n y; unset -n y; typeset -n y; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #542. **`nameref.tests` 17 -> 11.**

## Root cause

`unset -n NAME` removed the variable when NAME was not a nameref:

```sh
y=2; unset -n y; declare -p y     # bash: declare -- y="2"   gnash: y: not found
```

bash's `-n` names a **nameref** to remove; finding none, it stops rather than
falling back to a plain unset. Plain `unset y`, and `unset -n` on a real nameref
(remove the reference, spare the target), were both already correct — only this
case fell through.

## Why this was worth chasing

The visible symptom was nowhere near the bug. In `nameref11.sub`:

```
59  y=2
65  typeset -n y     # fails: `2' is not a valid nameref target
68  unset -n y       # bash: no-op, y keeps "2".  gnash: y deleted
70  typeset -n y     # bash: fails again on the "2" still there
                     # gnash: y is gone, so this SUCCEEDS
71  y=2              # gnash errors here instead, with a different message
```

I had this filed as a line-attribution problem — bash reporting a diagnostic
against the *declaring* line rather than the assigning one — and had sketched
two designs for it: recording the declaring builtin on the `Variable`, and
emulating bash's stale `this_command_name`. Both would have been wasted, and
neither would have worked. gnash handles the `typeset -n` conversion correctly
in isolation, message and status included; the variable had simply been deleted
three lines earlier, so there was nothing left to reject.

The estimate moved with the diagnosis: 17 -> 16 for the message-plumbing idea,
17 -> 13 once the real cause was known, **17 -> 11** measured.

## Verification

- `nameref.tests` **17 -> 11**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1979 -> 1973 lines.
- `ctest` 22/22; `run_diff.sh` **319/319** with 5 new cases: the non-nameref
  no-op, a real nameref (reference gone, target kept), plain `unset`, an
  unset name, and the `typeset -n` / `unset -n` / `typeset -n` sequence that
  reproduces the suite's chain.
