### PR TITLE
fix(intl): locale-charset \u encoding, %ls/%lc, LC_NUMERIC, character-aware splitting

### DIFF
--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -16,6 +16,10 @@ namespace gnash::core {
 // return true.  Otherwise return false.
 bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status);
 
+// A name quoted for an error message (bash printable_filename): ANSI-C form
+// when it contains nonprinting/invalid bytes, otherwise the name unchanged.
+std::string printable_name(const std::string &s);
+
 // Would NAME run as a command (builtin/keyword/function/alias/PATH)?  Used by
 // interactive syntax highlighting.
 bool command_is_valid(Shell &sh, const std::string &name);

--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -155,6 +155,12 @@ std::string mb_capitalize(const std::string &s);
 // since bash performs it before the builtin is entered.
 void apply_assignment_word(Shell &sh, const std::string &word, const char *ctx = nullptr);
 
+// Encode a Unicode code point for \u/\U (bash u32cconv): the locale charset's
+// bytes when LC_CTYPE is not UTF-8 (via iconv), UTF-8 otherwise; a code point
+// iconv cannot represent appends the ISO C99 escape text (\uXXXX/\UXXXXXXXX)
+// and one >= 0x80000000 appends nothing.  Used by $'...', printf, echo -e.
+void append_utf8(std::string &out, unsigned long cp);
+
 }  // namespace gnash::core
 
 #endif  // GNASH_CORE_EXPAND_HPP

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -295,6 +295,7 @@ class Shell {
   void end_interruptible_wait();
   int pending_trapped_signal();               // a pending signal that has a trap, or 0
   void note_child_reaped();                   // count a reaped child for the SIGCHLD trap
+  void reapply_locale();  // re-derive LC_CTYPE/LC_NUMERIC from LC_*/LANG vars
   // Where `set -x' output goes.  stderr unless $BASH_XTRACEFD names an open
   // file descriptor; see apply_xtracefd().
   std::FILE *xtrace_out() const { return xtrace_fp ? xtrace_fp : stderr; }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -92,6 +92,19 @@ std::string decode_b(const std::string &s, bool &stop, bool bare_octal = true) {
         out += static_cast<char>(v);
         break;
       }
+      case 'u': case 'U': {
+        // \uHHHH / \UHHHHHHHH: encode via the locale charset (bash u32cconv).
+        int maxd = (e == 'u') ? 4 : 8, k = 0;
+        unsigned long v = 0;
+        while (k < maxd && i + 1 < s.size() && std::isxdigit((unsigned char)s[i + 1])) {
+          char h = s[++i];
+          v = v * 16 + (h <= '9' ? h - '0' : (std::tolower(h) - 'a' + 10));
+          k++;
+        }
+        if (k == 0) { out += '\\'; out += e; break; }
+        append_utf8(out, v);
+        break;
+      }
       case '0': {
         // \0nnn : the 0 is a prefix; up to 3 octal digits follow.
         int v = 0, k = 0;
@@ -292,6 +305,19 @@ void decode_fmt_escape(const std::string &fmt, size_t &i, std::string &out) {
       }
       if (k == 0) { out += "\\x"; return; }
       out += static_cast<char>(v);
+      return;
+    }
+    case 'u': case 'U': {
+      // \uHHHH / \UHHHHHHHH: encode via the locale charset (bash u32cconv).
+      int maxd = (e == 'u') ? 4 : 8, k = 0;
+      unsigned long v = 0;
+      while (k < maxd && i < fmt.size() && std::isxdigit(static_cast<unsigned char>(fmt[i]))) {
+        char h = fmt[i++];
+        v = v * 16 + (h <= '9' ? h - '0' : (std::tolower(h) - 'a' + 10));
+        k++;
+      }
+      if (k == 0) { out += '\\'; out += e; return; }
+      append_utf8(out, v);
       return;
     }
     case '0': case '1': case '2': case '3':

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -500,6 +500,60 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
           out += decode_b(next(), stop);
           consumed_any = true;
           if (stop) { argi = argv.size(); i = fmt.size(); break; }
+        } else if (conv == 'l' && j + 1 < fmt.size() &&
+                   (fmt[j + 1] == 's' || fmt[j + 1] == 'c') && MB_CUR_MAX > 1) {
+          // %ls / %lc: field width and precision count wide CHARACTERS, and
+          // padding is always spaces -- bash's printwidestr, not the C
+          // library's byte-counting %ls.
+          char wconv = fmt[j + 1];
+          std::string a = next();
+          std::wstring ws;
+          {
+            std::wstring buf(a.size() + 1, L'\0');
+            std::mbstate_t st{};
+            const char *src = a.c_str();
+            size_t wn = std::mbsrtowcs(&buf[0], &src, a.size() + 1, &st);
+            if (wn == static_cast<size_t>(-1)) {
+              // Invalid multibyte text: bash getwidestr zero-extends each byte.
+              buf.clear();
+              for (unsigned char b : a) buf += static_cast<wchar_t>(b);
+              ws = buf;
+            } else {
+              buf.resize(wn);
+              ws = buf;
+            }
+          }
+          // %lc uses only the first character; a null/empty argument produces
+          // a single null byte (posix interp 1647).
+          if (wconv == 'c') ws = ws.empty() ? std::wstring(1, L'\0') : ws.substr(0, 1);
+          // Parse `-', field width and precision out of the spec text.
+          bool ljust = false;
+          size_t sp = i + 1;
+          while (sp < j && std::strchr("-+ #0", fmt[sp])) { if (fmt[sp] == '-') ljust = true; sp++; }
+          long fw = 0;
+          while (sp < j && std::isdigit(static_cast<unsigned char>(fmt[sp])))
+            fw = fw * 10 + (fmt[sp++] - '0');
+          long pr = -1;
+          if (sp < j && fmt[sp] == '.') {
+            pr = 0;
+            sp++;
+            while (sp < j && std::isdigit(static_cast<unsigned char>(fmt[sp])))
+              pr = pr * 10 + (fmt[sp++] - '0');
+          }
+          long nc = (pr >= 0 && pr <= static_cast<long>(ws.size()))
+                        ? pr : static_cast<long>(ws.size());
+          long pad = fw - nc;
+          if (pad < 0) pad = 0;
+          if (!ljust) out.append(pad, ' ');
+          for (long k = 0; k < nc; k++) {
+            char mb[MB_LEN_MAX];
+            int r = std::wctomb(mb, ws[k]);
+            if (r > 0) out.append(mb, r);
+            else out += static_cast<char>(ws[k]);  // bash convwidestr fallback
+          }
+          if (ljust) out.append(pad, ' ');
+          consumed_any = true;
+          j++;  // the conversion consumed two characters (`ls' / `lc')
         } else if (conv == 's') {
           if (!append_formatted(out, spec, next().c_str())) oversize = true;
           consumed_any = true;

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -254,6 +254,18 @@ std::string q_ansic(const std::string &s) {
   r += '\'';
   return r;
 }
+}  // namespace (close anon: printable_name is used by the executor's error paths)
+
+// bash's printable_filename: a name quoted for an error message.  One with
+// nonprinting characters (or bytes invalid in the locale) is shown in ANSI-C
+// form -- `$'5\247@...': command not found` -- and any other name is shown
+// as-is, NOT backslash-quoted.
+std::string printable_name(const std::string &s) {
+  return q_needs_ansic(s) ? q_ansic(s) : s;
+}
+
+namespace {
+
 std::string shell_quote(const std::string &s) {
   if (s.empty()) return "''";
   if (q_needs_ansic(s)) return q_ansic(s);
@@ -1102,8 +1114,8 @@ int change_dir(Shell &sh, const std::string &dir, bool physical, const char *cal
   logical = canon_logical(logical);
   const std::string &target = physical ? dir : logical;
   if (chdir(target.c_str()) != 0) {
-    std::fprintf(stderr, "%s%s: %s: %s\n", sh.err_prefix().c_str(), caller, dir.c_str(),
-                 std::strerror(errno));
+    std::fprintf(stderr, "%s%s: %s: %s\n", sh.err_prefix().c_str(), caller,
+                 printable_name(dir).c_str(), std::strerror(errno));
     return 1;
   }
   // Updating a readonly PWD/OLDPWD fails (bash reports it and cd returns 1),

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1874,10 +1874,11 @@ int Executor::run_simple(const SimpleCommand *c) {
       std::fflush(nullptr);
       do_exec(cargv);
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
                      exec_file == argv[0] ? "command not found" : "not found");
       else
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(), std::strerror(errno));
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
+                     printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
     // external command, in its own process group
@@ -1909,11 +1910,11 @@ int Executor::run_simple(const SimpleCommand *c) {
       cargv.push_back(nullptr);
       do_exec(cargv);
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
                      exec_file == argv[0] ? "command not found" : "not found");
       else
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), exec_file.c_str(),
-                     std::strerror(errno));
+        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
+                     printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
     if (sh_.job_control) setpgid(pid, pid);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1592,13 +1592,20 @@ int Executor::run_simple(const SimpleCommand *c) {
       else sh_.vars.erase(it->first);
     }
     restore.clear();
+    bool relocale = false;
     for (const auto &a : assigns) {
       sh_.temp_env_active.erase(a.first);
       sh_.temp_prior.erase(a.first);
       sh_.temp_consumed.erase(a.first);
       auto d = sh_.temp_env_depth.find(a.first);
       if (d != sh_.temp_env_depth.end() && --d->second <= 0) sh_.temp_env_depth.erase(d);
+      // Applying `LC_ALL=C printf ...' went through Shell::set (which resets
+      // the locale); the teardown above wrote vars directly, so re-derive.
+      if (a.first == "LC_ALL" || a.first == "LC_CTYPE" || a.first == "LC_NUMERIC" ||
+          a.first == "LANG")
+        relocale = true;
     }
+    if (relocale) sh_.reapply_locale();
   };
 
   int status = 0;

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2629,12 +2629,20 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     // Try only CHARACTER-boundary split points, so `${x%?}' removes one whole
     // multibyte character rather than a single trailing byte (which would leave
     // a broken sequence).  cb lists the byte offsets of every boundary, 0..size.
+    // EXCEPT: bash drops to byte-wise matching (remove_upattern) when either
+    // the value or the pattern is not valid multibyte text -- so a pattern
+    // holding a bare continuation byte can strip mid-character:
+    // `${euro##*$'\202'}' leaves only euro's last byte (intl3.sub).
+    auto mb_valid = [](const std::string &t) {
+      return std::mbstowcs(nullptr, t.c_str(), 0) != static_cast<size_t>(-1);
+    };
+    bool bytewise = MB_CUR_MAX > 1 && (!mb_valid(val) || !mb_valid(pat));
     std::vector<size_t> cb;
     for (size_t i = 0;; ) {
       cb.push_back(i);
       if (i >= val.size()) break;
       size_t len = 1;
-      mb_decode(val, i, len);
+      if (!bytewise) mb_decode(val, i, len);
       i += len;
     }
     if (rest[0] == '#') {  // prefix removal (shortest = first, longest = last)

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -334,12 +334,15 @@ static std::string mb_case_fold(const std::string &val, const std::string &pat,
   return out;
 }
 
+}  // namespace
+
 // Encode a Unicode code point for \u / \U, matching bash's u32cconv: in the
 // active LC_CTYPE locale's charset when it is not UTF-8 (Big5, EUC, ...), with
 // UTF-8 as both the common case and the can't-convert fallback.  wcrtomb is
 // no use here: on the BSDs (macOS included) wchar_t in a Big5 locale is the
 // zero-extended multibyte value, not a Unicode code point, so like bash we
-// convert the UTF-8 form with iconv.
+// convert the UTF-8 form with iconv.  (External linkage: printf's format
+// escapes and echo -e/%b use the same encoder.)
 void append_utf8_raw(std::string &out, unsigned long v);
 
 void append_utf8(std::string &out, unsigned long v) {
@@ -380,6 +383,9 @@ void append_utf8(std::string &out, unsigned long v) {
 }
 
 // The plain UTF-8 encoding (also the fallback when iconv can't convert).
+// The full bash u32toutf8 ladder: the historic 5- and 6-byte forms encode
+// values past the Unicode range, and anything >= 0x80000000 encodes to
+// NOTHING at all ($'\Uffffffff' is empty in bash).
 void append_utf8_raw(std::string &out, unsigned long v) {
   if (v <= 0x7f) {
     out += static_cast<char>(v);
@@ -390,13 +396,28 @@ void append_utf8_raw(std::string &out, unsigned long v) {
     out += static_cast<char>(0xe0 | (v >> 12));
     out += static_cast<char>(0x80 | ((v >> 6) & 0x3f));
     out += static_cast<char>(0x80 | (v & 0x3f));
-  } else {
+  } else if (v <= 0x1fffff) {
     out += static_cast<char>(0xf0 | (v >> 18));
+    out += static_cast<char>(0x80 | ((v >> 12) & 0x3f));
+    out += static_cast<char>(0x80 | ((v >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (v & 0x3f));
+  } else if (v <= 0x3ffffff) {
+    out += static_cast<char>(0xf8 | (v >> 24));
+    out += static_cast<char>(0x80 | ((v >> 18) & 0x3f));
+    out += static_cast<char>(0x80 | ((v >> 12) & 0x3f));
+    out += static_cast<char>(0x80 | ((v >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (v & 0x3f));
+  } else if (v <= 0x7fffffff) {
+    out += static_cast<char>(0xfc | (v >> 30));
+    out += static_cast<char>(0x80 | ((v >> 24) & 0x3f));
+    out += static_cast<char>(0x80 | ((v >> 18) & 0x3f));
     out += static_cast<char>(0x80 | ((v >> 12) & 0x3f));
     out += static_cast<char>(0x80 | ((v >> 6) & 0x3f));
     out += static_cast<char>(0x80 | (v & 0x3f));
   }
 }
+
+namespace {
 
 // ANSI-C dequoting for $'...' -- matches bash's ansicstr(..., flags=2).  Beyond
 // the single-letter escapes it decodes octal (\nnn), hex (\xHH and \x{...}),

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3164,9 +3164,13 @@ std::vector<std::pair<std::string, std::string>> Expander::split_ifs(const std::
   while (i < n) {
     std::string cur, curm;
     while (i < n && !soft_ifs(i) && !(mask[i] == MMARK && s[i] == FIELD_SEP)) {
-      cur += s[i];
-      curm += mask[i];
-      i++;
+      // Advance by whole characters: a trail byte of a valid multibyte char
+      // must never be tested against IFS (IFS=$'\254' does not split `€',
+      // whose last byte is 254 -- intl3.sub).
+      size_t len = clen(i);
+      cur.append(s, i, len);
+      curm.append(mask, i, len);
+      i += len;
     }
     fields.emplace_back(cur, curm);
     if (i >= n) break;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1509,23 +1509,34 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
 }
 
 static bool is_locale_var(const std::string &n) {
-  return n == "LC_ALL" || n == "LC_CTYPE" || n == "LANG";
+  return n == "LC_ALL" || n == "LC_CTYPE" || n == "LC_NUMERIC" || n == "LANG";
 }
 
-// Re-apply the LC_CTYPE locale from the shell's own LC_ALL/LC_CTYPE/LANG
-// variables, in POSIX precedence order, so a runtime `export LC_ALL=en_US.UTF-8'
-// makes subsequent ${#var}/substring operations count characters.  Only the
-// LC_CTYPE category (which governs MB_CUR_MAX / mbrtowc) is changed.
+// Re-apply the locale from the shell's own LC_ALL/LC_*/LANG variables, in
+// POSIX precedence order, so a runtime `export LC_ALL=en_US.UTF-8' makes
+// subsequent ${#var}/substring operations count characters.  Two categories
+// are tracked: LC_CTYPE (MB_CUR_MAX / mbrtowc / \u encoding) and LC_NUMERIC
+// (printf's radix character -- de_DE formats %.4f as `1,0000').
 static void apply_ctype_locale(Shell &sh) {
   auto val = [&](const char *k) -> std::string {
     auto it = sh.vars.find(k);
     return it != sh.vars.end() ? it->second.value : std::string();
   };
-  std::string loc = val("LC_ALL");
+  std::string all = val("LC_ALL"), lang = val("LANG");
+  std::string loc = all;
   if (loc.empty()) loc = val("LC_CTYPE");
-  if (loc.empty()) loc = val("LANG");
+  if (loc.empty()) loc = lang;
   if (!loc.empty()) std::setlocale(LC_CTYPE, loc.c_str());
+  loc = all;
+  if (loc.empty()) loc = val("LC_NUMERIC");
+  if (loc.empty()) loc = lang;
+  if (!loc.empty()) std::setlocale(LC_NUMERIC, loc.c_str());
 }
+
+// Public re-application hook: the executor calls this after a temporary
+// environment (`LC_ALL=C printf ...') is torn down, since the teardown
+// restores the variables without going through Shell::set.
+void Shell::reapply_locale() { apply_ctype_locale(*this); }
 
 bool Shell::set(const std::string &n_in, const std::string &v,
                 const char *nameref_ctx) {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -529,6 +529,20 @@ echo "L=$LINENO"'
   'exec <&-; read abcde 2>&1 | grep -q "read error"; echo rc=$?'
   # read(2) failing outright (closed fd) is a reported error, not a quiet EOF.
   '{ exec <&-; read x; echo rc=$?; } 2>&1 | sed "s|^[^ ]*: ||"'
+  # \u/\U escapes encode via the locale charset (bash u32cconv) in printf,
+  # %b and echo -e; >= 0x80000000 encodes to nothing.
+  'export LC_ALL=en_US.UTF-8; printf "\uff\n" | od -An -b | tr -s " "'
+  'export LC_ALL=en_US.UTF-8; printf "%b\n" "\uff" | od -An -b | tr -s " "'
+  'export LC_ALL=en_US.UTF-8; echo -e "\\u0152" | od -An -b | tr -s " "'
+  'export LC_ALL=en_US.UTF-8; printf "[%s]\n" "$(printf "\Uffffffff")"'
+  # %ls/%lc: width and precision count wide characters, space-padded.
+  'export LC_ALL=en_US.UTF-8; V=ಇಳಿಕೆಗಳು; printf "%4.2ls|%-4.2ls|%4.2lc|\n" "$V" "$V" "$V"'
+  # LC_NUMERIC follows LANG/LC_ALL, including after a temp-env teardown.
+  'unset LC_ALL; export LANG=de_DE.UTF-8; printf "%.2f\n" 1; LANG=C printf "%.2f\n" 1; printf "%.2f\n" 1'
+  # IFS splits on characters (a trail byte of € is not a delimiter)...
+  'export LC_ALL=en_US.UTF-8; IFS=$'"'"'\254'"'"'; t="+$'"'"'\342\202\254'"'"'+"; set -- $t; echo $#'
+  # ...but ${x##pat} drops to bytes when the pattern is invalid multibyte.
+  'export LC_ALL=en_US.UTF-8; e=$'"'"'\342\202\254'"'"'; echo "${e##*$'"'"'\202'"'"'}" | od -An -b | tr -s " "'
 )
 
 fails=0


### PR DESCRIPTION
Closes #562. Takes **intl.tests from 1827 diff lines to byte-perfect** (70 of 83 suites now at zero).

Seven commits, each one conceptual change:

1. **fix(unicode):** bash's full `u32toutf8` ladder — historic 5/6-byte forms up to 0x7FFFFFFF, *empty* for ≥ 0x80000000 (`$'\Uffffffff'` is empty); encoder exposed for reuse.
2. **feat(printf):** decode `\u`/`\U` in format strings, `%b`, and `echo -e` via the shared locale-charset encoder (bash `u32cconv`: UTF-8 locale → UTF-8; otherwise iconv into `nl_langinfo(CODESET)`; ISO C99 escape text when unrepresentable). This alone was ~1770 of the diff lines (every unicode1.sub codepage test, including the temp-env `LC_CTYPE=fr_FR.ISO8859-1 printf` form).
3. **feat(printf):** `%ls`/`%lc` — width/precision in wide characters with space padding (bash `printwidestr`), `%lc` null argument → single null byte (posix interp 1647), invalid multibyte → per-byte zero-extension.
4. **fix(locale):** LC_NUMERIC tracked alongside LC_CTYPE (de_DE prints `1,0000`), and temp-env teardown (`LANG=C printf ...`) now re-derives the locale — it previously leaked the temporary locale into the rest of the script.
5. **fix(error):** unprintable command/cd names print in ANSI-C form (`$'5\247@...': command not found`), bash's `printable_filename`.
6. **fix(split):** IFS field splitting advances by whole characters — `IFS=$'\254'` no longer splits `€` in half.
7. **fix(expand):** `${x##pat}` falls back to byte-boundary split points when the value or pattern is invalid multibyte (bash `remove_upattern` fallback).

On macOS, bash's `u32cconv` uses only the iconv path (`__STDC_ISO_10646__` undefined), so identical algorithm + same libiconv ⇒ byte-identical output, including the odd CP1251 conversions.

Verification:
- `ctest`: 22/22; `run_diff.sh`: **all 359 scripts match** (8 new regression cases)
- Full scoreboard sweep: intl 1827 → 0, every other suite unchanged