### PR TITLE
perf(expand): skip expansion for an assignment that expands to itself

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3602,7 +3602,18 @@ std::string Expander::expand_no_split(const std::string &text, bool do_glob, boo
   return joined;
 }
 
+// Nothing in TEXT can be touched by assignment-context expansion: no parameter
+// or command substitution, no arithmetic, no quoting to remove, no tilde, and
+// no process substitution (`<(cmd)' / `>(cmd)', which expand_no_split performs
+// by default).  A value made only of ordinary characters expands to itself, so
+// the whole pipeline can be skipped -- worth doing because string building in a
+// loop hits this path once per iteration.
+static bool assignment_expands_to_itself(const std::string &s) {
+  return s.find_first_of("$`\\~'\"<>") == std::string::npos;
+}
+
 std::string Expander::expand_assignment(const std::string &text) {
+  if (assignment_expands_to_itself(text)) return text;
   return expand_no_split(tilde_assign(sh_, text));
 }
 

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -507,6 +507,21 @@ echo "L=$LINENO"'
   '{ set -u; declare -A m; declare -n r="m[key]"; : "$r"; } 2>&1 | sed "s|^[^ ]*: ||"'
   'set -u; declare -A m=([key]=V); declare -n r="m[key]"; echo "$r"'
   '{ set -u; unset zz; : "$zz"; } 2>&1 | sed "s|^[^ ]*: ||"'
+  # An assignment value made only of ordinary characters expands to itself and
+  # skips the expansion pipeline.  These pin what must NOT take that path --
+  # process substitution in particular, which has no `$'"'"' or quote to give it away.
+  'v=<(echo hi); echo "${v%%[0-9]*}"'
+  'v=plainvalue; echo "$v"'
+  'x=9; v=$x-lit; echo "$v"'
+  'v=~; [ "$v" = "$HOME" ] && echo tilde-ok'
+  'v=a\ b; echo "[$v]"'
+  # ...and what an append must still honour, whatever fast path it takes.
+  '{ readonly s=a; s+=b; } 2>&1 | sed "s|^[^ ]*: ||"; echo "[$s]"'
+  'declare -l s=A; s+=BC; echo "[$s]"'
+  's=a; s+=b true; echo "[$s]"'
+  'declare -a v=(1 2); v+=x; declare -p v'
+  'PATH=/bin; PATH+=:/xyz; echo "$PATH"'
+  'declare -n r=t; t=a; r+=b; echo "[$t]"'
 )
 
 fails=0


### PR DESCRIPTION
Adapted from **#515** by @Gustav-Simonsson, which proposed three fast paths for
scalar assignment and append. This takes the first, with a correctness fix, and
explains below why the other two are not taken.

## What is taken

An assignment value made only of ordinary characters expands to itself, so
`expand_assignment()` can return it untouched. Building a string in a loop hits
this once per iteration: **~9%** on a 60k-iteration `s+=xyz` benchmark (0.67s ->
0.61s).

**The predicate needed widening.** #515 tested for `$`, a backquote, a
backslash, a tilde and quotes. `expand_no_split()` takes `do_procsub = true` by
default, so

```sh
v=<(echo hi)
```

contains none of those characters and would have stopped expanding — the value
would become the literal `<(echo hi)` instead of `/dev/fd/N`. `<` and `>` are
now rejected too. In practice an unquoted `<`/`>` in an assignment RHS is either
process substitution or was already escaped (and so caught by the backslash),
so this costs nothing on the fast path.

## What is not taken, and why

Both remaining fast paths write around `Shell::set()`, which is where readonly
enforcement, case-folding attributes, the special-variable hooks and nameref
resolution live. Their guards test only for a nameref and the integer
attribute. Concretely, each of these is correct today and would regress:

| case | expected | with the proposed append fast path |
|---|---|---|
| `readonly s=a; s+=b` | error, `s` unchanged | silently appends |
| `declare -l s=A; s+=BC` | `abc` | case-folding skipped |
| `s=a; s+=b true; echo $s` | `a` — prefix assignments are **temporary** | `ab` leaks to the caller |
| `PATH=/bin; PATH+=:/xyz` | hooks run | hooks skipped |

The third — reading `vit->second.value` directly for anything that is not a
nameref — is wrong for an array, where the old value of `v+=x` is element 0, not
the variable's scalar field: `declare -a v=(1 2); v+=x` must give
`([0]="1x" [1]="2")`.

The prefix-assignment one is the most serious: the fast path sets
`fast_path_applied` and skips `assigns.emplace_back(...)`, so a temporary
assignment becomes permanent.

Worth noting for anyone reading the benchmark in #515: most of the 42% it
reports comes from these two paths, not from the one taken here. A safe version
would need the guards to cover readonly, every attribute, the special-variable
set and the temporary/permanent distinction — at which point little of the saved
work remains.

## Verification

- `ctest` 22/22; `run_diff.sh` **347/347**, with **11 new cases**: the fast path
  itself, four values that must *not* take it (process substitution, `$`, tilde,
  backslash), and the six append semantics tabulated above — so a future attempt
  at the same optimization has to keep them.
- Full 83-suite sweep: no suite changed, 66 byte-perfect, 1965 lines.
