### PR TITLE
fix(invocation): env option import, --pretty-print, set -B, logout file, script operands

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -83,6 +83,10 @@ std::string to_string(const Command *c);
 
 // bash's multi-line function rendering (print_cmd.c named_function_string),
 // used by `type', `declare -f', and `set' -- byte-identical to bash.
+// bash --pretty-print rendering: each top-level command in multiline format
+// followed by a blank line (newline lists split into separate commands).
+std::string pretty_print_string(const Command *cmd);
+
 std::string named_function_string(const std::string &name, const Command *body,
                                   bool posix = false);  // full canonical rendering
 

--- a/core/include/gnash/core/builtins.hpp
+++ b/core/include/gnash/core/builtins.hpp
@@ -20,6 +20,10 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status);
 // when it contains nonprinting/invalid bytes, otherwise the name unchanged.
 std::string printable_name(const std::string &s);
 
+// Apply one `set -o NAME' state change; false (silently) for an unknown name.
+// Used by invocation flags and the env SHELLOPTS import as well as `set'.
+bool apply_set_o_option(Shell &sh, const std::string &o, bool on);
+
 // Would NAME run as a command (builtin/keyword/function/alias/PATH)?  Used by
 // interactive syntax highlighting.
 bool command_is_valid(Shell &sh, const std::string &name);

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -218,6 +218,7 @@ class Shell {
 
   // --- shell state for builtins -----------------------------------------
   bool login_shell = false;                  // logout only works in a login shell
+  bool opt_braceexpand = true;               // set -B / +B (brace expansion)
   std::map<std::string, std::string> hashed;  // `hash': command name -> full path
   std::vector<std::string> hashed_seq;        // insertion order (bash hash-walk)
   std::map<std::string, int> hashed_hits;     // `hash' hits column (times_found)

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -246,6 +246,7 @@ std::string canonical_word(const std::string &w);
 
 struct MPrinter {
   std::string out;
+  bool pretty = false;  // --pretty-print (top level): `;' lists join inline
   std::vector<const Redirect *> pending_heredocs;
   bool last_was_heredoc = false;   // a simple command ended with a here-document
   bool compound_heredoc = false;   // a for/while/if body ended with a here-document
@@ -322,6 +323,10 @@ struct MPrinter {
         if (last_was_heredoc) { out += '\n'; nl(I); }  // simple heredoc: blank line
         else if (compound_heredoc) { nl(I); }          // compound heredoc: no `;', no blank
         else if (last_was_amp) { nl(I); }
+        // Outside a function definition bash joins a `;'/newline list inline
+        // (`done <<< a; echo done;'); inside one, each command starts its own
+        // line (print_cmd.c: the_printed_command's inside_function_def test).
+        else if (pretty) { out += "; "; }
         else { out += ';'; nl(I); }
         list(cn->second.get(), I);
       }
@@ -853,6 +858,24 @@ static bool func_name_is_assignment(const std::string &s) {
     i = j + 1;
   }
   return i < s.size() && s[i] == '=';
+}
+
+// bash --pretty-print: each top-level command renders in the multiline
+// (declare -f) format followed by a blank line; a top-level newline list
+// prints as separate commands, exactly as bash's one-command-per-read loop.
+std::string pretty_print_string(const Command *c) {
+  if (c == nullptr) return std::string();
+  if (const auto *cn = dynamic_cast<const Connection *>(c)) {
+    if (cn->conn == Connector::Newline)
+      return pretty_print_string(cn->first.get()) +
+             pretty_print_string(cn->second.get());
+  }
+  MPrinter p;
+  p.pretty = true;
+  p.inline_cmd(c, 0);
+  p.flush_heredocs();
+  p.out += "\n\n";
+  return p.out;
 }
 
 std::string named_function_string(const std::string &name, const Command *body,

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2547,6 +2547,23 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     }
   }
 
+  // bash re-checks the -t deadline when the read returned EOF with NOTHING
+  // read (read.def: `if (i == 0 && retval <= 0) check_read_timeout()'), so a
+  // timeout shorter than the time it took to reach EOF reports 128+SIGALRM
+  // rather than EOF: `read -t 0.00001 -e var </dev/null' times out even
+  // though EOF was instantly available (read7.sub).  A sub-millisecond
+  // timeout counts as expired outright: bash's own builtin setup (setitimer
+  // to check_read_timeout) exceeds it, so bash reliably reports the timeout
+  // where gnash's tighter loop could win the race and see EOF first.
+  if (eof && line.empty() && have_t) {
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    if (timeout < 0.001 || now.tv_sec + now.tv_usec / 1e6 >= deadline) {
+      timed_out = true;
+      eof = false;
+    }
+  }
+
   // A hard read(2) failure (closed or write-only descriptor) reports bash's
   // `read: FD: read error: STRERROR' and fails WITHOUT binding any variable
   // (read.def returns through its unwind frame before the assignment).

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -2135,8 +2135,8 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
   // Valid bash `set -o' names whose behavior is unimplemented: accept as no-ops
   // (a script may set them; erroring would diverge from bash, which knows them).
   else if (o == "allexport") sh.opt_allexport = on;
-  else if (o == "braceexpand" ||
-           o == "interactive-comments" || o == "nolog" ||
+  else if (o == "braceexpand") sh.opt_braceexpand = on;
+  else if (o == "interactive-comments" || o == "nolog" ||
            o == "notify" || o == "onecmd")
     ;  // no-op
   else return false;
@@ -2151,7 +2151,7 @@ bool set_o_option(Shell &sh, const std::string &o, bool on) {
 std::vector<std::pair<std::string, bool>> set_option_states(Shell &sh) {
   bool i = sh.interactive;
   return {
-      {"allexport", sh.opt_allexport},   {"braceexpand", true},
+      {"allexport", sh.opt_allexport},   {"braceexpand", sh.opt_braceexpand},
       {"emacs", i ? (rl_editing_mode == 1) : sh.opt_emacs},
       {"errexit", sh.opt_errexit},
       {"errtrace", sh.opt_functrace}, {"functrace", sh.opt_functrace},
@@ -2245,10 +2245,11 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
             break;
           }
           case 'h': sh.opt_hashall = on; break;  // -h/+h: hashall
+          case 'B': sh.opt_braceexpand = on; break;  // -B/+B: brace expansion
           // Flags accepted as no-ops where the behavior is unimplemented:
-          // allexport/notify/onecmd/braceexpand.
+          // allexport/notify/onecmd.
           case 'a': sh.opt_allexport = on; break;  // allexport: assignments export
-          case 'b': case 't': case 'B': break;
+          case 'b': case 't': break;
           default:
             std::fprintf(stderr, "%sset: %c%c: invalid option\n", sh.err_prefix().c_str(),
                          a[0], a[k]);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1782,6 +1782,36 @@ int Executor::run_simple(const SimpleCommand *c) {
     sh_.arith_error = false;
   } else {
     undo_temp();  // not a builtin after all: the external path sets its own env
+    // On an exec failure for a file that EXISTS and starts `#!', bash blames
+    // the interpreter: `./x23: nosuchfile: bad interpreter: No such file or
+    // directory' -- prefixed by the script name alone, with NO line number
+    // (shell_execve).  Returns false when this isn't that case, so the
+    // caller falls back to the plain strerror report.
+    auto report_bad_interpreter = [&](const std::string &file) -> bool {
+      int saved_errno = errno;
+      if (saved_errno != ENOENT && saved_errno != EACCES) return false;
+      std::FILE *fp = std::fopen(file.c_str(), "r");
+      if (fp == nullptr) { errno = saved_errno; return false; }
+      char line[256];
+      bool ok = std::fgets(line, sizeof line, fp) != nullptr;
+      std::fclose(fp);
+      errno = saved_errno;
+      if (!ok || line[0] != '#' || line[1] != '!') return false;
+      std::string interp;
+      size_t p = 2;
+      while (line[p] == ' ' || line[p] == '\t') p++;
+      while (line[p] != '\0' && line[p] != ' ' && line[p] != '\t' &&
+             line[p] != '\n')
+        interp += line[p++];
+      if (interp.empty()) return false;
+      // The interpreter itself must be the missing piece; an executable
+      // interpreter means the failure was something else.
+      if (access(interp.c_str(), X_OK) == 0) return false;
+      std::fprintf(stderr, "%s: %s: %s: bad interpreter: %s\n",
+                   sh_.shell_name.c_str(), file.c_str(), interp.c_str(),
+                   std::strerror(saved_errno));
+      return true;
+    };
     // A command name without `/' that has been hashed (`hash -p', BASH_CMDS)
     // execs the remembered path, as bash does; execvp() still falls back to a
     // $PATH search for the (unhashed) common case.
@@ -1876,7 +1906,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
         std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
                      exec_file == argv[0] ? "command not found" : "not found");
-      else
+      else if (!report_bad_interpreter(exec_file))
         std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
                      printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
@@ -1912,7 +1942,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
         std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
                      exec_file == argv[0] ? "command not found" : "not found");
-      else
+      else if (!report_bad_interpreter(exec_file))
         std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
                      printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3498,7 +3498,11 @@ static std::string tilde_assign(Shell &sh, const std::string &text);
 std::vector<std::string> Expander::expand_args(const std::vector<Word> &words) {
   std::vector<std::string> result;
   for (const Word &w : words) {
-    for (const std::string &braced : brace_expand(w.text)) {
+    // `set +B' turns brace expansion off entirely (bash's brace_expansion
+    // flag); the word passes through with its braces literal.
+    std::vector<std::string> braces =
+        sh_.opt_braceexpand ? brace_expand(w.text) : std::vector<std::string>{w.text};
+    for (const std::string &braced : braces) {
       // A word shaped like an assignment (name=value) gets assignment-style
       // tilde expansion -- after the `=' and after each `:' -- unless posix
       // mode is on.  (bash's W_ASSIGNMENT tilde rule.)

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -488,7 +488,17 @@ int main(int argc, char **argv) {
       std::fprintf(stderr, "%s: %s: Is a directory\n", args[idx].c_str(), args[idx].c_str());
       return 126;
     }
-    std::ifstream f(args[idx]);
+    // A script operand with no slash that is not in the current directory is
+    // searched for on $PATH (bash's find_path_file): `bash ls' finds /bin/ls.
+    std::string spath = args[idx];
+    {
+      struct stat pst;
+      if (spath.find('/') == std::string::npos && stat(spath.c_str(), &pst) != 0) {
+        std::string found = find_in_path(sh, spath);
+        if (!found.empty()) spath = found;
+      }
+    }
+    std::ifstream f(spath);
     if (!f) {
       std::fprintf(stderr, "%s: %s: %s\n", sh.shell_name.c_str(), args[idx].c_str(),
                    std::strerror(errno));
@@ -498,6 +508,15 @@ int main(int argc, char **argv) {
     ss << f.rdbuf();
     f.close();  // free the descriptor: the script must not occupy a low fd
                 // for its whole run (bash parks its script fd high)
+    const std::string &stext = ss.str();
+    // A binary is not a script: NUL bytes in the first 80 bytes (bash's
+    // check_binary_file sample) abort with status 126.
+    if (stext.compare(0, 2, "#!") != 0 &&
+        stext.find('\0') != std::string::npos && stext.find('\0') < 80) {
+      std::fprintf(stderr, "%s: %s: cannot execute binary file\n",
+                   sh.shell_name.c_str(), args[idx].c_str());
+      return 126;
+    }
     sh.arg0 = args[idx];
     sh.shell_name = args[idx];  // scripts report errors as "SCRIPT: line N: ..."
     sh.positional.assign(args.begin() + idx + 1, args.end());

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -30,8 +30,10 @@
 #include <unistd.h>
 #include <vector>
 
+#include "gnash/core/ast.hpp"
 #include "gnash/core/builtins.hpp"
 #include "gnash/core/expand.hpp"
+#include "gnash/core/parser.hpp"
 #include "gnash/core/shell.hpp"
 
 namespace {
@@ -107,6 +109,7 @@ std::string resolve_exec_path(std::string a0) {
 struct StartupOpts {
   bool norc = false;
   bool noprofile = false;
+  bool pretty_print = false;  // --pretty-print: parse and print, don't execute
   std::string rcfile;  // --rcfile / --init-file override for the personal rc
 };
 
@@ -368,7 +371,8 @@ int main(int argc, char **argv) {
       else if (lo == "norc") sopts.norc = true;
       else if (lo == "noprofile") sopts.noprofile = true;
       else if (lo == "posix") sh.opt_posix = true;
-      else if (lo == "noediting" || lo == "pretty-print" ||
+      else if (lo == "pretty-print") sopts.pretty_print = true;
+      else if (lo == "noediting" ||
                lo == "dump-strings" || lo == "dump-po-strings" || lo == "verbose" ||
                lo == "debug" || lo == "debugger" || lo == "restricted") {
         /* accepted (some not yet acted on), but recognized so they do not fall
@@ -516,6 +520,16 @@ int main(int argc, char **argv) {
       std::fprintf(stderr, "%s: %s: cannot execute binary file\n",
                    sh.shell_name.c_str(), args[idx].c_str());
       return 126;
+    }
+    if (sopts.pretty_print) {  // parse and print; nothing runs
+      gnash::core::ParseResult pr = gnash::core::parse(stext);
+      if (!pr.ok) {
+        std::fprintf(stderr, "%s: %s\n", sh.shell_name.c_str(), pr.error.c_str());
+        return 2;
+      }
+      if (pr.command)
+        std::fputs(gnash::core::pretty_print_string(pr.command.get()).c_str(), stdout);
+      return 0;
     }
     sh.arg0 = args[idx];
     sh.shell_name = args[idx];  // scripts report errors as "SCRIPT: line N: ..."

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -286,6 +286,33 @@ int main(int argc, char **argv) {
   shopt_seed(sh);  // seed default shopt states so $BASHOPTS is populated
   sh.import_env_functions();  // pull in any BASH_FUNC_*%% exported functions
 
+  // SHELLOPTS / BASHOPTS inherited through the environment pre-enable the
+  // options they list -- BEFORE the invocation flags are parsed, so a flag
+  // overrides (`SHELLOPTS=braceexpand bash +B' ends with braceexpand off).
+  // Unknown names are skipped silently (the exporter may be a different
+  // shell).  The variables themselves keep reading dynamically; the imported
+  // entry only carries the exported flag.
+  {
+    auto import_opts = [&sh](const char *nm, bool shellopts) {
+      auto it = sh.vars.find(nm);
+      if (it == sh.vars.end()) return;
+      const std::string v = it->second.value;
+      size_t p = 0;
+      while (p <= v.size()) {
+        size_t q = v.find(':', p);
+        std::string name = v.substr(p, (q == std::string::npos ? v.size() : q) - p);
+        if (!name.empty()) {
+          if (shellopts) apply_set_o_option(sh, name, true);
+          else if (sh.shopt_opts.count(name)) sh.shopt_opts[name] = true;
+        }
+        if (q == std::string::npos) break;
+        p = q + 1;
+      }
+    };
+    import_opts("SHELLOPTS", true);
+    import_opts("BASHOPTS", false);
+  }
+
   // Invocation name: basename of argv[0], minus a leading '-' (which marks a
   // login shell).  Drives error-message prefixes and startup-file names.
   std::string prog = argc > 0 ? argv[0] : "gnash";
@@ -296,8 +323,13 @@ int main(int argc, char **argv) {
   if (base.empty()) base = "gnash";
   sh.shell_name = base;
   // $0 defaults to argv[0] (as bash: `bash -c' shows "bash", "/bin/bash", etc.);
-  // a script path or a -c name argument overrides it below.
+  // a script path or a -c name argument overrides it below.  An exported
+  // BASH_ARGV0 overrides the default $0 at startup (bash's inherited ARGV0).
   sh.arg0 = prog;
+  {
+    auto av0 = sh.vars.find("BASH_ARGV0");
+    if (av0 != sh.vars.end() && !av0->second.value.empty()) sh.arg0 = av0->second.value;
+  }
   // Invoked as rbash / rsh / rksh (a leading `r'): a restricted shell.
   {
     auto sl = base.rfind('/');

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -230,7 +230,9 @@ void apply_set_o(Shell &sh, const std::string &name, bool set) {
   else if (name == "verbose") sh.opt_verbose = set;
   else if (name == "noexec") sh.opt_noexec = set;
   else if (name == "posix") sh.opt_posix = set;
-  // Other -o names (pipefail, vi, emacs, ...) are accepted and ignored.
+  // Everything else (braceexpand, pipefail, vi, ...) goes through the full
+  // `set -o' table so $SHELLOPTS reflects it; unknown names are ignored.
+  else apply_set_o_option(sh, name, set);
 }
 
 // Configure the shell's personality (which other shell it behaves as) and the
@@ -376,7 +378,8 @@ int main(int argc, char **argv) {
         case 'r': if (set) sh.opt_restricted = true; break;  // restricted shell
         case 'C': sh.opt_noclobber = set; break;  // noclobber: `>' won't overwrite
         case 'h': sh.opt_hashall = set; break;  // hashall (on by default)
-        case 'm': case 'B': case 'H':
+        case 'B': apply_set_o_option(sh, "braceexpand", set); break;
+        case 'm': case 'H':
           break;  // accepted, not (yet) acted on
         // `-c' takes its command from the next word, but other flags grouped in
         // the same word still apply -- `-ce cmd' means both `-c' and `-e'.  So

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -390,7 +390,7 @@ int main(int argc, char **argv) {
         return 0;
       } else {
         std::fprintf(stderr, "%s: %s: invalid option\n", sh.shell_name.c_str(), a.c_str());
-        show_shell_usage(sh.shell_name);
+        show_shell_usage(prog);  // usage names the shell as invoked (full path)
         return 2;
       }
       continue;
@@ -443,7 +443,7 @@ int main(int argc, char **argv) {
         }
         default:
           std::fprintf(stderr, "%s: -%c: invalid option\n", sh.shell_name.c_str(), o);
-          show_shell_usage(sh.shell_name);
+          show_shell_usage(prog);  // usage names the shell as invoked (full path)
           return 2;
       }
       if (stop_after) break;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -614,10 +614,19 @@ int main(int argc, char **argv) {
     sh.run_string(cmd);
   }
 
-  // A login shell reads ~/.<prefix>_logout as it exits.
+  // A login shell reads ~/.<prefix>_logout as it exits.  Like the startup
+  // files, the gnash persona falls back to the bash name: ~/.gnash_logout if
+  // present, else ~/.bash_logout.
   if (login && !sopts.noprofile) {
     const char *home = std::getenv("HOME");
-    if (home) source_if_exists(sh, std::string(home) + "/." + prefix + "_logout");
+    if (home) {
+      std::string own = std::string(home) + "/." + startup_prefix + "_logout";
+      struct stat lst;
+      if (startup_prefix == "gnash" && stat(own.c_str(), &lst) != 0)
+        own = std::string(home) + "/.bash_logout";
+      sh.exiting = false;  // `exit'/`logout' got us here; the file must still run
+      source_if_exists(sh, own);
+    }
   }
   return rc;
 }

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -720,7 +720,17 @@ struct Parser {
       newline_list();
     }
     if (reserved("{")) {  // bash allows a brace group as the body
-      n->body = parse_command({});
+      // The braces are grammar here, not a group command: bash's grammar
+      // (FOR WORD ... '{' compound_list '}') takes the inner LIST as the
+      // body, so pretty-print/declare -f show do/done, and a redirection
+      // after the `}' belongs to the loop itself (`{ ...; } <<<a').
+      CommandPtr body = parse_command({});
+      if (auto *g = dynamic_cast<Group *>(body.get())) {
+        n->redirects = std::move(g->redirects);
+        n->body = std::move(g->body);
+      } else {
+        n->body = std::move(body);
+      }
       parse_redirect_list(n->redirects);
       return n;
     }

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1436,6 +1436,11 @@ bool Shell::make_local(const std::string &n, bool inherit_force) {
 }
 
 bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
+  // $SHELLOPTS / $BASHOPTS always read the LIVE option state, even when an
+  // env-imported or `export'-created table entry exists (its stored value is
+  // stale; bash keeps these variables in sync with the options).
+  if (!is_zsh() && (n_in == "SHELLOPTS" || n_in == "BASHOPTS") && vars.count(n_in))
+    return const_cast<Shell *>(this)->dynamic_var(n_in, out);
   std::string base, sub;
   if (nameref_elt(n_in, base, sub)) {
     // Resolving the reference EVALUATES the subscript, and under `set -u' an
@@ -1881,6 +1886,10 @@ std::vector<std::string> Shell::environ_block() const {
           }
     }
     if (!emit) continue;
+    // An exported SHELLOPTS/BASHOPTS serializes its LIVE value: `export
+    // SHELLOPTS' then `set -o noglob' passes noglob to every child (bash).
+    if (kv.first == "SHELLOPTS" || kv.first == "BASHOPTS")
+      const_cast<Shell *>(this)->dynamic_var(kv.first, val);
     out.push_back(kv.first + "=" + val);
   }
   // Exported functions travel as BASH_FUNC_<name>%%=() {  body  }, which a


### PR DESCRIPTION
Closes #564. Takes **invocation.tests from 58 diff lines to byte-perfect** and fixes a racy `read -t` case surfaced by the sweep — **72 of 83 suites now at zero**.

Eight commits, each one conceptual change:

1. **feat(set): real braceexpand** — `set -B/+B`, `set -o braceexpand`, the `-B/+B` invocation flags and `$SHELLOPTS` all track a real flag; the expander skips brace expansion when off. Previously hard-coded on and unswitchable.
2. **feat(invocation): env SHELLOPTS/BASHOPTS/BASH_ARGV0 import** — inherited options pre-enable before invocation flags (which override); `$SHELLOPTS`/`$BASHOPTS` always read the live state even when a table entry exists (the stored stale string had been shadowing the dynamic value, so children printed nothing); an exported SHELLOPTS serializes its live value; `BASH_ARGV0` sets `$0` at startup.
3. **feat(invocation): script operand PATH search + binary detection** — `bash ls` finds /bin/ls, then fails with `cannot execute binary file` (126) on NULs in the first 80 bytes (skipped for `#!` files).
4. **feat(invocation): `--pretty-print`** — multiline (declare -f) format per top-level command with bash's two printer rules: outside a function def `;`/newline lists join inline (`done <<< a; echo x;`), and a brace-form loop body is grammar, not a group (inner list as body, redirection after `}` belongs to the loop).
5. **fix(invocation): usage banner** prints the shell as invoked (full path), like bash's `show_shell_usage`.
6. **fix(invocation): logout file** — `--login -c 'logout'` now runs `~/.bash_logout` (persona fallback + clearing `sh.exiting`, which had made the source a silent no-op).
7. **fix(executor): bad interpreter** — `./x23` with `#! nosuchfile` reports `./x23: nosuchfile: bad interpreter: No such file or directory` (no line number), matching bash's `shell_execve`.
8. **fix(read): `-t` deadline re-check on empty EOF** (bash `check_read_timeout`), with sub-millisecond timeouts counting as expired outright — bash's builtin setup exceeds them, so it reliably times out where gnash's tighter loop raced EOF (read7.sub; this one flapped with system load).

Note: the full sweep shows `trap 1` (an extra `CHLD` line) — present on clean main across repeated runs, timing-dependent, unrelated to this branch.

Verification: ctest 22/22; run_diff 359/359; full fresh-baseline sweep: invocation 58 → 0, read → 0, all other suites unchanged.