### PR TITLE
fix(lexer): enforce HEREDOC_MAX (17th here-document is fatal)

### DIFF
--- a/core/include/gnash/core/lexer.hpp
+++ b/core/include/gnash/core/lexer.hpp
@@ -70,6 +70,11 @@ struct Token {
   // warns and takes their bodies from the lines after the full command.
   int comsub_unterm = 0;
   int comsub_unterm_line = 0;
+  // Set on the Eof token when a single command registered more than
+  // HEREDOC_MAX (16) here-documents: bash's push_heredoc reports a fatal
+  // `maximum here-document count exceeded' and exits the shell.
+  bool heredoc_overflow = false;
+  int heredoc_overflow_line = 0;
   // For a here-document delimiter word, the collected body and whether the
   // delimiter was quoted (which disables expansion of the body).
   std::string heredoc_body;

--- a/core/include/gnash/core/parser.hpp
+++ b/core/include/gnash/core/parser.hpp
@@ -52,6 +52,10 @@ struct ParseResult {
   // warns `command substitution: N unterminated here-document').
   int comsub_unterm = 0;
   int comsub_unterm_line = 0;
+  // A command registered more than HEREDOC_MAX (16) here-documents: bash's
+  // push_heredoc reports `maximum here-document count exceeded' and exits.
+  bool heredoc_overflow = false;
+  int heredoc_overflow_line = 0;
 };
 
 // Parse a complete program.

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -79,6 +79,9 @@ struct Lexer {
   int comsub_unterm = 0;
   int comsub_unterm_line = 0;
   int awaiting = -1;  // -1 none, 0 <<, 1 <<-
+  int cmd_heredocs = 0;  // here-documents registered for the current command
+  bool heredoc_overflow = false;  // > HEREDOC_MAX on one command (fatal, bash)
+  int heredoc_overflow_line = 0;
   bool unterminated = false;
   char unterm_close = 0;  // the closer we were looking for at EOF
   // The line the unterminated span STARTED on.  bash's parse_matched_pair
@@ -947,6 +950,7 @@ struct Lexer {
         pos++;
         if (!pending.empty()) collect_heredocs();
         awaiting = -1;
+        cmd_heredocs = 0;  // need_here_doc resets once the bodies are gathered
         continue;
       }
       if (c == '#') {  // comment to end of line
@@ -992,6 +996,12 @@ struct Lexer {
         std::string d = dequote_delim(t.text, q);
         pending.push_back({out.size() - 1, d, awaiting == 1, q});
         awaiting = -1;
+        // bash's push_heredoc: the 17th here-document on one command is a
+        // fatal syntax error (HEREDOC_MAX == 16).
+        if (++cmd_heredocs > 16 && !heredoc_overflow) {
+          heredoc_overflow = true;
+          heredoc_overflow_line = t.line;
+        }
       }
     }
     // A here-doc redirection with no newline after it (input ended on the
@@ -1014,6 +1024,8 @@ struct Lexer {
     eof.heredoc_eof_quoted = heredoc_eof_quoted;
     eof.comsub_unterm = comsub_unterm;
     eof.comsub_unterm_line = comsub_unterm_line;
+    eof.heredoc_overflow = heredoc_overflow;
+    eof.heredoc_overflow_line = heredoc_overflow_line;
     out.push_back(eof);
   }
 };

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -1217,6 +1217,15 @@ struct Parser {
 
   ParseResult run() {
     ParseResult res;
+    // A too-many-here-documents overflow is a fatal syntax error that
+    // supersedes everything else the parse might have found.
+    if (!toks.empty() && toks.back().heredoc_overflow) {
+      res.ok = false;
+      res.error = "maximum here-document count exceeded";
+      res.error_line = toks.back().heredoc_overflow_line;
+      res.heredoc_overflow = true;
+      return res;
+    }
     if (!toks.empty() && toks.back().lex_error) {
       res.ok = false;
       res.incomplete = true;  // unterminated quote/substitution

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2517,6 +2517,19 @@ int Shell::run_string(const std::string &script, const std::vector<int> *cont_li
                       ? parse_with_aliases(script, aliases, global_aliases, suffix_aliases,
                                            opt_posix, cont_lines)
                       : parse(script, opt_posix, cont_lines);
+  if (!r.ok && r.heredoc_overflow) {
+    // A fatal `maximum here-document count exceeded': bash prints it bare
+    // (no `syntax error' prefix) and exits the shell with status 2.
+    std::string ctx;
+    if (!error_context.empty()) ctx = error_context + ": ";
+    else if (invocation_char == 'c') ctx = "-c: ";
+    std::fprintf(stderr, "%s: %sline %d: maximum here-document count exceeded\n",
+                 shell_name.c_str(), ctx.c_str(),
+                 lineno_base + (r.error_line > 0 ? r.error_line : 1));
+    exiting = true;
+    exit_status = 2;
+    return (last_status = 2);
+  }
   if (!r.ok) {
     // bash's format: `NAME: [CONTEXT: ][-c: ]line N: syntax error...' per
     // message line; "near unexpected token" joins without a colon, and the

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -543,6 +543,27 @@ echo "L=$LINENO"'
   'export LC_ALL=en_US.UTF-8; IFS=$'"'"'\254'"'"'; t="+$'"'"'\342\202\254'"'"'+"; set -- $t; echo $#'
   # ...but ${x##pat} drops to bytes when the pattern is invalid multibyte.
   'export LC_ALL=en_US.UTF-8; e=$'"'"'\342\202\254'"'"'; echo "${e##*$'"'"'\202'"'"'}" | od -An -b | tr -s " "'
+  # HEREDOC_MAX (16): the 17th here-document on one command is fatal.
+  'cat <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A; echo unreached'
+  # ...but 16 on one command is fine.
+  'cat <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A <<A >/dev/null
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+A
+echo ok16'
 )
 
 fails=0


### PR DESCRIPTION
Closes #573. Takes **exportfunc.tests from 7 to 5 diff lines**.

bash's `push_heredoc` caps here-documents per command at 16 (`HEREDOC_MAX`) and makes the 17th a fatal `maximum here-document count exceeded` that exits the shell. gnash accepted any number. The lexer now counts per-command here-document registrations (reset when a newline gathers the bodies, mirroring bash's `need_here_doc`), flags an overflow, and the parser surfaces it as a fatal error printed bare with the offending line, exiting with status 2.

The remaining 5 exportfunc lines, and comsub2/comsub-posix/comsub-eof, are all bash line-number/parse-error artifacts (the `parse_and_execute` `line_number--` offset, `for`/`select`-in-function-body `compoundcmd_lineno`, funsub-in-redirection-subscript parsing, case-in-comsub scan errors, and the heredoc-at-comsub-EOF behavior bash's own source comments flag as a bug it intends to fix). Those are documented for a later, dedicated pass.

Verification: ctest 22/22; run_diff **all 361 scripts match** (2 new cases: 17-heredoc overflow fatal, 16 allowed); full sweep — exportfunc 7 → 5, every other suite unchanged (read's 10µs-timeout line flakes in bash's own baseline, unrelated).