### PR TITLE
fix(redir): pipe fd-0 collision with closed stdin; read reports hard errors

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2360,7 +2360,9 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       : 0.0;
 
   bool eof = false, timed_out = false;
-  // Read a byte, honoring the deadline: 1 = got byte, 0 = EOF/error, -1 = timeout.
+  int read_errno = 0;  // a non-EINTR read(2) failure (closed/write-only fd)
+  // Read a byte, honoring the deadline: 1 = got byte, 0 = EOF, -1 = timeout,
+  // -2 = read error (read(2) failed with other than EINTR; errno saved).
   auto read_byte = [&](char &ch) -> int {
     if (have_t) {
       struct timeval now;
@@ -2375,7 +2377,13 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       tv.tv_usec = static_cast<suseconds_t>((remain - static_cast<double>(tv.tv_sec)) * 1e6);
       if (select(fd + 1, &rfds, nullptr, nullptr, &tv) <= 0) return -1;
     }
-    return ::read(fd, &ch, 1) == 1 ? 1 : 0;
+    ssize_t r = ::read(fd, &ch, 1);
+    if (r == 1) return 1;
+    // A failure other than EINTR is a hard read error, reported as such
+    // (bash read.def: `read: FD: read error: STRERROR', status 1); EINTR
+    // keeps the EOF path so a pending trap is honored as before.
+    if (r < 0 && errno != EINTR) { read_errno = errno; return -2; }
+    return 0;
   };
 
   // Read up to the delimiter (or `nchars' with -n/-N) byte by byte so we don't
@@ -2421,7 +2429,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     for (;;) {
       char ch;
       int r = read_byte(ch);
-      if (r <= 0) { eof = (r == 0); timed_out = (r < 0); break; }
+      if (r <= 0) { eof = (r == 0); timed_out = (r == -1); break; }
       if (ch == '\0' && delim != 0) continue;    // stray NULs are discarded
       if (mb_data_byte(ch)) {
         line += ch;
@@ -2432,7 +2440,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       if (!raw && ch == '\\') {                  // backslash escaping (unless -r)
         char nx;
         int r2 = read_byte(nx);
-        if (r2 <= 0) { eof = (r2 == 0); timed_out = (r2 < 0); break; }  // trailing \ dropped
+        if (r2 <= 0) { eof = (r2 == 0); timed_out = (r2 == -1); break; }  // trailing \ dropped
         if (nx == '\n') continue;                // line continuation: drop both
         line += nx;
         quoted += '\1';
@@ -2444,6 +2452,16 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
       quoted += '\0';
       if (have_n && mb_count(line) >= nchars) break;
     }
+  }
+
+  // A hard read(2) failure (closed or write-only descriptor) reports bash's
+  // `read: FD: read error: STRERROR' and fails WITHOUT binding any variable
+  // (read.def returns through its unwind frame before the assignment).
+  if (read_errno != 0) {
+    std::fflush(stdout);
+    std::fprintf(stderr, "%sread: %d: read error: %s\n", sh.err_prefix().c_str(),
+                 fd, std::strerror(read_errno));
+    return 1;
   }
 
   const std::string ifs = sh.ifs();

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1096,8 +1096,20 @@ int Executor::run_pipeline(const Connection *c) {
         signal(SIGTTIN, SIG_DFL);
         signal(SIGTTOU, SIG_DFL);
       }
-      if (prev_read != -1) { dup2(prev_read, 0); close(prev_read); }
-      if (i + 1 < n) { close(pipefd[0]); dup2(pipefd[1], 1); close(pipefd[1]); }
+      // With stdin (or stdout) closed in the shell, pipe() hands out fd 0 (or
+      // 1) as a pipe end, so the end may already BE the target of the dup2 --
+      // a blind dup2-then-close would close the fd just put in place.  Guard
+      // exactly as bash's do_piping does: `if (pipe_in > 0) close', and for
+      // the write side `if (pipe_out == 0 || pipe_out > 1) close'.
+      if (prev_read != -1) {
+        dup2(prev_read, 0);
+        if (prev_read > 0) close(prev_read);
+      }
+      if (i + 1 < n) {
+        close(pipefd[0]);
+        dup2(pipefd[1], 1);
+        if (pipefd[1] == 0 || pipefd[1] > 1) close(pipefd[1]);
+      }
       sh_.job_control = false;  // pipeline stage: no nested tty control
       // A pipeline stage is a subshell: without errtrace it does not inherit the
       // ERR trap (the whole pipeline fires it once in the parent instead), and

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -522,6 +522,13 @@ echo "L=$LINENO"'
   'declare -a v=(1 2); v+=x; declare -p v'
   'PATH=/bin; PATH+=:/xyz; echo "$PATH"'
   'declare -n r=t; t=a; r+=b; echo "[$t]"'
+  # With stdin closed, pipe() hands out fd 0 as a pipe end; the child fd dance
+  # must not close the descriptor it just put in place (redir5.sub).
+  'exec <&-; echo hi | cat; echo rc=$?'
+  'exec <&-; echo a | cat | cat; echo rc=$?'
+  'exec <&-; read abcde 2>&1 | grep -q "read error"; echo rc=$?'
+  # read(2) failing outright (closed fd) is a reported error, not a quiet EOF.
+  '{ exec <&-; read x; echo rc=$?; } 2>&1 | sed "s|^[^ ]*: ||"'
 )
 
 fails=0


### PR DESCRIPTION
Closes #560. Takes **redir.tests to byte-perfect** (69 of 83 suites now at zero).

The suite's last diff line — an extra `grep: (standard input): Bad file descriptor` — unwound into two real bugs:

1. **fix(pipeline):** with the shell's stdin closed, `pipe()` returns fd 0 as the read end, and the pipeline child's `dup2(prev_read, 0); close(prev_read)` closed the stdin it had just installed. Every pipeline RHS then read from a closed descriptor: `exec <&-; echo hi | cat` printed nothing, rc=1. Guards now mirror bash's `do_piping` exactly (`if (pipe_in > 0) close`; write side `if (pipe_out == 0 || pipe_out > 1) close`). The lastpipe branch already had the guard — the normal child path was missed.

2. **fix(read):** `read` treated any short `read(2)` as EOF, so a closed/write-only fd failed silently. bash reports `read: FD: read error: STRERROR` for any failure other than EINTR and returns 1 without binding the variable; EINTR keeps the existing EOF path so pending-trap handling is unchanged. This is what redir5.sub's `read abcde 2>&1 | grep -q 'read error'` checks — it needs both fixes: the grep must see a working pipe *and* the message must exist.

Probed against bash: closed stdin with 2- and 3-stage pipelines, closed stdout, both closed, `read` from `<&2`, plain EOF (`read a </dev/null`), and normal pipe reads.

Verification:
- `ctest --test-dir build`: 22/22
- `run_diff.sh`: **all 351 scripts match** (4 new regression cases)
- Full scoreboard sweep: redir 1 → 0, every other suite unchanged