### PR TITLE
fix(coproc): high fd allocation, dead-coproc teardown

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -465,6 +465,7 @@ class Shell {
   // advertised once the process behind them is gone.
   std::string coproc_name;
   long coproc_pid = 0;
+  int coproc_rfd = -1, coproc_wfd = -1;  // parent ends; closed when reaped
   // Unset the coproc variables if its process has been reaped; a no-op while
   // it is still running, or when there is no coproc.
   void reap_coproc();

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -908,6 +908,10 @@ int Executor::run(const Command *c) {
 
   sh_.run_pending_traps();  // deliver any signals received between commands
 
+  // A dead coprocess is torn down (fds closed, NAME/NAME_PID unset) before
+  // the next command runs, as bash's SIGCHLD-driven coproc_reap does.
+  if (sh_.coproc_pid) sh_.reap_coproc();
+
   // $LINENO / error line.  bash installs a command's line for only a FEW
   // command types -- SET_LINE_NUMBER() appears in execute_cmd.c for the simple
   // command (run_simple sets its own, below), the subshell, `(( ))' and
@@ -2059,11 +2063,29 @@ int Executor::run_coproc(const CoprocCommand *c) {
     std::fprintf(stderr, "%scoproc: pipe: %s\n", sh_.err_prefix().c_str(), std::strerror(errno));
     return (sh_.last_status = 1);
   }
+  // bash's sh_openpipe moves each pipe end to the HIGHEST free descriptor
+  // below 64 (move_to_high_fd with maxfd 64) as soon as the pipe is created:
+  // the first coproc allocates 63/62 + 61/60 and publishes 63/60; a second
+  // one, started with those still open, gets 62/58 (coproc.tests).
+  auto move_high64 = [](int fd) {
+    int nfds = 64;
+    for (nfds--; nfds > 3; nfds--)
+      if (fcntl(nfds, F_GETFD) == -1) break;
+    if (nfds > 3 && fd != nfds && dup2(fd, nfds) != -1) {
+      close(fd);
+      return nfds;
+    }
+    return fd;
+  };
+  out_pipe[0] = move_high64(out_pipe[0]);
+  out_pipe[1] = move_high64(out_pipe[1]);
   if (pipe(in_pipe) < 0) {
     std::fprintf(stderr, "%scoproc: pipe: %s\n", sh_.err_prefix().c_str(), std::strerror(errno));
     close(out_pipe[0]); close(out_pipe[1]);
     return (sh_.last_status = 1);
   }
+  in_pipe[0] = move_high64(in_pipe[0]);
+  in_pipe[1] = move_high64(in_pipe[1]);
   bool jc = sh_.job_control;
   std::string cmd = to_string(c->body.get());
   pid_t pid = fork();
@@ -2086,18 +2108,16 @@ int Executor::run_coproc(const CoprocCommand *c) {
     std::fflush(nullptr);
     _exit(s & 0xff);
   }
-  // Parent: keep the shell's read/write ends, move them to high descriptors (so
-  // they do not collide with user redirections) and mark them close-on-exec.
+  // Parent: keep the shell's read/write ends (already on their high
+  // descriptors) and mark them close-on-exec, as bash does.
   close(in_pipe[0]);
   close(out_pipe[1]);
-  auto move_high = [](int fd) {
-    int hi = fcntl(fd, F_DUPFD, 10);
-    if (hi >= 0) { close(fd); fd = hi; }
-    fcntl(fd, F_SETFD, FD_CLOEXEC);
-    return fd;
-  };
-  int read_fd = move_high(out_pipe[0]);
-  int write_fd = move_high(in_pipe[1]);
+  int read_fd = out_pipe[0];
+  int write_fd = in_pipe[1];
+  fcntl(read_fd, F_SETFD, FD_CLOEXEC);
+  fcntl(write_fd, F_SETFD, FD_CLOEXEC);
+  sh_.coproc_rfd = read_fd;
+  sh_.coproc_wfd = write_fd;
   if (jc) setpgid(pid, pid);
   sh_.last_bg_pid = pid;
   Shell::Job *j = sh_.add_job(pid, {pid}, cmd, true);

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -210,12 +210,36 @@ int wait_job(Shell::Job &j) {
 // readonly array reports and survives.
 void Shell::reap_coproc() {
   if (coproc_pid == 0) return;
-  for (const auto &j : jobs)
+  // Poll for the coprocess's death (bash notices via SIGCHLD before the next
+  // command runs): a job entry not yet marked done gets one WNOHANG check
+  // here, so a coproc that exited immediately (`coproc nosuchcmd') is torn
+  // down before the following command reads its variables (coproc.tests).
+  bool alive = false;
+  for (auto &j : jobs)
     for (long p : j.pids)
-      if (p == coproc_pid && !j.done) return;  // still running
+      if (p == coproc_pid && !j.done) {
+        int wst = 0;
+        if (waitpid(static_cast<pid_t>(coproc_pid), &wst, WNOHANG) ==
+            static_cast<pid_t>(coproc_pid)) {
+          j.done = true;
+          j.running = false;
+          j.status = WIFEXITED(wst) ? WEXITSTATUS(wst)
+                                    : (WIFSIGNALED(wst) ? 128 + WTERMSIG(wst) : 128);
+          note_child_reaped();
+        } else {
+          alive = true;
+        }
+      }
+  if (alive) return;
   std::string nm = coproc_name;
   coproc_name.clear();
   coproc_pid = 0;
+  // bash's coproc_dispose closes the shell's ends of the pipes; without this
+  // the descriptors leak and the NEXT coproc gets lower numbers than bash's
+  // (a fresh one reuses 63/60 once these are gone -- coproc.tests).
+  if (coproc_rfd >= 0) close(coproc_rfd);
+  if (coproc_wfd >= 0) close(coproc_wfd);
+  coproc_rfd = coproc_wfd = -1;
   // Both names are resolved the way an ordinary `unset' would resolve them, so
   // `declare -n ref=x; coproc ref' tears down `x' and leaves `ref' alone.
   std::string tgt = deref(nm);


### PR DESCRIPTION
Closes #570. Takes **coproc.tests and nameref.tests to byte-perfect** — with #569, **80 of 83 suites now at zero**.

The `63/60` mystery from the old notes decoded: it isn't `move_to_high_fd`'s HIGH_FD_MAX (256) but `sh_openpipe`'s explicit `move_to_high_fd(fd, 1, 64)` — each pipe end moves to the highest free fd below 64 at creation. First coproc: pipes land on 63/62 and 61/60, shell keeps read=63/write=60. Second coproc with the first still open: 62/58.

Two more pieces: `reap_coproc` now closes the shell's pipe ends (bash `coproc_dispose`) — they leaked, which is why gnash's fds crept upward — and polls the child with WNOHANG per command, so `coproc xcase ...` (helper never built in the test tree, so the child dies instantly on exec failure in *both* shells) is torn down before the next command: `${COPROC[@]}` empty, `exec >&${COPROC[1]}-` degrades to `exec >&-`, and the subsequent `echo`/`read <&4` produce bash's exact `Bad file descriptor` diagnostics.

Verification: ctest 22/22; run_diff 359/359; sweep: coproc 11 → 0, nameref 2 → 0, others unchanged.