### PR TITLE
fix(expand): parameter-expansion validation (new-exp.tests)

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -70,7 +70,8 @@ class Expander {
   // Value of a parameter (including specials); `set` reports whether it was set.
   // `defaulting_op' is set by ${x-…}/${x:-…}/${x=…}/${x+…}/${x?…} callers, where
   // an unset variable is handled by the operator and must NOT trip `set -u'.
-  std::string param_value(const std::string &name, bool &set, bool defaulting_op = false);
+  std::string param_value(const std::string &name, bool &set, bool defaulting_op = false,
+                          bool braced = false);
 
   // Replace any <(cmd) / >(cmd) in WORD with a /dev/fd/N path, forking the inner
   // command and recording it on the shell for later cleanup.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2291,6 +2291,31 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     return std::string();
   }
 
+  // Validate the ${!...} prefix-listing form (${!PREFIX*} / ${!PREFIX@})
+  // up front.  It is well-formed only when the `*'/`@' is the final character
+  // and the prefix is empty (${!*}, ${!@}) or a valid identifier (${!x*}).
+  // A non-identifier prefix (${!1*}), a doubled special (${!@*}), or trailing
+  // junk (${!_Q* }) is a bad substitution.  Keys (${!a[@]}) have a `[' before
+  // the `@'/`*' and are left to the array path.
+  if (b.size() > 1 && b[0] == '!') {
+    size_t bracket = b.find('[', 1);
+    size_t sp = b.find_first_of("*@", 1);
+    if (sp != std::string::npos && (bracket == std::string::npos || sp < bracket)) {
+      std::string pre = b.substr(1, sp - 1);
+      // A valid identifier prefix starts with a letter or `_' (not a digit).
+      bool ident = !pre.empty() &&
+                   (std::isalpha(static_cast<unsigned char>(pre[0])) || pre[0] == '_');
+      for (char c : pre)
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) ident = false;
+      bool ok = (pre.empty() || ident) && sp + 1 == b.size();
+      if (!ok) {
+        std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+        sh.arith_error = true;
+        return std::string();
+      }
+    }
+  }
+
   // ${!name} indirection and ${!prefix*}/${!prefix@} name listing.  A `['
   // after the name is the ${!arr[@]} keys form, handled by the array path.
   if (b.size() > 1 && b[0] == '!' &&

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -584,7 +584,8 @@ static std::string tilde_assign(Shell &sh, const std::string &text) {
   return out;
 }
 
-std::string Expander::param_value(const std::string &name, bool &set, bool defaulting_op) {
+std::string Expander::param_value(const std::string &name, bool &set, bool defaulting_op,
+                                  bool braced) {
   set = true;
   if (name == "?") return std::to_string(sh_.last_status);
   if (name == "$") return sh_.get("$");
@@ -647,7 +648,10 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     // `set -u': an unset positional is an unbound-variable error too
     // (`sh -uc 'echo $1'' -- posixexp1.sub).
     if (sh_.opt_nounset && !defaulting_op) {
-      std::fprintf(stderr, "%s$%s: unbound variable\n", sh_.err_prefix().c_str(), name.c_str());
+      // bash names an unbound positional `$N' for the bare `$N' form but `N'
+      // for the braced `${N}' form.
+      std::fprintf(stderr, "%s%s%s: unbound variable\n", sh_.err_prefix().c_str(),
+                   braced ? "" : "$", name.c_str());
       sh_.exiting = true;
       sh_.exit_status = 127;
     }
@@ -2584,7 +2588,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       return std::string();
     }
   } else {
-    val = ex.param_value(name, set, defaulting_op);
+    val = ex.param_value(name, set, defaulting_op, /*braced=*/true);
   }
   if (length) return std::to_string(mb_charlen(val));
   return apply_param_op(ex, sh, name, val, set, rest, dq, have_sub, tsub, /*top_level=*/true);

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2404,6 +2404,16 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     }
   }
 
+  // A command or arithmetic substitution in parameter-NAME position
+  // (`${$(cmd)}', `${$((expr))}') is not a valid parameter: bash reports a
+  // bad substitution rather than treating the leading `$' as the PID.  (`${$}'
+  // alone is still the PID.)
+  if (b.size() >= 2 && b[0] == '$' && b[1] == '(') {
+    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+    sh.arith_error = true;
+    return std::string();
+  }
+
   size_t p = 0;
   std::string name;
   bool named_by_quote = false;
@@ -2779,13 +2789,24 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
                         [&](const std::string &cs) { return pat_match(pat, cs); });
   }
 
-  // ${name@op} -- parameter transformations.
-  if (rest[0] == '@' && rest.size() >= 2) {
+  // ${name@op} -- parameter transformations.  The operator must be exactly one
+  // known transform letter; a missing one (`${v@}') or an unknown one
+  // (`${v@C}') is a bad substitution -- but only once the parameter is set, as
+  // bash validates the operator after the unset-to-empty step.
+  if (rest[0] == '@') {
+    bool valid = rest.size() == 2 && std::strchr("UuLQEPAaKk", rest[1]) != nullptr;
     // @a/@A report the variable's attributes even when its scalar context
     // (element 0) is unset -- an assoc array without ["0"] still has them.
-    if (!set && !(rest[1] == 'a' || rest[1] == 'A') )
-      return std::string();  // unset -> empty (even for @Q)
+    bool attr = valid && (rest[1] == 'a' || rest[1] == 'A');
+    if (!set && !attr) return std::string();  // unset -> empty (even for @Q)
     if (!set && sh.vars.find(name) == sh.vars.end()) return std::string();
+    if (!valid) {
+      std::string bodytxt = name + (have_sub ? "[" + sub + "]" : "") + rest;
+      std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
+                   bodytxt.c_str());
+      sh.arith_error = true;
+      return std::string();
+    }
     char t = rest[1];
     // Scalar/bare-name @k/@K quote the (element-0) value like @Q; the array
     // subscript forms ${a[@]@k}/${a[@]@K} are handled at the array dispatch.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -813,8 +813,12 @@ static bool slice_ref(const std::string &body, std::string &name, char &sel,
 // A negative length in an ARRAY slice is a hard error in bash (only a scalar
 // substring reads one as an offset from the end).  Report it and abort the
 // command, as any other expansion error does.
-static void slice_len_error(Shell &sh, long long len) {
-  std::fprintf(stderr, "%s%lld: substring expression < 0\n", sh.err_prefix().c_str(), len);
+static void slice_len_error(Shell &sh, const std::string &lenx) {
+  // bash quotes the length expression as WRITTEN (`$(($# - 2))'), not its
+  // evaluated value, so an array slice with a negative length reproduces the
+  // source text in the diagnostic.
+  std::fprintf(stderr, "%s%s: substring expression < 0\n", sh.err_prefix().c_str(),
+               lenx.c_str());
   sh.arith_error = true;
   sh.arith_abort = true;  // bash unwinds the whole command list, not just this word
 }
@@ -1876,7 +1880,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             if (!ok) len = 0;
             // Unlike a scalar substring, an array slice has no "from the end"
             // reading: bash rejects any negative length outright.
-            if (len < 0) slice_len_error(sh_, len);
+            if (len < 0) slice_len_error(sh_, slenx);
             count = len < 0 ? 0 : len;  // the error already abandons the list
           } else {
             count = static_cast<long long>(keys.size());
@@ -1900,7 +1904,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (shaslen) {
             long long len = eval_arith(sh_, expand_no_split(slenx, false, false), &ok);
             if (!ok) len = 0;
-            if (len < 0) slice_len_error(sh_, len);
+            if (len < 0) slice_len_error(sh_, slenx);
             count = len < 0 ? 0 : len;  // the error already abandons the list
           } else {
             count = n - off;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -582,6 +582,19 @@ echo ok16'
   # $GNASH_* tunables), so compare only the bash-derived portion up to the
   # last shared entry, which must still match bash byte-for-byte.
   'help variables | sed -n "/^variables:/,/should be saved on the history list/p"'
+  # Parameter-expansion validation (new-exp.tests).  Fold stderr and strip the
+  # `NAME: line N: ` prefix so the diagnostic text is what is compared.
+  'echo "${!1*}" 2>&1 | sed -E "s/.*line [0-9]+: //"'      # digit prefix listing
+  'echo "${!@*}" 2>&1 | sed -E "s/.*line [0-9]+: //"'      # doubled special
+  '_Qa=1; echo "${!_Q* }" 2>&1 | sed -E "s/.*line [0-9]+: //"'  # trailing junk
+  'echo "${!@}"; echo "${!*}"'                             # valid: empty prefix
+  'v=hi; echo "${v@}" 2>&1 | sed -E "s/.*line [0-9]+: //"' # empty transform op
+  'v=hi; echo "${v@C}" 2>&1 | sed -E "s/.*line [0-9]+: //"' # unknown transform op
+  'unset v; echo "[${v@C}]"'                               # unset: empty, no error
+  'echo "${$((1))}" 2>&1 | sed -E "s/.*line [0-9]+: //"'   # arith in name position
+  'echo "${$(echo x)}" 2>&1 | sed -E "s/.*line [0-9]+: //"' # comsub in name position
+  'set -u; echo "${9}" 2>&1 | sed -E "s/.*line [0-9]+: //"; set -u; echo "$9" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'set a; echo "${@:1:$(($# - 2))}" 2>&1 | sed -E "s/.*line [0-9]+: //"'  # neg length raw text
 )
 
 fails=0


### PR DESCRIPTION
The validation cluster from the `new-exp.tests` investigation — cases where gnash silently accepted (or mis-handled) a parameter expansion that bash rejects. Five commits:

- **`${!prefix*}` / `${!prefix@}`** — well-formed only when the `*`/`@` is the final char and the prefix is empty (`${!*}`, `${!@}`) or a valid identifier (`${!x*}`). A digit prefix (`${!1*}`), doubled special (`${!@*}`), or trailing junk (`${!_Q* }`) is now `bad substitution` (previously accepted or mis-read as indirect).
- **`${var@op}`** — must be exactly one known transform (`U u L Q E P A a K k`); an unknown op (`${x@C}`) or a missing one (`${v@}`) is now `bad substitution` — but only once the parameter is set (unset → empty first, matching bash). Also **`${$(cmd)}` / `${$((expr))}`** (an expansion in parameter-name position) is now `bad substitution`, not the PID.
- **array-slice negative length** — the error now quotes the length expression as written (`$(($# - 2)): substring expression < 0`) rather than its evaluated value.
- **braced positional under `set -u`** — `${N}` now reports `N: unbound variable` (bare `$N` still reports `$N:`), matching bash.

Verification: builds clean; ctest 22/22; run_diff **all 383 scripts match** (11 new validation cases); `new-exp.tests` **279 → 269**, no suite regressed.

Note: the broader `new-exp`/`exp`/`posixexp`/`glob`/`more-exp` counts you may see reflect the newly-installed `recho` test helper exposing pre-existing word-splitting divergences (the "cluster I" family) — identical on clean `main`, tracked separately, not part of this change.