### PR TITLE
fix: six small-suite conformance gaps (set-x, parser, exp, posixexp, attr, array)

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -87,6 +87,9 @@ std::string to_string(const Command *c);
 // followed by a blank line (newline lists split into separate commands).
 std::string pretty_print_string(const Command *cmd);
 
+// One word's bash-canonical display text ($'...' decoded, $(...) re-rendered).
+std::string canonical_word_text(const std::string &w);
+
 std::string named_function_string(const std::string &name, const Command *body,
                                   bool posix = false);  // full canonical rendering
 

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -860,6 +860,11 @@ static bool func_name_is_assignment(const std::string &s) {
   return i < s.size() && s[i] == '=';
 }
 
+// The bash-canonical display text of one word ($'...' decoded, command
+// substitutions re-rendered) -- what xtrace's compound-assignment printer
+// shows for each element.
+std::string canonical_word_text(const std::string &w) { return canonical_word(w); }
+
 // bash --pretty-print: each top-level command renders in the multiline
 // (declare -f) format followed by a blank line; a top-level newline list
 // prints as separate commands, exactly as bash's one-command-per-read loop.

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1678,7 +1678,19 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       std::string opt = "-xg";
       if (array_flag) opt.push_back(array_flag);
       std::vector<std::string> d = {"export", opt, a};
+      // Rebuild the raw-provenance table to match the delegated argv, so
+      // bi_declare's quoted-vs-compound decision still sees whether THIS
+      // argument's parentheses were quoted in the source (attr2.sub:
+      // `export r=(4)' is a compound, `export r='(5)'' a literal string).
+      std::vector<Shell::RawArg> saved_raw = sh.raw_args;
+      std::vector<Shell::RawArg> draw(3);
+      draw[0] = {"export", false, false};
+      draw[1] = {opt, false, false};
+      if (i < saved_raw.size()) draw[2] = saved_raw[i];
+      else draw[2] = {a, false, a.find("=(") != std::string::npos};
+      sh.raw_args = draw;
       int r = bi_declare(sh, d, false, false);
+      sh.raw_args = saved_raw;
       if (r) st = r;
       // `export -n NAME=VALUE' still performs the assignment; it just does not
       // leave the name exported.
@@ -3416,6 +3428,20 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             e.second = std::to_string(eval_arith(sh, e.second, &iok));
           }
         sh.array_assign(name, pre_elems, append, as_assoc);
+      } else if (arraylit && !subscript && !unwrap_quoted &&
+                 !(i < sh.raw_args.size() && sh.raw_args[i].compound_assign)) {
+        // The parentheses were QUOTED (`readonly 'c=(3)''): with no explicit
+        // -a/-A this is not a compound assignment at all -- the literal
+        // string is the value, landing in element 0 when the variable is
+        // already an array (bash declare.def; attr.tests f3).  declare and
+        // typeset are excluded when the variable is already an array: they
+        // REPARSE a quoted compound there (`declare 'a=(1 2 3)'' --
+        // array19.sub), which is what unwrap_quoted captures.
+        Expander sex(sh);
+        if (!sh.set(name, sex.expand_assignment(val))) {
+          ret = 1;
+          continue;
+        }
       } else if (arraylit || subscript) {
         // An UNQUOTED compound (`declare -n array=(one two three)') is assigned
         // as an array literal even under -n; the "reference variable cannot be an

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -571,6 +571,15 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
       bool plain = rb != std::string::npos && rb + 1 < e.size() && e[rb + 1] == '=';
       if (app || plain) {
         std::string sub = ex.expand_no_split(e.substr(1, rb - 1));
+        // Bug-compat: in the ARITHMETIC (indexed) path a \001 byte in the
+        // expanded subscript collides with bash's internal CTLESC and
+        // vanishes (quoting the byte after it), so `[$'x\001y\177z']=foo'
+        // errors on `xy^?z', not `x^Ay^?z'.  An ASSOCIATIVE key keeps its
+        // bytes intact (exp8.sub tests both).
+        if (!assoc)
+          for (size_t cb = 0; cb < sub.size();)
+            if (sub[cb] == '\001') sub.erase(cb, 1), cb++;
+            else cb++;
         // The value of a `[sub]=value' element is an assignment RHS, so a `~'
         // tilde-expands at the start and after each unquoted `:' (bash); a bare
         // word element, handled below, only gets leading-tilde expansion.

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1288,10 +1288,24 @@ int Executor::run_simple(const SimpleCommand *c) {
         // `var[0]=X' assigns).
         pending_elem.push_back(a);
       } else if (a.is_array) {
-        // NOTE: an array/element assignment is not xtrace'd here -- bash prints it
-        // via its compound-assignment word-list deparser (each element expanded
-        // then re-quoted, e.g. source `$'\t'' -> `'<tab>''), which gnash does not
-        // reproduce; tracing the verbatim source word would not match.  Deferred.
+        if (sh_.opt_xtrace) {
+          // bash traces a compound assignment via its word-list deparser: the
+          // PARSED elements re-printed -- `$' '' shows as `' '' (lex-time
+          // ANSI expansion), `$@' stays unexpanded -- single-space separated
+          // (set-x2.sub).
+          std::string line = a.name + (a.append ? "+=(" : "=(");
+          bool first = true;
+          std::string inner = a.value.size() >= 2 ? a.value.substr(1, a.value.size() - 2)
+                                                  : std::string();
+          for (const Token &tk : tokenize(inner)) {
+            if (tk.type != Tok::Word || tk.text.empty()) continue;
+            if (!first) line += ' ';
+            line += canonical_word_text(tk.text);
+            first = false;
+          }
+          line += ')';
+          xtrace_lines.push_back(line);
+        }
         apply_array_assign(sh_, ex, a);  // array literal: applied now
       } else {
         auto vit = sh_.vars.find(a.name);

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -298,7 +298,18 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       }
       case RedirOp::HereDoc:
       case RedirOp::HereDocStrip: {
+        bool saved_ae = sh.arith_error;
+        sh.arith_error = false;
         std::string body = r.heredoc_quoted ? r.heredoc_body : ex.expand_heredoc(r.heredoc_body);
+        // An expansion failure in the body (`${'x1'%'t'}: bad substitution')
+        // aborts the redirection -- and with it the command -- as bash does
+        // (posixexp7.sub); the diagnostic was already printed, and later
+        // commands are unaffected.
+        if (sh.arith_error) {
+          sh.arith_error = saved_ae;
+          return false;
+        }
+        sh.arith_error = saved_ae;
         int f = heredoc_fd(body);
         if (f < 0) return false;
         return assign_fd(f);
@@ -430,7 +441,15 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
     }
     case RedirOp::HereDoc:
     case RedirOp::HereDocStrip: {
+      bool saved_ae = sh.arith_error;
+      sh.arith_error = false;
       std::string body = r.heredoc_quoted ? r.heredoc_body : ex.expand_heredoc(r.heredoc_body);
+      // A bad substitution in the body aborts the redirection (bash).
+      if (sh.arith_error) {
+        sh.arith_error = saved_ae;
+        return false;
+      }
+      sh.arith_error = saved_ae;
       int f = heredoc_fd(body);
       if (f < 0) return false;
       redir_to(f, target_fd < 0 ? 0 : target_fd);

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -179,7 +179,9 @@ struct Lexer {
     if (pos < n) w += in[pos++];
     else { unterminated = true; if (!unterm_close) { unterm_close = '`'; unterm_line = startln; } }
   }
-  void scan_paren(std::string &w, bool comsub_ctx = false) {  // pos at '('
+  void scan_paren(std::string &w, bool comsub_ctx = false,
+                  bool array_lit = false) {  // pos at '('
+    int startln = line_for(pos);  // the open line, reported for an unterminated array literal
     int depth = 0;
     struct PHd { std::string delim; bool strip; int depth; bool quoted; };
     std::vector<PHd> paren_heredocs;  // pending heredocs inside the parens
@@ -381,6 +383,30 @@ struct Lexer {
       } else if (c == '#' && !saw_word) {
         // A comment runs to the end of the line: a `)' in it is not the closer.
         while (pos < n && in[pos] != '\n') { w += in[pos]; pos++; }
+      } else if (array_lit && c == '[' && !saw_word) {
+        // A subscript at ELEMENT START of a compound assignment: bash scans
+        // the `[...]' as one unit (P_ARRAYSUB), so a `)' inside the brackets
+        // belongs to the subscript, not the literal -- `((X=([))]' therefore
+        // runs out of input still looking for the compound's `)'
+        // (parser.tests).
+        saw_word = true;
+        word_plain = false;
+        int bdepth = 0;
+        while (pos < n) {
+          char bc = in[pos];
+          if (bc == '\\' && pos + 1 < n) { w += bc; w += in[pos + 1]; pos += 2; continue; }
+          if (bc == '\'') { scan_single(w); continue; }
+          if (bc == '"') { scan_double(w); continue; }
+          if (bc == '[') bdepth++;
+          else if (bc == ']') {
+            w += bc;
+            pos++;
+            if (--bdepth == 0) break;
+            continue;
+          }
+          w += bc;
+          pos++;
+        }
       } else if (c == '\'') {
         saw_word = true; word_plain = false;
         scan_single(w);
@@ -411,7 +437,13 @@ struct Lexer {
     } while (pos < n && depth > 0);
     if (depth > 0) {
       unterminated = true;
-      if (!unterm_close) unterm_close = ')';
+      if (!unterm_close) {
+        unterm_close = ')';
+        // An unterminated ARRAY LITERAL reports its open line, like a quote
+        // (bash parse_matched_pair start_lineno); `$(' keeps the end-of-input
+        // line (parse_comsub) via unterm_line staying 0.
+        if (array_lit) unterm_line = startln;
+      }
       // NOTE: a here-document registered but whose BODY has not started is
       // deliberately not flagged here -- the `\' ending the delimiter word
       // itself (`<<\EOT\' + `4') is a line continuation that builds the
@@ -660,7 +692,7 @@ struct Lexer {
         // bash's parser treats `printf "%s\n" -a a=(a 'b  c')' (array1.sub);
         // leaving it unconsumed makes it an operator token the parser rejects.
         if (!assignment_acceptable()) break;
-        scan_paren(w);  // compound (array) assignment value: name=(...)
+        scan_paren(w, false, true);  // compound (array) assignment value: name=(...)
         quoted = true;
         continue;
       }


### PR DESCRIPTION
Closes #568. Takes **set-x, parser, exp, posixexp and attr to byte-perfect** (array stays at zero after a near-miss caught mid-branch) — **78 of 83 suites now at zero**.

Five commits:

1. **feat(xtrace):** compound array assignments now trace via bash's word-list deparser semantics — parsed elements re-printed (`$' '` → `' '`, `$@` unexpanded), single-space separated.
2. **fix(redir):** a bad substitution in a here-document body aborts the command like any redirection failure; previously the error printed and `cat` ran anyway.
3. **fix(arith):** CTLESC bug-compat — bash loses a `\001` byte from an *indexed* compound subscript, erroring on `xy^?z` rather than `x^Ay^?z`; associative keys keep their bytes (exp8.sub tests both, and the first draft that stripped both regressed the assoc case — caught by the suite).
4. **fix(lexer):** `[subscript]` at element start of an array literal scans as one unit (P_ARRAYSUB), so `((X=([))]` reports `unexpected EOF while looking for matching ')'` at the literal's open line.
5. **fix(declare):** quoted `name=(...)` with no `-a`/`-A` is a literal scalar value; declare/typeset still reparse against an existing array (`declare 'a=(1 2 3)'` — the case that initially regressed array19.sub and is now gated on `unwrap_quoted`); `export`'s delegation to declare rebuilds the raw-provenance table so the quoted-vs-compound decision sees the source word.

Verification: ctest 22/22; run_diff 359/359; full fresh-baseline sweep — remaining non-zero suites are only comsub-eof 8, comsub-posix 5, comsub2 4, coproc 11, exportfunc 7, nameref 2.