### PR TITLE
fix(type): hash-table consultation, hit counts, command -v aliases, ANSI-C display

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -220,6 +220,7 @@ class Shell {
   bool login_shell = false;                  // logout only works in a login shell
   std::map<std::string, std::string> hashed;  // `hash': command name -> full path
   std::vector<std::string> hashed_seq;        // insertion order (bash hash-walk)
+  std::map<std::string, int> hashed_hits;     // `hash' hits column (times_found)
   std::map<std::string, bool> shopt_opts;     // `shopt' option states
   std::set<std::string> disabled_builtins;    // `enable -n': builtins turned off
   std::map<std::string, std::string> aliases;  // `alias': name -> expansion
@@ -230,6 +231,16 @@ class Shell {
   void hash_remember(const std::string &name, const std::string &path) {
     if (!hashed.count(name)) hashed_seq.push_back(name);
     hashed[name] = path;
+    hashed_hits[name] = 0;  // (re)insertion resets times_found (bash phash_insert)
+  }
+  // Look NAME up in the command hash table.  A hit bumps the hits counter --
+  // bash's hash_search increments times_found on every successful lookup, so
+  // `type', `command -v', and command execution all count as hits.
+  const std::string *hash_lookup(const std::string &name) {
+    auto it = hashed.find(name);
+    if (it == hashed.end()) return nullptr;
+    hashed_hits[name]++;
+    return &it->second;
   }
   void alias_remember(const std::string &name, const std::string &val) {
     if (!aliases.count(name)) alias_seq.push_back(name);

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -606,10 +606,197 @@ struct MPrinter {
   }
 };
 
+// bash's lexer expands `$'...'' (ansicstr) and `$"..."' at read_token_word
+// time, so a reconstructed word never shows the `$...' source: `v=$'\001''
+// displays as `v='^A'' and `v=$"msg"' as `v="msg"'.  gnash keeps the source
+// text in the AST, so the printer performs the same expansion.
+
+// bash's sh_single_quote: wrap S in single quotes, ' -> '\''.
+std::string ansi_single_quote(const std::string &s) {
+  std::string out = "'";
+  for (char c : s) {
+    if (c == '\'') out += "'\\''";
+    else out += c;
+  }
+  out += '\'';
+  return out;
+}
+
+void utf8_append(std::string &out, unsigned long cp) {
+  if (cp < 0x80) out += static_cast<char>(cp);
+  else if (cp < 0x800) {
+    out += static_cast<char>(0xC0 | (cp >> 6));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  } else if (cp < 0x10000) {
+    out += static_cast<char>(0xE0 | (cp >> 12));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  } else {
+    out += static_cast<char>(0xF0 | (cp >> 18));
+    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out += static_cast<char>(0x80 | (cp & 0x3F));
+  }
+}
+
+// Decode the escapes of an ANSI-C string body (the text between $' and '),
+// bash's ansicstr: unknown escapes keep the backslash, a NUL truncates.
+std::string ansi_c_decode(const std::string &s) {
+  std::string out;
+  size_t i = 0;
+  auto hexval = [](char c) -> int {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+  };
+  while (i < s.size()) {
+    if (s[i] != '\\') { out += s[i++]; continue; }
+    if (i + 1 >= s.size()) { out += '\\'; break; }
+    char e = s[i + 1];
+    i += 2;
+    char c = 0;
+    switch (e) {
+      case 'a': c = '\a'; break;
+      case 'b': c = '\b'; break;
+      case 'e': case 'E': c = '\033'; break;
+      case 'f': c = '\f'; break;
+      case 'n': c = '\n'; break;
+      case 'r': c = '\r'; break;
+      case 't': c = '\t'; break;
+      case 'v': c = '\v'; break;
+      case '\\': case '\'': case '"': case '?': c = e; break;
+      case 'x': case 'u': case 'U': {
+        int maxd = e == 'x' ? 2 : e == 'u' ? 4 : 8;
+        unsigned long v = 0;
+        int nd = 0;
+        while (nd < maxd && i < s.size() && hexval(s[i]) >= 0) {
+          v = v * 16 + hexval(s[i]);
+          i++; nd++;
+        }
+        if (nd == 0) { out += '\\'; out += e; continue; }  // no digits: literal
+        if (e == 'x') c = static_cast<char>(v);
+        else { utf8_append(out, v); continue; }
+        break;
+      }
+      case '0': case '1': case '2': case '3':
+      case '4': case '5': case '6': case '7': {
+        int v = e - '0', nd = 1;
+        while (nd < 3 && i < s.size() && s[i] >= '0' && s[i] <= '7') {
+          v = v * 8 + (s[i] - '0');
+          i++; nd++;
+        }
+        c = static_cast<char>(v);
+        break;
+      }
+      case 'c': {
+        if (i >= s.size()) { out += "\\c"; continue; }
+        char ch = s[i++];
+        if (ch == '\\' && i < s.size() && s[i] == '\\') i++;  // \c\\ = ctrl-backslash
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)) & 0x1f);
+        break;
+      }
+      default: out += '\\'; out += e; continue;
+    }
+    if (c == '\0') return out;  // NUL truncates the decoded string (C string)
+    out += c;
+  }
+  return out;
+}
+
+// Expand $'...' / $"..." spans of a word into their lexed display form,
+// tracking the quoting contexts bash's lexer distinguishes: not inside '...'
+// or `...` or after $$; active at top level, inside "..."-embedded $(...),
+// inside ${...} and inside $(...).
+std::string ansi_expand_word(const std::string &w) {
+  std::string out;
+  size_t i = 0;
+  while (i < w.size()) {
+    char c = w[i];
+    if (c == '\\') {  // escaped char: copy both
+      out += c;
+      if (i + 1 < w.size()) out += w[i + 1];
+      i = std::min(i + 2, w.size());
+      continue;
+    }
+    if (c == '\'') {  // single-quoted span: verbatim
+      size_t j = w.find('\'', i + 1);
+      if (j == std::string::npos) { out += w.substr(i); break; }
+      out += w.substr(i, j - i + 1);
+      i = j + 1;
+      continue;
+    }
+    if (c == '`') {  // backquotes are re-lexed at expansion time: verbatim
+      out += c;
+      i++;
+      while (i < w.size()) {
+        if (w[i] == '\\' && i + 1 < w.size()) { out += w[i]; out += w[i + 1]; i += 2; continue; }
+        out += w[i];
+        if (w[i++] == '`') break;
+      }
+      continue;
+    }
+    if (c == '"') {  // double quotes: $'..' stays, but a nested $(..) re-lexes
+      out += c;
+      i++;
+      while (i < w.size()) {
+        if (w[i] == '\\' && i + 1 < w.size()) { out += w[i]; out += w[i + 1]; i += 2; continue; }
+        if (w[i] == '"') { out += '"'; i++; break; }
+        if (w[i] == '$' && i + 1 < w.size() && w[i + 1] == '(') {
+          size_t j = i + 1;
+          for (int depth = 0; j < w.size(); j++) {
+            if (w[j] == '(') depth++;
+            else if (w[j] == ')' && --depth == 0) break;
+          }
+          if (j >= w.size()) { out += w.substr(i); i = w.size(); break; }
+          out += "$(";
+          out += ansi_expand_word(w.substr(i + 2, j - (i + 2)));
+          out += ')';
+          i = j + 1;
+          continue;
+        }
+        out += w[i++];
+      }
+      continue;
+    }
+    if (c == '$' && i + 1 < w.size()) {
+      char n = w[i + 1];
+      if (n == '$') { out += "$$"; i += 2; continue; }  // PID, not a quote opener
+      if (n == '\'') {
+        size_t j = i + 2;  // find the closing ', honoring backslash escapes
+        while (j < w.size() && w[j] != '\'') j += (w[j] == '\\' && j + 1 < w.size()) ? 2 : 1;
+        if (j >= w.size()) { out += w.substr(i); break; }
+        out += ansi_single_quote(ansi_c_decode(w.substr(i + 2, j - (i + 2))));
+        i = j + 1;
+        continue;
+      }
+      if (n == '"') { i++; continue; }  // $"..." -> "..." (locale string)
+      if (n == '(') {  // re-lexed context: expand inside
+        size_t j = i + 1;
+        for (int depth = 0; j < w.size(); j++) {
+          if (w[j] == '(') depth++;
+          else if (w[j] == ')' && --depth == 0) break;
+        }
+        if (j >= w.size()) { out += w.substr(i); break; }
+        out += "$(";
+        out += ansi_expand_word(w.substr(i + 2, j - (i + 2)));
+        out += ')';
+        i = j + 1;
+        continue;
+      }
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 // Re-render `$(...)' command substitutions in W through the parser, as bash
 // prints the parsed form ("$( echo hi )" becomes "$(echo hi)").  On any parse
-// trouble the original text is kept.
-std::string canonical_word(const std::string &w) {
+// trouble the original text is kept.  ANSI-C / locale strings are expanded
+// first, as bash's lexer has already done that by the time it prints.
+std::string canonical_word(const std::string &w_in) {
+  std::string w = ansi_expand_word(w_in);
   size_t at = w.find("$(");
   if (at == std::string::npos) return w;
   std::string out;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -3810,10 +3810,16 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
   for (; i < argv.size(); i++) {
     const std::string &n = argv[i];
 
-    // -P forces a PATH search and ignores everything else.
+    // -P skips aliases/keywords/functions/builtins -- but NOT the hash table:
+    // describe_command's phash_search guard is `all == 0 || CDESC_FORCE_PATH',
+    // so `type -P NAME' reports a hashed path first, then (under -a) the $PATH
+    // matches as well.
     if (fP) {
+      const std::string *hp = sh.hash_lookup(n);
+      if (hp) std::printf("%s\n", ft ? "file" : hp->c_str());
+      if (hp && !fa) continue;
       auto files = find_all_in_path(sh, n);
-      if (files.empty()) { st = 1; continue; }
+      if (files.empty()) { if (!hp) st = 1; continue; }
       for (size_t k = 0; k < (fa ? files.size() : 1u); k++)
         std::printf("%s\n", ft ? "file" : files[k].c_str());
       continue;
@@ -3833,6 +3839,14 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
       locs.insert(locs.end() - ((!ff && sh.functions.count(n)) ? 1 : 0), {'b', {}});
     else if (have_b)
       locs.push_back({'b', {}});
+    // The hash table is consulted only when none of the above matched and this
+    // is not `type -a' (bash returns from describe_command before reaching
+    // phash_search otherwise); the lookup itself counts as a hash-table hit.
+    // A hashed entry needs no existence check -- `hash -p /nosuch x; type x'
+    // reports the bogus path (bash).
+    if (locs.empty() && !fa) {
+      if (const std::string *hp = sh.hash_lookup(n)) locs.push_back({'H', *hp});
+    }
     for (const std::string &f : find_all_in_path(sh, n)) locs.push_back({'F', f});
 
     if (locs.empty()) {
@@ -3857,7 +3871,7 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
                           : L.kind == 'b' ? "builtin"
                                           : "file");
       } else if (fp) {
-        if (L.kind == 'F') std::printf("%s\n", L.text.c_str());
+        if (L.kind == 'F' || L.kind == 'H') std::printf("%s\n", L.text.c_str());
       } else {
         switch (L.kind) {
           case 'a':
@@ -3871,6 +3885,9 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
           case 'b':
             std::printf("%s is a %sshell builtin\n", n.c_str(),
                         (sh.opt_posix && is_special_builtin(n)) ? "special " : "");
+            break;
+          case 'H':
+            std::printf("%s is hashed (%s)\n", n.c_str(), L.text.c_str());
             break;
           case 'F': std::printf("%s is %s\n", n.c_str(), L.text.c_str()); break;
         }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7125,13 +7125,23 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       t.insert(t.end(), argv.begin() + i, argv.end());
       st = bi_type(sh, t);
     } else if (desc_v) {
-      // For each name print the name (function/builtin/keyword) or its full path
-      // (external), 0 if all resolved, 1 otherwise.
+      // For each name print the alias definition (reusable form), the name
+      // (function/builtin/keyword), or the full path (hashed, then $PATH);
+      // 0 if all resolved, 1 otherwise.  Like `type', an alias is reported
+      // only when aliases would actually expand, and a hashed path is
+      // reported (and counted as a hit) before any $PATH search.
+      bool aliases_on = sh.interactive;
+      auto eit = sh.shopt_opts.find("expand_aliases");
+      if (eit != sh.shopt_opts.end() && eit->second) aliases_on = true;
       st = (i < argv.size()) ? 0 : 1;
       for (size_t j = i; j < argv.size(); j++) {
         const std::string &n = argv[j];
-        if (sh.functions.count(n) || is_builtin_name(n) || is_reserved_word(n)) {
+        if (aliases_on && sh.aliases.count(n)) {
+          std::printf("alias %s=%s\n", n.c_str(), alias_quote(sh.aliases.at(n)).c_str());
+        } else if (sh.functions.count(n) || is_builtin_name(n) || is_reserved_word(n)) {
           std::printf("%s\n", n.c_str());
+        } else if (const std::string *hp = sh.hash_lookup(n)) {
+          std::printf("%s\n", hp->c_str());
         } else {
           std::string p = find_in_path(sh, n);
           if (!p.empty()) std::printf("%s\n", p.c_str());

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4884,7 +4884,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
     bool consumed = false;
     for (size_t k = 1; k < a.size(); k++) {
       char o = a[k];
-      if (o == 'r') { sh.hashed.clear(); sh.hashed_seq.clear(); expunge = true; }
+      if (o == 'r') { sh.hashed.clear(); sh.hashed_seq.clear(); sh.hashed_hits.clear(); expunge = true; }
       else if (o == 'l') list_l = true;
       else if (o == 'd') del_d = true;
       else if (o == 't') print_t = true;
@@ -4942,7 +4942,11 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
         std::printf("builtin hash -p %s %s\n", sh.hashed.at(k).c_str(), k.c_str());
     else {
       std::printf("hits\tcommand\n");
-      for (const auto &k : sh.hashed_order()) std::printf("%4d\t%s\n", 0, sh.hashed.at(k).c_str());
+      for (const auto &k : sh.hashed_order()) {
+        auto h = sh.hashed_hits.find(k);
+        std::printf("%4d\t%s\n", h == sh.hashed_hits.end() ? 0 : h->second,
+                    sh.hashed.at(k).c_str());
+      }
     }
     return 0;
   }
@@ -4950,6 +4954,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
   for (; i < argv.size(); i++) {
     const std::string &n = argv[i];
     if (del_d) {  // `hash -d NAME': error if NAME is not hashed
+      sh.hashed_hits.erase(n);
       if (sh.hashed.erase(n) == 0) {
         std::fflush(stdout);
         std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str());
@@ -4958,12 +4963,12 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
       continue;
     }
     if (print_t) {
-      auto it = sh.hashed.find(n);
+      const std::string *hp = sh.hash_lookup(n);  // a -t lookup counts as a hit
       // With -l too, -t prints the reusable form (`hash -lt cat' ->
       // `builtin hash -p /path cat'), as bash does.
-      if (it == sh.hashed.end()) { std::fflush(stdout); std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str()); st = 1; }
-      else if (list_l) std::printf("builtin hash -p %s %s\n", it->second.c_str(), n.c_str());
-      else std::printf("%s\n", it->second.c_str());
+      if (hp == nullptr) { std::fflush(stdout); std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str()); st = 1; }
+      else if (list_l) std::printf("builtin hash -p %s %s\n", hp->c_str(), n.c_str());
+      else std::printf("%s\n", hp->c_str());
       continue;
     }
     std::string p = find_in_path(sh, n);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1750,9 +1750,9 @@ int Executor::run_simple(const SimpleCommand *c) {
     // $PATH search for the (unhashed) common case.
     std::string exec_file = argv[0];
     if (argv[0].find('/') == std::string::npos) {
-      auto h = sh_.hashed.find(argv[0]);
-      if (h != sh_.hashed.end()) {
-        exec_file = h->second;
+      const std::string *h = sh_.hash_lookup(argv[0]);  // a hit bumps `hash' hits
+      if (h != nullptr) {
+        exec_file = *h;
         // `shopt -s checkhash': verify the remembered path still names an
         // executable before using it; a stale entry falls back to a fresh
         // $PATH search and is re-remembered (bash).  Without checkhash the


### PR DESCRIPTION
Closes #554.

Takes bash's `type.tests` from 11 scoreboard diff lines to behaviourally byte-perfect (the remaining 6 lines are purely the `${THIS_SH##*/}` basename artifact of scoring a shell named `gnash` against one named `bash`).

Four conceptual commits:

1. **feat(hash): track hit counts.** `hash` printed a hard-coded 0 in the hits column. bash's `hash_search` increments `times_found` on every successful lookup, so execution, `type`, `command -v`, and `hash -t` all count; re-hashing resets to 0. New `Shell::hash_lookup` is the counting lookup (the executor's parent-side lookup now counts too).

2. **fix(type): consult the hash table.** After `hash -p /tmp/x foo`: `type foo` → `foo is hashed (/tmp/x)`, `type -p foo` → `/tmp/x`, `type -t foo` → `file`, all without checking the path exists. Consulted only when alias/keyword/function/builtin miss and `-a` is absent (bash returns before `phash_search` otherwise — so no hit is counted on early matches), but consulted under `-P` (describe_command's guard is `all == 0 || CDESC_FORCE_PATH`), verified against bash: `type -P` prints the hashed path, `type -aP` prints hashed + all $PATH matches, `type -ap` skips the hash.

3. **fix(command): `command -v` reports aliases and hashed paths.** Reusable alias form (`alias morealias='more'`), gated on aliases actually expanding; hashed path before the $PATH search.

4. **fix(printer): expand `$'...'`/`$"..."` in reconstructed words.** bash's lexer decodes ANSI-C/locale strings at `read_token_word` time, so `type f` shows `v='^A'`, not `v=$'\001'`. `canonical_word` now decodes at print time with bash's `ansicstr` semantics and `sh_single_quote` re-quoting; applies at top level, inside `${...}` and `$(...)`, but not inside `'...'`, `"..."`, backquotes, or after `$$` — each context probed against bash 5.3.

Verification:
- `ctest --test-dir build`: 22/22
- `tests/harness/run_diff.sh`: all 347 scripts match bash
- Full testsuite scoreboard sweep: type 11 → 6 (all remaining = shell-name artifact), no other suite changed