### PR TITLE
fix(expand): keep "$@" fields for $@ in a quoted substitute word

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1382,6 +1382,22 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
               if (dq && !sh_.is_zsh() && !has_at) {
                 std::string ex = expand_dq_word(word);
                 for (char c : ex) { out += c; mask += '1'; }
+              } else if (dq && !sh_.is_zsh()) {
+                // Quoted ${p±word} whose word carries $@/[@]: the whole word
+                // is inside the surrounding quotes, so the splat keeps "$@"
+                // field structure (one field per element, no IFS splitting)
+                // and literal text glues to the first/last field
+                // (`"${1+  $@  }"' -> `<  abc> ... <jkl  >').  The word's own
+                // unescaped double quotes are quote-removed only -- they don't
+                // change semantics inside the outer quotes (`a"b" c' -> ab c).
+                std::string w;
+                bool esc = false;
+                for (char c : word) {
+                  if (esc) { w += c; esc = false; continue; }
+                  if (c == '\\') { w += c; esc = true; continue; }
+                  if (c != '"') w += c;
+                }
+                process("\"" + w + "\"", out, mask, false, false);
               } else if (heredoc) {
                 // Inside ${...} in a here-document, DOUBLE quotes and
                 // backslash escapes are active (`${P+\"$P\"}' emits `"A"',

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -595,6 +595,14 @@ echo ok16'
   'echo "${$(echo x)}" 2>&1 | sed -E "s/.*line [0-9]+: //"' # comsub in name position
   'set -u; echo "${9}" 2>&1 | sed -E "s/.*line [0-9]+: //"; set -u; echo "$9" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'set a; echo "${@:1:$(($# - 2))}" 2>&1 | sed -E "s/.*line [0-9]+: //"'  # neg length raw text
+  # Unquoted $@ in a QUOTED ${var±word} substitute keeps "$@" field structure:
+  # one field per positional, literal word text glued to the first/last field.
+  'f() { for a in "$@"; do echo "[$a]"; done; }; set "a b" c d; f "${1+$@}"'
+  'f() { for a in "$@"; do echo "[$a]"; done; }; set abc def; f "${1+  $@  }"'
+  'f() { for a in "$@"; do echo "[$a]"; done; }; set "a b" c; unset foo; f "${foo- x$@y }"'
+  'f() { for a in "$@"; do echo "[$a]"; done; }; set "a b" c; unset foo; f "${foo-"$@" tail}"'
+  'f() { for a in "$@"; do echo "[$a]"; done; }; unset foo; f "${foo-a"b  c"d}"; set --; f "${foo-x$@y}"'
+  'f() { for a in "$@"; do echo "[$a]"; done; }; set -- "" x; unset foo; f "${foo-$@}"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #596.

## Root cause

In `expand_dollar`'s fire path for `${var±word}`, a double-quoted brace whose word contains `$@`/`[@]` fell through to the unquoted-default-word branch, which IFS-splits the positionals' contents and remaps the word's literal text to splittable.

## Fix

Add a dq-with-splat branch that expands the word inside the surrounding quotes: the word is re-processed wrapped in double quotes (its own unescaped quotes stripped — they are quote-removal only inside the outer quotes), so `$@` emits one field per positional and literal text glues to the first/last field, matching bash.

## Verification

- Probed bash 5.3 across the corner cases (inner-quoted `"$@"`, glue text, empty positionals, no positionals, quote toggling `a"b" c`, `$*` joining) — gnash output now byte-identical on all of them.
- Scoreboard: exp.tests 13 → 4 diff lines; more-exp.tests 11 → 0 (byte-perfect).
- 6 new run_diff regression cases; 5 fail against the pre-fix binary, all 389 match after.
- ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)