### PR TITLE
feat(expand): implement patsub_replacement (& in ${var/pat/rep})

### DIFF
--- a/core/include/gnash/core/expand.hpp
+++ b/core/include/gnash/core/expand.hpp
@@ -30,6 +30,11 @@ class Expander {
   std::string expand_no_split(const std::string &text, bool do_glob = false,
                               bool do_procsub = true);
 
+  // expand_no_split, but also returning the per-char quoting mask (aligned
+  // with the result).  Used by ${var/pat/rep}: patsub_replacement needs to
+  // know which `&'/`\&' of the replacement were quoted.
+  std::string expand_no_split_masked(const std::string &text, std::string &mask_out);
+
   // Expand a word that will be used as a match pattern (case patterns,
   // [[ == ]] right sides): quoted characters are backslash-escaped in the
   // result so the matcher treats them literally, while unquoted glob

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2827,18 +2827,46 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     // independent of whether the enclosing ${...} is double-quoted -- so single
     // quotes, double quotes, and a backslash before any character are all
     // processed (`\'' -> `'', `'ab'' -> `ab'), matching bash.
+    std::string repmask;
     std::string rep = slash == std::string::npos
                           ? std::string()
-                          : ex.expand_no_split(body2.substr(slash + 1));
+                          : ex.expand_no_split_masked(body2.substr(slash + 1), repmask);
+    // shopt patsub_replacement (default on): an UNQUOTED, unescaped `&' in the
+    // replacement -- literal in the word (mask '2') or arriving from an
+    // unquoted expansion ('0'/'4') -- expands to the matched text; `\&' is a
+    // literal `&' and `\\' a literal backslash.  Quoted portions are inert
+    // (the word's own `\&'/"&" already reach here quote-removed, mask '1').
+    // bash enables the machinery only when the expanded replacement contains
+    // an `&' at all (quoted or not); a replacement without one keeps its
+    // backslashes untouched.
+    auto ps = sh.shopt_opts.find("patsub_replacement");
+    bool amp_active = ps != sh.shopt_opts.end() && ps->second &&
+                      rep.find('&') != std::string::npos;
+    auto apply_rep = [&](const std::string &matched) {
+      if (!amp_active) return rep;
+      std::string r;
+      for (size_t k = 0; k < rep.size(); k++) {
+        if (repmask[k] != '1' && rep[k] == '\\' && k + 1 < rep.size() &&
+            (rep[k + 1] == '&' || rep[k + 1] == '\\')) {
+          r += rep[k + 1];
+          k++;
+        } else if (repmask[k] != '1' && rep[k] == '&') {
+          r += matched;
+        } else {
+          r += rep[k];
+        }
+      }
+      return r;
+    };
     // `#' matches the longest prefix, `%' the longest suffix; one replacement.
     if (anchor == '#') {
       for (size_t j = val.size() + 1; j-- > 0;)
-        if (pat_match(pat, val.substr(0, j))) return rep + val.substr(j);
+        if (pat_match(pat, val.substr(0, j))) return apply_rep(val.substr(0, j)) + val.substr(j);
       return val;
     }
     if (anchor == '%') {
       for (size_t j = 0; j <= val.size(); j++)
-        if (pat_match(pat, val.substr(j))) return val.substr(0, j) + rep;
+        if (pat_match(pat, val.substr(j))) return val.substr(0, j) + apply_rep(val.substr(j));
       return val;
     }
     if (pat.empty()) return val;
@@ -2851,7 +2879,7 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
         if (pat_match(pat, val.substr(k, j - k))) { best = j; break; }
       }
       if (best != std::string::npos && (!did || global)) {
-        result += rep;
+        result += apply_rep(val.substr(k, best - k));
         k = (best == k) ? k + 1 : best;  // avoid infinite loop on empty match
         did = true;
         if (!global) {
@@ -3790,6 +3818,29 @@ std::string Expander::expand_regex(const std::string &text) {
     r += c;
   }
   return r;
+}
+
+std::string Expander::expand_no_split_masked(const std::string &text, std::string &mask_out) {
+  std::string src = expand_leading_tilde(sh_, text);
+  std::string out, mask;
+  bool saved_split = splitting_;
+  splitting_ = false;  // result is flattened, so $* joins with IFS[0]
+  process(src, out, mask, false);
+  splitting_ = saved_split;
+  // Drop internal markers, keeping the mask aligned: field separators become
+  // spaces (splittable-marked), quoted-nulls vanish.
+  std::string joined, jmask;
+  joined.reserve(out.size());
+  for (size_t k = 0; k < out.size(); k++) {
+    if (k < mask.size() && mask[k] == MMARK) {
+      if (out[k] == FIELD_SEP) { joined += ' '; jmask += '0'; }
+      continue;
+    }
+    joined += out[k];
+    jmask += k < mask.size() ? mask[k] : '2';
+  }
+  mask_out = jmask;
+  return joined;
 }
 
 std::string Expander::expand_no_split(const std::string &text, bool do_glob, bool do_procsub) {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -629,6 +629,12 @@ echo ok16'
   # visible (set) variables are listed, and an empty quoted @ list drops.
   'f() { echo "n=$#"; for a; do echo "[$a]"; done; }; _QA=1 _QB=2; IFS="-$IFS"; f "${!_Q*}"; f "${!_Q@}"; f ${!_Q*}; f "${!_Y@}"'
   'declare _QUNSET; _QA=1; echo "[${!_Q*}]"'
+  # patsub_replacement: unquoted & in the replacement expands to the match,
+  # \& is literal, quoted portions are inert, shopt -u restores literal &.
+  's=abcdefg; echo ${s/abc/& }; echo "${s//?/& }"; echo ${s/abc/\& }; echo ${s/abc/"& "}; echo ${s/abc/\\& }'
+  's=abcdefg; r="x&y"; echo ${s/abc/$r}; echo ${s/abc/"$r"}; r2="x\&y"; echo ${s/abc/$r2}'
+  's=abcdefg; shopt -u patsub_replacement; echo ${s/abc/& }; echo ${s/abc/\&}; r="\\&"; echo ${s/abc/"$r"}'
+  's=abcdefg; echo ${s/#abc/&-}; echo ${s/%efg/-&}'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #607.

## What

Implements bash 5.2's `patsub_replacement`: with the option on (the default), an unquoted, unescaped `&` in the expanded replacement of `${var/pat/rep}` expands to the matched portion of the value; `\&` is a literal `&`, `\\` a literal backslash; quoted portions are inert. The machinery only engages when the expanded replacement contains an `&` (bash parity — otherwise backslashes pass through untouched). `shopt -u patsub_replacement` restores literal behavior.

## How

New `Expander::expand_no_split_masked()` returns the per-char quoting mask alongside the flattened expansion — the existing mask already distinguishes every case the feature needs (`'1'` quoted/escaped, `'2'` literal word text, `'0'`/`'4'` expansion output). A per-match `apply_rep()` lambda is used by the anchored (`/#`, `/%`), single, and global replacement paths.

## Verification

- `new-exp16.sub` (the full 45-case patsub_replacement matrix: quoting variants, variable-sourced replacements, shopt toggling) byte-identical to bash 5.3.
- 4 new run_diff regression cases (3 fail pre-fix); all 409 match post-fix. ctest 23/23; exp/posixexp/more-exp/quote/ifs/varenv/assoc/array all stay 0.
- Note: the new-exp *suite* score is currently dominated by a separate performance hang in the replace-all scan on large values (the 45s harness timeout truncates the run); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)