### PR TITLE
ci(cla): run the CLA action under Node 24

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -64,8 +64,12 @@ jobs:
           !(github.event_name == 'pull_request_target' &&
             (github.event.pull_request.user.login == 'brianjfox' ||
              endsWith(github.event.pull_request.user.login, '[bot]')))
-        # Pin to the latest release of contributor-assistant/github-action.
-        uses: contributor-assistant/github-action@v2.6.1
+        # contributor-assistant/github-action is archived and its every release
+        # declares `runs.using: node20', which GitHub is removing from Actions
+        # runners (fall 2026).  Pinned by SHA to our fork of its v2.6.1 release
+        # with only `action.yml' bumped to node24 -- the bundled dist/index.js
+        # is unchanged.  See brianjfox/github-action, tag v2.6.1-node24.
+        uses: brianjfox/github-action@d771e8b34a69d4395a6e3ac9ebe3bc219e3e1fea
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Closes #578.

GitHub is removing Node 20 from Actions runners (runners defaulted to Node 24 on 2026-06-16; Node 20 removed fall 2026 — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Our `cla` check ran `contributor-assistant/github-action@v2.6.1`, whose `action.yml` declares `runs.using: "node20"`.

That upstream action is **archived and read-only** — every release is node20 and there will be no Node 24 release (its README says to fork). So this points the CLA step at **`brianjfox/github-action`**, a fork of the v2.6.1 release with a single one-line change — `action.yml`'s `runs.using: node20` → `node24`. The bundled `dist/index.js` (1.18 MB) is byte-identical and runs as-is under Node 24, so there's no rebuild and no behavior change beyond the runtime.

Pinned by full commit SHA (`d771e8b`, tag `v2.6.1-node24`) so the fork can't shift under us.

Note: `pull_request_target` runs the **base** branch's workflow, so this only takes effect once merged to main — this PR's own `cla` check still runs the old node20 action.