### PR TITLE
fix(nameref): report a set -u failure in a subscript against itself

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -636,6 +636,10 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
   if (sh_.get_if_set(name, v)) return v;
   if (sh_.dynamic_var(name, v)) return v;  // RANDOM/SECONDS/LINENO/BASHPID/EPOCH*
   set = false;
+  // An unbound variable found while RESOLVING this one (a `set -u' failure in a
+  // nameref's subscript) has already been reported against its own name; do not
+  // blame the nameref for it as well.
+  if (sh_.exiting) return std::string();
   if (sh_.opt_nounset && !defaulting_op) {
     std::fprintf(stderr, "%s%s: unbound variable\n", sh_.err_prefix().c_str(), name.c_str());
     sh_.exiting = true;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1438,6 +1438,19 @@ bool Shell::make_local(const std::string &n, bool inherit_force) {
 bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   std::string base, sub;
   if (nameref_elt(n_in, base, sub)) {
+    // Resolving the reference EVALUATES the subscript, and under `set -u' an
+    // unset variable inside it is the error bash reports -- naming that
+    // variable, not the nameref.  Evaluate it once, here: is_set() skips the
+    // evaluation entirely when the base array does not exist (so the failure
+    // was lost and the nameref got blamed instead), while array_get() would
+    // otherwise evaluate it a second time and report twice.  An associative
+    // subscript is a KEY, not arithmetic, so it is left alone.
+    auto bit = vars.find(base);
+    if (bit == vars.end() || bit->second.kind != VarKind::Assoc) {
+      bool sok = true;
+      (void)eval_arith(const_cast<Shell &>(*this), sub, &sok);
+      if (exiting) return false;
+    }
     if (!is_set(n_in)) return false;
     out = array_get(base, sub);
     return true;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -498,6 +498,15 @@ echo "L=$LINENO"'
   '{ set -u; a=(); "${a[0]}"; } 2>&1 | sed "s|^[^ ]*: ||"'
   '{ set -u; declare -A m; m=(); "${m[key]}"; } 2>&1 | sed "s|^[^ ]*: ||"'
   'set -u; a=(1 2); k=1; echo "${a[k]}"'
+  # Resolving a nameref EVALUATES its subscript, so a `set -u'"'"' failure there is
+  # reported against that variable -- once -- and not against the nameref.  An
+  # associative subscript is a key, not arithmetic, so the nameref is blamed.
+  '{ set -u; declare -n r="a[k]"; : "$r"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  '{ set -u; a=(1 2); declare -n r="a[k]"; : "$r"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'set -u; a=(1 2); k=1; declare -n r="a[k]"; echo "$r"'
+  '{ set -u; declare -A m; declare -n r="m[key]"; : "$r"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  'set -u; declare -A m=([key]=V); declare -n r="m[key]"; echo "$r"'
+  '{ set -u; unset zz; : "$zz"; } 2>&1 | sed "s|^[^ ]*: ||"'
 )
 
 fails=0


### PR DESCRIPTION
Completes the second half of #548. **`nameref.tests` 5 -> 3.**

## Two symptoms, one cause

```sh
$ gnash -uc 'declare -n r="a[k]"; : "$r"'
gnash: line 1: r: unbound variable          # bash: k: unbound variable

$ gnash -uc 'a=(1 2); declare -n r="a[k]"; : "$r"'
gnash: line 1: k: unbound variable
gnash: line 1: k: unbound variable          # bash reports it once
```

Resolving a nameref to an array element **evaluates its subscript**, and under
`set -u` an unset variable in that subscript is what bash reports -- naming that
variable, not the nameref.

`Shell::is_set()` returns early when the base array does not exist, *before*
reaching its `eval_arith(sub)` -- so with `a` unset the failure never happened
and the nameref got blamed instead. When the base *does* exist, `is_set()`
evaluates the subscript and then `get_if_set()` calls `array_get()`, which
evaluates it again -- hence the duplicate.

Evaluating once in `get_if_set()`, up front, fixes both: the missing report
because it no longer depends on the base existing, and the duplicate because the
first failure returns immediately.

Two details that needed care:

- An **associative** subscript is a key, not arithmetic, so it is left alone --
  `declare -A m; declare -n r="m[key]"` correctly still blames `r`.
- Once the subscript has reported, the caller must not blame the nameref as
  well, so the scalar `set -u` path returns early when the shell is already
  unwinding.

## Verification

- `nameref.tests` **5 -> 3**. Full 83-suite sweep: the only change; 66
  byte-perfect, 1967 -> 1965 lines.
- `ctest` 22/22; `run_diff.sh` **336/336** with 6 new cases: both symptoms, a
  *successful* resolution through a subscript variable, both associative forms,
  and a plain `set -u` failure -- the last two pinning that the key gate and the
  unwind-suppression did not break ordinary behaviour.
