### PR TITLE
fix(expand): indirect through ${!ref[sub]} on a nameref

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2253,6 +2253,30 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       while (q < b.size() && (std::isalnum(static_cast<unsigned char>(b[q])) || b[q] == '_')) q++;
       iname = b.substr(1, q - 1);
     }
+    // `${!ref[sub]}' where REF is a NAMEREF indirects through that element of
+    // the target array; an element holding no name to reference is bash's
+    // `NAME[sub]: invalid indirect expansion'.  Checked before the gate below,
+    // which otherwise drops the whole form through to the generic `${...}'
+    // path -- where a leading `!' reads as the $! special parameter and the
+    // expansion silently becomes the last background pid.  `[@]'/`[*]' are the
+    // list-the-indices forms and are left to the array machinery, and a plain
+    // (non-nameref) variable subscripts to nothing without complaint, as bash.
+    {
+      auto nrit = sh.vars.find(iname);
+      if (nrit != sh.vars.end() && nrit->second.nameref && q + 2 < b.size() &&
+          b[q] == '[' && b.back() == ']' && b[q + 1] != '@' && b[q + 1] != '*') {
+        std::string sub = b.substr(q + 1, b.size() - q - 2);
+        std::string elem = sh.array_get(sh.deref(iname), sub);
+        if (elem.empty()) {
+          std::fprintf(stderr, "%s%s%s: invalid indirect expansion\n", sh.err_prefix().c_str(),
+                       iname.c_str(), b.substr(q).c_str());
+          sh.arith_error = true;
+          return std::string();
+        }
+        return length ? std::to_string(mb_charlen(expand_brace_body(ex, sh, elem, dq)))
+                      : expand_brace_body(ex, sh, elem, dq);
+      }
+    }
     if (q == b.size() || b[q] != '[') {
       if (q + 1 == b.size() && (b[q] == '*' || b[q] == '@')) {
         std::string names;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -485,6 +485,13 @@ echo "L=$LINENO"'
   '{ declare -n r; exec {r}>/dev/null; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
   '{ declare -n r; { echo hi; } {r}>/dev/null; } 2>&1 | sed "s|^[^ ]*: ||"; echo "rc=$?"'
   'exec {fd}>/dev/null; echo "ok=$((fd>2))"; exec {fd}>&-'
+  # `${!ref[sub]}'"'"' on a NAMEREF indirects through that element of the target.
+  # An element naming nothing is an invalid indirect expansion; `[@]'"'"'/`[*]'"'"' stay
+  # the list-the-indices forms, and a plain variable subscripts to nothing.
+  '{ declare -n foo=bar; echo ${!foo[2]}; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'declare -n foo=bar; bar=(a q c); q=HIT; echo "${!foo[1]}"'
+  'declare -n foo=bar; bar=(x y z); echo "${!foo[@]}"'
+  'foo=bar; echo "[${!foo[2]}]"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #546. **`nameref.tests` 9 -> 7.**

## Root cause

`${!ref[sub]}` on a nameref silently expanded to the **last background pid**.

The `${!name...}` handler is gated on `q == b.size() || b[q] != '['`, so the
subscripted form was dropped through to the generic `${...}` path — where the
leading `!` reads as the `$!` special parameter. `nameref11.sub` hits this
having started a coproc earlier in the file, which is why the suite showed a pid
where bash reports `foo[2]: invalid indirect expansion`.

That gate is also why my first attempt at this failed: I added the check *after*
it, so the code never ran. The fix is to test before the gate.

## The rule

For a nameref, `${!ref[sub]}` indirects through that element of the target
array — the element's value is the name to expand. An element holding no name is
`NAME[sub]: invalid indirect expansion`, naming the subscripted form.

`[@]`/`[*]` remain the list-the-indices forms, and a plain (non-nameref)
variable subscripts to nothing without complaint. Both verified against bash
rather than assumed — an earlier guess that the error applied to *any* nameref
subscript was wrong: `bar=(x y z); ${!foo[1]}` is legal and expands through
`bar[1]`.

## Verification

- `nameref.tests` **9 -> 7**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1971 -> 1969 lines.
- `ctest` 22/22; `run_diff.sh` **326/326** with 4 new cases: the error, a
  successful indirection through an element (`bar=(a q c); q=HIT` -> `HIT`,
  which pins that it really indirects rather than just erroring), `[@]`, and the
  plain-variable form that must stay quiet.

## Not fixed here

bash **unwinds the command list** on an invalid indirect expansion; gnash fails
only the command. Pre-existing and shared with the unsubscripted `${!bar}` form,
so out of scope for this change — noted on #546, along with
`foo=bad-name; echo ${!foo}` printing `name` where bash reports
`bad-name: invalid variable name`.
