### PR TITLE
fix(glob): honor nocaseglob in pathname expansion

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3441,6 +3441,9 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
   // `shopt -u globskipdots' lets `.' and `..' be matched.
   auto gsd = sh_.shopt_opts.find("globskipdots");
   if (gsd != sh_.shopt_opts.end() && !gsd->second) gflags |= GX_NODOTSKIP;
+  // `shopt -s nocaseglob': match filenames case-insensitively.
+  auto ncg = sh_.shopt_opts.find("nocaseglob");
+  if (ncg != sh_.shopt_opts.end() && ncg->second) gflags |= GX_NOCASE;
   // A non-null $GLOBIGNORE also enables dot matching, then filters out any
   // result matching one of its colon-separated patterns.
   std::string globignore = sh_.get("GLOBIGNORE");


### PR DESCRIPTION
Fixes #594.

## Root cause

`libglob` already implements case folding (`GX_NOCASE` → `FNM_CASEFOLD` in `libglob/src/glob.cpp`), but the expander's glob call site in `core/src/expand.cpp` never consulted the `nocaseglob` shopt, so the option was accepted yet had no effect.

## Fix

Pass `GX_NOCASE` when `nocaseglob` is set, alongside the neighboring `dotglob`/`globskipdots` flag handling.

## Verification

- bash-testsuite scoreboard: `glob.tests` 18 diff lines → 0 (byte-perfect vs bash 5.3).
- Manual: `shopt -s nocaseglob; echo b*` now matches `Beware` like bash; unset restores case-sensitive matching.
- ctest 23/23; `run_diff.sh` all 383 scripts match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)