### PR TITLE
fix(expand): space-join unquoted @-splats in a substitute word

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -94,6 +94,14 @@ class Expander {
   // bytes that happen to equal FIELD_SEP/QNULL).  op_fields_ signals a pending
   // splice; expand_dollar clears it before, and consumes it after, each body.
   bool op_fields_ = false;
+  // Expanding an UNQUOTED ${var±word} substitute word: an unquoted @-splat
+  // there is space-joined (splittable) instead of emitting hard field breaks
+  // (bash's acknowledged inconsistency -- posixexp4.sub).
+  bool subst_word_ = false;
+  // Emit the separator between two unquoted @-splat fields: a hard field
+  // break normally; a splittable space in a substitute word with a non-empty
+  // IFS (with a NULL IFS bash keeps the fields separate even there).
+  void splat_sep(std::string &out, std::string &mask);
   std::string op_out_, op_mask_;
 
   // Expand W (a substitute word) into op_out_/op_mask_ preserving field markers,

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1095,11 +1095,16 @@ void Expander::emit_array_items(const std::vector<std::string> &items, char sel,
     bool first = true;
     for (size_t k = 0; k < items.size(); k++) {
       if (splitting_ && items[k].empty()) continue;
-      if (!first) { out += FIELD_SEP; mask += MMARK; }
+      if (!first) splat_sep(out, mask);
       first = false;
       for (char c : items[k]) { out += c; mask += '0'; }
     }
   }
+}
+
+void Expander::splat_sep(std::string &out, std::string &mask) {
+  if (subst_word_ && !sh_.ifs().empty()) { out += ' '; mask += '0'; }
+  else { out += FIELD_SEP; mask += MMARK; }
 }
 
 void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::string &out,
@@ -1318,7 +1323,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           bool first = true;
           for (size_t k = 0; k < pos.size(); k++) {
             if (splitting_ && pos[k].empty()) continue;
-            if (!first) { out += FIELD_SEP; mask += MMARK; }
+            if (!first) splat_sep(out, mask);
             first = false;
             for (char c : pos[k]) { out += c; mask += '0'; }
           }
@@ -1425,8 +1430,17 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
                 process("\"" + w2 + "\"", out, mask, false, false);
               } else {
                 // Unquoted default word: a leading `~' tilde-expands (bash).
+                // While the word expands, an unquoted @-splat is space-JOINED
+                // (splittable) rather than emitted as hard fields -- bash's
+                // acknowledged inconsistency (posixexp4.sub): under IFS=: the
+                // whole join stays one word, while a plain unquoted $@ keeps
+                // its fields.  $* (including its null-IFS separate-fields
+                // form) and quoted "$@" are not affected.
                 size_t m0 = mask.size();
+                bool sw0 = subst_word_;
+                subst_word_ = true;
                 process(expand_leading_tilde(sh_, word), out, mask, false, false);
+                subst_word_ = sw0;
                 // The replacement is EXPANSION OUTPUT: its unquoted literal
                 // text IFS-splits like a parameter's value (`${IFS+foo 'b c'
                 // baz}' is three fields, the middle protected by its quotes).
@@ -1625,7 +1639,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             bool first = true;
             for (size_t k = 0; k < items.size(); k++) {
               if (splitting_ && items[k].empty()) continue;
-              if (!first) { out += FIELD_SEP; mask += MMARK; }
+              if (!first) splat_sep(out, mask);
               first = false;
               for (char c : items[k]) { out += c; mask += '0'; }
             }
@@ -2042,7 +2056,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       bool first = true;
       for (size_t k = 0; k < pos.size(); k++) {
         if (splitting_ && pos[k].empty()) continue;
-        if (!first) { out += FIELD_SEP; mask += MMARK; }
+        if (!first) splat_sep(out, mask);
         first = false;
         for (char c : pos[k]) { out += c; mask += '0'; }
       }

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -618,6 +618,13 @@ echo ok16'
   'echo `echo \"Hi\"`'
   'echo "`echo \\\"x\\\"`"'
   'echo $((`echo \"1\"`+1)) 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  # Unquoted @-splats in an UNQUOTED ${var±word} substitute are space-joined
+  # then IFS-split (bash posixexp4 quirk): one word under IFS=:, separate
+  # fields under a null IFS, ordinary splitting under the default IFS.
+  'f() { echo "n=$#"; for a; do echo "[$a]"; done; }; set -- " abc" "def ghi"; IFS=:; unset v; f ${v-$@}; f ${v-${@}}'
+  'f() { echo "n=$#"; for a; do echo "[$a]"; done; }; a=("x y" z); IFS=:; unset v; f ${v-${a[@]}}'
+  'f() { echo "n=$#"; for a; do echo "[$a]"; done; }; set -- "a b" "" c; IFS=; unset v; f ${v-$@}; f ${v-$*}'
+  'f() { echo "n=$#"; for a; do echo "[$a]"; done; }; set -- "a b" "" c; unset v; f ${v-$@}; f ${v-"$@"}'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #602.

## Root cause

The unquoted default-word branch of the `${var±word}` fire path re-processes the word, and the unquoted `@`-splat emitters insert hard FIELD_SEP markers there just as for a plain unquoted `$@` — but bash space-joins the splat in this context and lets ordinary IFS splitting act on the result (its posixexp4.sub documents the inconsistency). With `IFS=:` the join must stay one word; with a null IFS bash keeps separate fields (empties dropped).

## Fix

New `Expander::subst_word_` flag set while the unquoted substitute word expands; the four unquoted `@`-splat emitters (bare `$@`, `${@}`, plain `${a[@]}`, array-items helper) go through a shared `splat_sep()` that emits a splittable space instead of a field break when the flag is set and IFS is non-empty. `$*` and quoted `"$@"` behavior is untouched.

## Verification

- 15-case probe matrix (IFS=: / null / default / unset, `$@`/`${@}`/`${a[@]}`/`"$@"`/`$*`, empty positionals, no positionals, glue text, `+` op) — byte-identical to bash 5.3.
- Scoreboard: posixexp.tests 8 → 0 — **byte-perfect**; exp/more-exp/quote/ifs/dstack stay 0; full-suite sweep shows no regressions (invocation's pre-existing divergence reproduces identically with the 2.0.3 release binary).
- 4 new run_diff regression cases (2 fail pre-fix); all 403 match post-fix. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)