### PR TITLE
fix(select): identifier error reports the ambient line, as bash does

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -935,10 +935,17 @@ int Executor::run(const Command *c) {
     }
     return sh_.last_status;
   }
-  if (c->line > 0 && (dynamic_cast<const ArithCommand *>(c) ||
-                      dynamic_cast<const CondCommand *>(c) ||
-                      dynamic_cast<const ForCommand *>(c)))
-    sh_.cur_lineno = sh_.lineno_base + c->line;
+  // (`select' installs its line INSIDE run_select, after the loop-variable
+  // identifier check: bash's execute_select_command calls check_identifier
+  // before `line_number = select_command->line', so that diagnostic reports
+  // the ambient line -- errors.tests `bad-select'.)
+  {
+    auto *fc = dynamic_cast<const ForCommand *>(c);
+    if (c->line > 0 && (dynamic_cast<const ArithCommand *>(c) ||
+                        dynamic_cast<const CondCommand *>(c) ||
+                        (fc && !fc->is_select)))
+      sh_.cur_lineno = sh_.lineno_base + c->line;
+  }
   int st = sh_.last_status;
   if (auto *pa = dynamic_cast<const Subshell *>(c)) st = run_subshell(pa);
   else if (auto *pb = dynamic_cast<const Group *>(c)) st = run_group(pb);
@@ -2227,7 +2234,10 @@ int Executor::run_for(const ForCommand *c) {
 // layout and the KSH_COMPATIBLE reprint-only-after-an-empty-line behavior.
 int Executor::run_select(const ForCommand *c) {
   // The loop variable must be a valid identifier, validated at run time as bash
-  // does (`NAME: line N: `x-y': not a valid identifier').
+  // does (`NAME: line N: `x-y': not a valid identifier').  The check runs
+  // BEFORE the select's own line is installed (bash's execute_select_command
+  // calls check_identifier first), so the diagnostic carries the ambient line
+  // -- inside a function, the line its body starts on.
   if (!c->var.empty()) {
     bool okname = std::isalpha(static_cast<unsigned char>(c->var[0])) || c->var[0] == '_';
     for (char ch : c->var)
@@ -2239,6 +2249,7 @@ int Executor::run_select(const ForCommand *c) {
       return (sh_.last_status = 1);
     }
   }
+  if (c->line > 0) sh_.cur_lineno = sh_.lineno_base + c->line;  // $LINENO / errors
   Expander ex(sh_);
   std::vector<std::string> items =
       c->words_present ? ex.expand_args(c->words) : sh_.positional;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1640,6 +1640,17 @@ int Executor::run_simple(const SimpleCommand *c) {
                                                        : sh_.lineno_base + 1;
       sh_.run_debug_trap(to_string(fit->second));
     }
+    // Entering the body, bash sets `line_number = function_line_number =
+    // tc->line' -- the line the body STARTS on (execute_function).  That is
+    // the ambient line inside the function for any construct that does not
+    // install its own (a select's identifier check, redirection errors on
+    // if/while/case, ...).
+    if (fit->second && fit->second->line > 0) {
+      auto blit = sh_.func_lineno_base.find(argv[0]);
+      sh_.cur_lineno = (blit != sh_.func_lineno_base.end() ? blit->second
+                                                           : sh_.lineno_base) +
+                       fit->second->line;
+    }
     status = unwinding() ? sh_.last_status : run(fit->second);
     // Deliver a signal caught during the body while the function scope is still
     // active, so its trap runs in-context (bash): a `return' in the trap then

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -629,8 +629,11 @@ struct Parser {
 
   CommandPtr parse_group() {
     push_open("{");
+    int group_line = cur().line;  // the `{' line: bash's function_bstart when
+                                  // the group is a function body
     expect_reserved("{");
     auto g = std::make_unique<Group>();
+    g->line = group_line;
     g->body = parse_list({"}"});
     expect_reserved("}");
     pop_open();


### PR DESCRIPTION
Closes #556. Takes **errors.tests to byte-perfect** (68 of 83 suites now at zero).

Two commits:

1. **fix(executor): install the function body's start line on entry.** bash's `execute_function` sets `line_number = function_line_number = tc->line` — the line the body starts on (the `{` line). gnash left the caller's line in place, and its Group AST node never recorded the `{` line at all. This is the ambient line inside a function for any construct that doesn't install its own.

2. **fix(select): validate the loop variable before installing the select's line.** bash's `execute_select_command` calls `check_identifier` *before* `line_number = select_command->line`, so `select $1 ...` with an invalid expansion blames the ambient line — unlike `for`, which installs its own line first. Probed against bash 5.3: top-level select blames its own line, select inside `if`/`then` blames the parse-end line of the enclosing command, select inside a function blames the body-start line, and `for` always blames itself; all six probes now match.

Verification:
- `ctest --test-dir build`: 22/22
- `tests/harness/run_diff.sh`: all 347 scripts match bash
- Full scoreboard sweep: errors 2 → 0, every other suite unchanged