### PR TITLE
fix(jobs): make a foreground job stopped with ^Z the current job

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1219,6 +1219,7 @@ int Executor::run_pipeline(const Connection *c) {
     Shell::Job *j = sh_.add_job(pgid, lp, to_string(c), false);
     j->stopped = true;
     j->running = false;
+    sh_.set_current_job(j->id);  // bash: a job that stops becomes the current job
     if (sh_.interactive) {
       std::fprintf(stderr, "\n[%d]+  Stopped                 %s\n", j->id, j->command.c_str());
       j->notified = true;  // bash J_NOTIFIED: don't report again at the next prompt
@@ -2006,6 +2007,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       Shell::Job *j = sh_.add_job(pid, {pid}, cmd, false);
       j->stopped = true;
       j->running = false;
+      sh_.set_current_job(j->id);  // bash: a job that stops becomes the current job
       status = 128 + SIGTSTP;
       if (sh_.interactive) {
         std::fprintf(stderr, "\n[%d]+  Stopped                 %s\n", j->id, cmd.c_str());

--- a/tests/job_notify_test.cpp
+++ b/tests/job_notify_test.cpp
@@ -88,8 +88,27 @@ int main(int argc, char **argv) {
     failures++;
   }
 
-  // Clean up: kill the stopped sleep and leave the shell.
-  send(master, "kill -9 %1\r", out);
+  // A job that stops becomes the current job: `jobs' marks it `+' and a bare
+  // `%' jobspec resolves to it (bash set_job_status_and_cleanup bumps
+  // call_set_current on a stop).
+  std::string jout;
+  send(master, "jobs\r", jout);
+  if (jout.find("[1]+") == std::string::npos) {
+    std::fprintf(stderr, "FAIL expected the stopped job marked [1]+ in jobs output\n%s\n",
+                 jout.c_str());
+    failures++;
+  }
+  out += jout;
+
+  // Kill the stopped sleep through the current-job spec and leave the shell.
+  std::string kout;
+  send(master, "kill -9 %\r", kout);
+  if (kout.find("no such job") != std::string::npos) {
+    std::fprintf(stderr, "FAIL `kill -9 %%' did not resolve the current job\n%s\n",
+                 kout.c_str());
+    failures++;
+  }
+  out += kout;
   send(master, "exit\r", out);
   send(master, "exit\r", out);
   close(master);


### PR DESCRIPTION
Fixes #592.

## Root cause

The foreground-stop paths in `core/src/executor.cpp` (pipeline and simple command) add the stopped job to the table but never update the current job — `add_job` only calls `reset_current()` for background jobs. The stopped job therefore had no `+` mark in `jobs` output, and current-job specs (`%`, `%%`, `%+`, bare `fg`/`bg`) failed with `no such job`.

## Fix

Call `set_current_job()` on the new job in both paths, matching bash's `set_job_status_and_cleanup`, which bumps `call_set_current` whenever a job stops. The background-stop path in `Shell::check_job_events` already did this.

## Verification

- Extended `tests/job_notify_test.cpp` (pty-driven) to assert `jobs` marks the stopped job `[1]+` and that `kill -9 %` resolves it. Verified the new assertions fail against the pre-fix binary and pass after the fix.
- Full ctest suite: 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)