### PR TITLE
fix(printf,echo): negative %(...)T epochs and echo \x with no hex digit

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -89,6 +89,10 @@ std::string decode_b(const std::string &s, bool &stop, bool bare_octal = true) {
           v = v * 16 + (h <= '9' ? h - '0' : (std::tolower(h) - 'a' + 10));
           k++;
         }
+        // `\x' with no hex digit is not an escape for `echo -e' -- bash emits
+        // the literal `\x' rather than a NUL byte (the octal `\NNN' path is
+        // likewise disabled for echo via bare_octal).
+        if (k == 0 && !bare_octal) { out += "\\x"; break; }
         out += static_cast<char>(v);
         break;
       }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -483,13 +483,16 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
           size_t close = fmt.find(")T", j);
           if (close != std::string::npos) {
             std::string datefmt = fmt.substr(j + 1, close - (j + 1));
+            // The argument is seconds since the epoch, with two special
+            // values (bash printf.def): -1 (the default when no argument is
+            // given) is the current time, and -2 is the shell's start time.
+            // Every other value -- INCLUDING other negatives -- is a literal
+            // time_t, so a pre-1970 date like -86400 formats as 1969-12-31.
             std::string a = next();
-            time_t when;
-            if (a.empty()) when = std::time(nullptr);
-            else {
-              long v = std::strtol(a.c_str(), nullptr, 10);
-              when = (v < 0) ? std::time(nullptr) : static_cast<time_t>(v);
-            }
+            long long v = a.empty() ? -1 : std::strtoll(a.c_str(), nullptr, 10);
+            time_t when = (v == -1) ? std::time(nullptr)
+                        : (v == -2) ? static_cast<time_t>(sh.seconds_base)
+                                    : static_cast<time_t>(v);
             struct tm tmv;
             localtime_r(&when, &tmv);
             char tbuf[256];


### PR DESCRIPTION
Two independent escape/format bugs in `builtins.cpp`, both reported by @Gustav-Simonsson.

**Closes #576** — `printf '%(DATEFMT)T'` sent every negative argument to the current time. bash gives `-1` (and the no-argument default) the current time and `-2` the shell's start time, but treats all other values — including other negatives — as a literal `time_t`, so `printf '%(%Y-%m-%d)T' -86400` is `1969-12-31`, not today.

**Closes #575** — `echo -e '\x'` (no hex digit) emitted a NUL byte; bash prints the literal two characters `\x`. The `\NNN` octal path was already disabled for echo via `bare_octal`; the `\x` path now takes the same guard. `printf %b` keeps its own behaviour.

Verified against bash for `%(...)T` args `-1 / -2 / -86400 / 0 / 86400` and the no-arg default, and for `echo -e` `\x` / `\x ` / `\x41`. ctest 22/22, run_diff 361/361.