### PR TITLE
fix(jobs): report a foreground job's stop only once

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1219,8 +1219,10 @@ int Executor::run_pipeline(const Connection *c) {
     Shell::Job *j = sh_.add_job(pgid, lp, to_string(c), false);
     j->stopped = true;
     j->running = false;
-    if (sh_.interactive)
+    if (sh_.interactive) {
       std::fprintf(stderr, "\n[%d]+  Stopped                 %s\n", j->id, j->command.c_str());
+      j->notified = true;  // bash J_NOTIFIED: don't report again at the next prompt
+    }
     st = 128 + SIGTSTP;
   }
 
@@ -2005,8 +2007,10 @@ int Executor::run_simple(const SimpleCommand *c) {
       j->stopped = true;
       j->running = false;
       status = 128 + SIGTSTP;
-      if (sh_.interactive)
+      if (sh_.interactive) {
         std::fprintf(stderr, "\n[%d]+  Stopped                 %s\n", j->id, cmd.c_str());
+        j->notified = true;  // bash J_NOTIFIED: don't report again at the next prompt
+      }
     } else {
       sh_.note_child_reaped();  // a foreground subshell that terminated
       status = WIFEXITED(wst) ? WEXITSTATUS(wst) : (128 + WTERMSIG(wst));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,14 @@ add_executable(command_complete_test command_complete_test.cpp)
 target_link_libraries(command_complete_test PRIVATE gnash::core gnash_warnings)
 add_test(NAME command_complete_test COMMAND command_complete_test)
 
+# Interactive job-control notices, driven over a pty against the built shell.
+add_executable(job_notify_test job_notify_test.cpp)
+target_link_libraries(job_notify_test PRIVATE gnash_warnings)
+if(NOT APPLE)
+  target_link_libraries(job_notify_test PRIVATE util)  # forkpty lives in libutil
+endif()
+add_test(NAME job_notify_test COMMAND job_notify_test $<TARGET_FILE:gnash>)
+
 # Differential execution check vs bash over the implemented feature set.
 if(BASH_EXECUTABLE)
   add_test(

--- a/tests/job_notify_test.cpp
+++ b/tests/job_notify_test.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// job_notify_test.cpp -- interactive job-control notification behavior.
+// Runs the built gnash on a pty, suspends a foreground command with ^Z, and
+// checks the resulting job notices against bash's behavior.
+//
+// Usage: job_notify_test <path-to-gnash>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+
+static int failures = 0;
+
+// Read everything the shell writes to the pty until it stays quiet for
+// `settle_ms', appending to `out'.  Returns false once the child hangs up.
+static bool drain(int fd, std::string &out, int settle_ms) {
+  for (;;) {
+    struct pollfd p = {fd, POLLIN, 0};
+    int r = poll(&p, 1, settle_ms);
+    if (r <= 0) return true;  // quiet: caller may continue
+    char buf[4096];
+    ssize_t n = read(fd, buf, sizeof buf);
+    if (n <= 0) return false;  // EIO/EOF: shell exited
+    out.append(buf, static_cast<size_t>(n));
+  }
+}
+
+static void send(int fd, const char *s, std::string &out) {
+  (void)!write(fd, s, std::strlen(s));
+  drain(fd, out, 400);
+}
+
+static size_t count_of(const std::string &hay, const std::string &needle) {
+  size_t n = 0;
+  for (size_t at = hay.find(needle); at != std::string::npos;
+       at = hay.find(needle, at + needle.size()))
+    n++;
+  return n;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: %s <gnash>\n", argv[0]);
+    return 2;
+  }
+
+  int master = -1;
+  pid_t pid = forkpty(&master, nullptr, nullptr, nullptr);
+  if (pid < 0) {
+    perror("forkpty");
+    return 2;
+  }
+  if (pid == 0) {
+    setenv("PS1", "T> ", 1);
+    unsetenv("ENV");
+    execl(argv[1], argv[1], "-i", static_cast<char *>(nullptr));
+    _exit(127);
+  }
+
+  std::string out;
+  drain(master, out, 600);  // initial prompt
+
+  send(master, "sleep 300\r", out);
+  send(master, "\x1a", out);  // ^Z: stop the foreground job
+  drain(master, out, 600);    // let the next prompt (and any late notice) land
+
+  // The stop of a foreground job is reported exactly once (bash prints one
+  // "[1]+  Stopped" line, not one at stop time and another before the prompt).
+  size_t notices = count_of(out, "Stopped");
+  if (notices != 1) {
+    std::fprintf(stderr, "FAIL expected exactly 1 Stopped notice after ^Z, got %zu\n%s\n",
+                 notices, out.c_str());
+    failures++;
+  }
+
+  // Clean up: kill the stopped sleep and leave the shell.
+  send(master, "kill -9 %1\r", out);
+  send(master, "exit\r", out);
+  send(master, "exit\r", out);
+  close(master);
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+
+  if (failures == 0) std::printf("job_notify_test: all tests passed\n");
+  return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #590.

## Root cause

Both foreground-stop paths in `core/src/executor.cpp` (pipeline and simple command) print the `[n]+ Stopped` notice as soon as `waitpid` reports `WIFSTOPPED`, but leave the new job's `notified` flag unset. The pre-prompt `reap_jobs(true)` pass then finds a stopped, unreported job and prints the identical notice a second time.

## Fix

Mark the job `notified` at the point the notice is printed, matching bash, which sets `J_NOTIFIED` when a job's status is reported.

## Verification

- New pty-driven regression test `tests/job_notify_test.cpp` (registered in ctest) suspends a foreground command with ^Z in an interactive gnash and asserts the `Stopped` notice appears exactly once. Verified it fails against the pre-fix binary and passes after the fix.
- Manual pty reproduction (`sleep 300` + ^Z) now prints one notice, matching bash.
- Full ctest suite: 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)