### PR TITLE
fix(expand): name the subscript as written in a set -u error

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2479,8 +2479,10 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     // `set -u': an unset ELEMENT is an unbound-variable error naming the
     // element (`narray[4]: unbound variable'), like param_value's for scalars.
     if (!set && sh.opt_nounset && !defaulting_op && tsub != "@" && tsub != "*") {
+      // bash names the subscript as WRITTEN, not the index it evaluated to:
+      // `a=() k=; "${a[k]}"' reports `a[k]', not `a[0]'.
       std::fprintf(stderr, "%s%s[%s]: unbound variable\n", sh.err_prefix().c_str(),
-                   name.c_str(), tsub.c_str());
+                   name.c_str(), sub.c_str());
       sh.exiting = true;
       sh.exit_status = 127;
       return std::string();

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -492,6 +492,12 @@ echo "L=$LINENO"'
   'declare -n foo=bar; bar=(a q c); q=HIT; echo "${!foo[1]}"'
   'declare -n foo=bar; bar=(x y z); echo "${!foo[@]}"'
   'foo=bar; echo "[${!foo[2]}]"'
+  # Under `set -u'"'"' an unset element is named by the subscript as WRITTEN, not by
+  # the index it evaluated to.
+  '{ set -u; a=() k=; "${a[k]}"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ set -u; a=(); "${a[0]}"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ set -u; declare -A m; m=(); "${m[key]}"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'set -u; a=(1 2); k=1; echo "${a[k]}"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #548. **`nameref.tests` 7 -> 5.**

## Root cause

```sh
a=() k=; "${a[k]}"      # bash: a[k]: unbound variable   gnash: a[0]: ...
```

`k` is empty, so the subscript evaluates to 0 and gnash reported the index it
computed. bash names the subscript as the script wrote it — the text the reader
can actually find. The raw form was already to hand (it is what the adjacent
`bad array subscript` diagnostic prints); the nounset message was using the
evaluated `tsub` instead.

## Verification

- `nameref.tests` **7 -> 5**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1969 -> 1967 lines.
- `ctest` 22/22; `run_diff.sh` **330/330** with 4 new cases: the evaluated-vs-
  written subscript, a literal index (where the two coincide, so it must not
  change), an associative key, and a *set* element that must still expand
  normally rather than erroring.

## Not fixed here

`declare -n r='a[k]'; : "$r"` under `set -u` with both `a` and `k` unset: bash
reports `k: unbound variable` — the subscript's own nounset failure firing while
the reference is resolved — where gnash reports `r`. gnash gets this right when
the base array exists (though it then reports twice), so the gap is that a
wholly unset base short-circuits before the subscript is evaluated. That is the
last `nameref` line of this kind and is on #548.
