### PR TITLE
fix(nameref): re-expand an array-element target's subscript on dereference

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -633,8 +633,26 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     return std::string();
   }
   std::string v;
-  if (sh_.get_if_set(name, v)) return v;
-  if (sh_.dynamic_var(name, v)) return v;  // RANDOM/SECONDS/LINENO/BASHPID/EPOCH*
+  bool nr_elt = false;
+  {
+    // A nameref to an array element re-expands the SUBSCRIPT on every
+    // dereference: bash's array_expand_index performs parameter and command
+    // substitution, so `declare -n r='x[i=0$(cmd)]'; : $r' runs cmd each
+    // time (nameref10.sub).  Shell::get has no expander down at its level --
+    // its raw arithmetic evaluation would silently drop the substitution --
+    // so a subscript that still needs expansion is handled here.
+    std::string nrbase, nrsub;
+    if (sh_.nameref_elt(name, nrbase, nrsub) &&
+        nrsub.find_first_of("$`") != std::string::npos) {
+      nr_elt = true;
+      std::string esub = expand_no_split(nrsub, false, false);
+      if (sh_.array_elem_set(nrbase, esub)) return sh_.array_get(nrbase, esub);
+    }
+  }
+  if (!nr_elt) {
+    if (sh_.get_if_set(name, v)) return v;
+    if (sh_.dynamic_var(name, v)) return v;  // RANDOM/SECONDS/LINENO/BASHPID/EPOCH*
+  }
   set = false;
   // An unbound variable found while RESOLVING this one (a `set -u' failure in a
   // nameref's subscript) has already been reported against its own name; do not


### PR DESCRIPTION
Closes #558. nameref suite 3 → 2 diff lines (the remaining pair is the coproc fd-numbering issue, tracked with the coproc cluster).

bash's `array_expand_index` runs parameter and command substitution on an array subscript at every evaluation, including when the reference arrives through a nameref (`declare -n r='x[i=0$(cmd)]'`). gnash's deref path bottomed out in `Shell::get` → `array_get`, whose raw `eval_arith` silently dropped the `$(...)` and defaulted to index 0 — right value by coincidence, lost side effects.

The fix intercepts in the expander's `param_value` (the layer that *can* run substitutions): a nameref-to-element whose subscript still contains `$`/backquote gets its subscript expanded there, then the element is fetched directly. Probed against bash: literal and `"$1"`-passed targets, local and global namerefs, assoc keys via comsub, indexed arrays, and an unset element under `set -u` with `${r:-default}`.

Verification: ctest 22/22; run_diff all 347 match; full sweep shows nameref 3 → 2, all other suites unchanged.