### PR TITLE
fix(parser,shell): add missing include and rename shadowing vars

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -6,6 +6,7 @@
 #include "gnash/core/parser.hpp"
 #include "gnash/core/subscript.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1983,12 +1983,12 @@ void Shell::set_personality(const std::string &name) {
     // bash always lists these as (empty) indexed arrays; their live values are
     // served dynamically by virtual_array for reads, so the stored array stays
     // empty and only surfaces in `declare'/`set' listings.
-    for (const char *nm : {"BASH_ARGC", "BASH_ARGV", "DIRSTACK"})
-      if (!vars.count(nm)) array_assign(nm, {}, false, false);
+    for (const char *var : {"BASH_ARGC", "BASH_ARGV", "DIRSTACK"})
+      if (!vars.count(var)) array_assign(var, {}, false, false);
     // BASH_ALIASES / BASH_CMDS are the associative equivalents (empty stored
     // arrays; virtual_array serves the live alias/hash tables for reads).
-    for (const char *nm : {"BASH_ALIASES", "BASH_CMDS"})
-      if (!vars.count(nm)) array_assign(nm, {}, false, true);
+    for (const char *var : {"BASH_ALIASES", "BASH_CMDS"})
+      if (!vars.count(var)) array_assign(var, {}, false, true);
     // GROUPS is the supplementary group list, with the REAL gid forced to
     // element 0: bash prepends it when getgroups() omits it and swaps it
     // forward when it is merely out of order (initialize_group_array).


### PR DESCRIPTION
include <algorithm> for std::sort
rename loop variables to avoid shadowing the nm variable