### PR TITLE
fix(printf): %c empty-arg NUL and %l length modifiers

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -508,7 +508,26 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
             continue;
           }
         }
-        std::string spec = fmt.substr(i, j - i + 1);
+        // A C length modifier (l, ll, h, hh, L, j, z, t) before a numeric or
+        // floating conversion is accepted and ignored: bash formats through
+        // intmax_t / long double regardless, and gnash promotes to long/double
+        // below.  Skip it so the real conversion char drives the dispatch and
+        // `spec' carries no length modifier -- otherwise `%ld' lands on `l',
+        // matches nothing, and the literal spec is printed.  (`q' is NOT a
+        // length modifier here: `%q' is bash's shell-quote conversion.)
+        // `%ls' / `%lc' in a multibyte locale are NOT length-modified -- they
+        // are the wide string/char forms handled specially below.
+        size_t flagsend = j;  // end of flags/width/precision
+        bool wide_lsc = conv == 'l' && j + 1 < fmt.size() &&
+                        (fmt[j + 1] == 's' || fmt[j + 1] == 'c') && MB_CUR_MAX > 1;
+        if (!wide_lsc) {
+          while (j < fmt.size() && std::strchr("lhLjzt", fmt[j])) j++;
+          if (j >= fmt.size()) { out += '%'; break; }  // dangling `%l' at end
+          conv = fmt[j];
+        }
+        std::string spec = wide_lsc
+            ? fmt.substr(i, j - i + 1)
+            : fmt.substr(i, flagsend - i) + std::string(1, conv);
         if (conv == '%') {
           out += '%';
         } else if (conv == 'q') {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -597,7 +597,9 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
           consumed_any = true;
         } else if (conv == 'c') {
           std::string a = next();
-          if (!a.empty()) out += a[0];
+          // An empty argument (explicit "" or a missing one) prints a single
+          // NUL byte, as bash does -- not nothing.
+          out += a.empty() ? '\0' : a[0];
           consumed_any = true;
         } else if (conv == 'd' || conv == 'i' || conv == 'x' || conv == 'X' ||
                    conv == 'o' || conv == 'u') {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -564,6 +564,14 @@ A
 A
 A
 echo ok16'
+  # printf %c with an empty/missing argument emits one NUL byte (not nothing).
+  'printf "%c" "" | od -An -tx1 | tr -s " "'
+  'printf "[%c]" "" "" | od -An -c | tr -s " "'
+  # printf accepts (and ignores) the l length modifier on numeric/float convs;
+  # %q stays the shell-quote conversion, not a length-modified `q'.
+  'printf "%ld|%5ld|%lx|%lX|%lo|%lu\n" 42 42 255 255 64 42'
+  'printf "%lf|%le|%lg\n" 3.14 3.14 3.14'
+  'printf "%q %q %q\n" "a b" "it'"'"'s" "*.x"'
 )
 
 fails=0


### PR DESCRIPTION
Two `printf` bugs in `builtins.cpp`, both reported by @Gustav-Simonsson.

**Closes #581** — a length modifier before a numeric/float conversion (`%ld`, `%lf`, `%lx`, `%lX`, `%lo`, `%lu`, `%le`, `%lg`, …) landed on the `l` instead of the conversion char, matched no branch, and printed the literal format string. The scanner now skips a C length-modifier run (`l`/`ll`/`h`/`hh`/`L`/`j`/`z`/`t`) so the real conversion drives the dispatch and `spec` carries no modifier. Deliberately **excludes `q`** — `%q` is bash's shell-quote conversion (I caught a regression where including `q` broke `%q`, now covered by a harness case) — and preserves the wide `%ls`/`%lc` handling in multibyte locales.

**Closes #577** — `printf "%c" ""` produced no output; bash emits a single NUL byte (and treats a missing argument identically). Now emits `\0` for an empty argument.

Verified against bash: all 11 `%lX` forms, `%c` for explicit-empty / missing / normal args, `%q`, and `%ls`/`%lc`/`%s`/`%d` unchanged. ctest 22/22, run_diff **all 366 match** (5 new regression cases).