### PR TITLE
fix(expand): unescape \" in a double-quoted backquote substitution

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2938,8 +2938,12 @@ void Expander::process_dq(const std::string &text, size_t &i, std::string &out,
       size_t j = i + 1;
       std::string inner;
       while (j < text.size() && text[j] != '`') {
+        // In double-quote context, backslash in a backquote substitution is
+        // also special before `"' (`"`echo \"hi\"`"' runs `echo "hi"'), on
+        // top of the usual `` \` ``/`\\'/`\$' rule.
         if (text[j] == '\\' && j + 1 < text.size() &&
-            (text[j + 1] == '`' || text[j + 1] == '\\' || text[j + 1] == '$')) {
+            (text[j + 1] == '`' || text[j + 1] == '\\' || text[j + 1] == '$' ||
+             text[j + 1] == '"')) {
           inner += text[j + 1];
           j += 2;
         } else {
@@ -3045,6 +3049,9 @@ std::string Expander::expand_arith(const std::string &text) {
       size_t j = i + 1;
       std::string inner;
       while (j < text.size() && text[j] != '`') {
+        // Unlike real double quotes, arithmetic context keeps `\"' intact in
+        // a backquote substitution (`$((`echo \"1\"`))' is bash's arithmetic
+        // syntax error, not 1): only `` \` ``/`\\'/`\$' are special here.
         if (text[j] == '\\' && j + 1 < text.size() &&
             (text[j + 1] == '`' || text[j + 1] == '\\' || text[j + 1] == '$')) {
           inner += text[j + 1];

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -612,6 +612,12 @@ echo ok16'
   'unset SECONDS; SECONDS=5; echo "[$SECONDS]"'
   'unset LINENO; LINENO=999; echo "[$LINENO]"'
   'unset EPOCHSECONDS BASHPID BASH_SUBSHELL HISTCMD; echo "[$EPOCHSECONDS][$BASHPID][$BASH_SUBSHELL][$HISTCMD]"'
+  # Backquotes in double quotes also unescape \" (the inner command sees real
+  # quote syntax); unquoted backquotes and arithmetic context keep \" intact.
+  'echo "`echo \"Hi there\"`"'
+  'echo `echo \"Hi\"`'
+  'echo "`echo \\\"x\\\"`"'
+  'echo $((`echo \"1\"`+1)) 2>&1 | sed -E "s/.*line [0-9]+: //"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #600.

## Root cause

`Expander::process_dq`'s backquote scanner collected the inner command text unescaping only `` \` ``, `\\`, `\$`. In double-quote context bash also strips a backslash before `"`, so the inner command sees real quote syntax.

## Fix

Add `"` to the unescape set in the `process_dq` scanner only. Verified bash does *not* apply this rule in arithmetic context (`$((`echo \"1\"`))` is an arithmetic syntax error in bash) — that scanner keeps the old rule, with a comment pinning the distinction. Unquoted backquotes were already correct.

## Verification

- Probe scripts (dq, unquoted, double-escaped, arith contexts) byte-identical vs bash 5.3.
- Scoreboard: exp.tests 2 → 0 — **byte-perfect**; arith stays 0.
- 4 new run_diff regression cases (3 fail pre-fix); all 399 match post-fix. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)