### PR TITLE
fix(exec): name exec when its {var} redirection cannot assign

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -136,7 +136,8 @@ static int open_redir_output(Shell &sh, const std::string &fn, bool clobbering) 
 }
 
 // Apply one redirect in-process; returns false on error.
-bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
+bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
+                    const char *fdvar_ctx = nullptr) {
   Expander ex(sh);
   int target_fd = r.source_fd;
   // Install NEWFD as FD, saving FD's previous state, and consume NEWFD.  When
@@ -206,7 +207,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
         ok = !(it != sh.vars.end() && it->second.readonly);
         if (ok) sh.array_set(base, sub, std::to_string(f));
       } else {
-        ok = sh.set(r.fd_var, std::to_string(f));
+        ok = sh.set(r.fd_var, std::to_string(f), fdvar_ctx);
       }
       if (!ok) {
         std::fprintf(stderr, "%s%s: cannot assign fd to variable\n", sh.err_prefix().c_str(),
@@ -446,9 +447,10 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved) {
   return true;
 }
 
-bool apply_redirects(Shell &sh, const std::vector<Redirect> &redirs, std::vector<SavedFd> &saved) {
+bool apply_redirects(Shell &sh, const std::vector<Redirect> &redirs, std::vector<SavedFd> &saved,
+                     const char *fdvar_ctx = nullptr) {
   for (const Redirect &r : redirs)
-    if (!apply_redirect(sh, r, saved)) return false;
+    if (!apply_redirect(sh, r, saved, fdvar_ctx)) return false;
   return true;
 }
 
@@ -1517,7 +1519,12 @@ int Executor::run_simple(const SimpleCommand *c) {
   (void)dummy;
 
   std::vector<SavedFd> saved;
-  if (!apply_redirects(sh_, c->redirects, saved)) {
+  // A `{var}' target that cannot be assigned is blamed on `exec' when the
+  // redirection is exec's own; the same redirection on a compound command is
+  // reported bare (bash).
+  const char *fdvar_ctx =
+      (!argv.empty() && argv[0] == "exec") ? "exec" : nullptr;
+  if (!apply_redirects(sh_, c->redirects, saved, fdvar_ctx)) {
     restore_fds(saved);
     return (sh_.last_status = 1);
   }

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -480,6 +480,11 @@ echo "L=$LINENO"'
   '{ y=2; unset y; declare -p y; } 2>&1 | sed "s|^[^ ]*: ||"'
   'unset -n nosuch; echo "rc=$?"'
   '{ y=2; typeset -n y; unset -n y; typeset -n y; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  # A `{var}'"'"' redirection target that cannot be assigned is blamed on `exec'"'"' when
+  # the redirection is exec'"'"'s own; on a compound command it is reported bare.
+  '{ declare -n r; exec {r}>/dev/null; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  '{ declare -n r; { echo hi; } {r}>/dev/null; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
+  'exec {fd}>/dev/null; echo "ok=$((fd>2))"; exec {fd}>&-'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #544. **`nameref.tests` 11 -> 9.**

## Root cause

```sh
declare -n r; exec {r}>/dev/null
```

reported `` `10': not a valid identifier `` where bash reports
`` exec: `10': not a valid identifier ``.

The same redirection on a compound command (`{ echo hi; } {r}>/dev/null`) is
reported **bare** in both shells, so the attribution belongs to *exec's own*
redirection rather than to the `{var}` assignment as such.
`apply_redirect`/`apply_redirects` now take the context to hand to
`Shell::set`, and `run_simple` supplies `"exec"` only when that is the command
word.

## Verification

- `nameref.tests` **11 -> 9**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1973 -> 1971 lines.
- `ctest` 22/22; `run_diff.sh` **322/322** with 3 new cases: exec's own
  redirection, the compound-command form that must stay bare, and a successful
  `{fd}` allocation.
