### PR TITLE
fix(expand): full attribute reporting for the @A/@a transforms

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -49,6 +49,22 @@ constexpr char QNULL = '\x02';
 // literal data (e.g. $'\001').
 constexpr char MMARK = 'M';
 
+// Attribute letters in bash's fixed order (var_attribute_string), matching
+// declare_var_string's rendering: a A i n r x c l u.  Used by @a/@A.
+static std::string var_attr_flags(const Variable &var) {
+  std::string flags;
+  if (var.kind == VarKind::Indexed) flags += 'a';
+  if (var.kind == VarKind::Assoc) flags += 'A';
+  if (var.integer) flags += 'i';
+  if (var.nameref) flags += 'n';
+  if (var.readonly) flags += 'r';
+  if (var.exported) flags += 'x';
+  if (var.capcase) flags += 'c';
+  if (var.lcase) flags += 'l';
+  if (var.ucase) flags += 'u';
+  return flags;
+}
+
 bool pat_match(const std::string &pattern, const std::string &text) {
   std::string p = pattern, t = text;
   return strmatch(p.data(), t.data(), FNM_EXTMATCH) == 0;
@@ -1752,7 +1768,20 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       char asel;
       if (array_op_ref(body, aoname, asel, arest)) {
         std::vector<std::string> items;
-        if (arest == "@A") {
+        // Whole-array @a on a declared-but-unset array: one word of attribute
+        // letters (a set array reports per element via the generic path; an
+        // invisible one has no elements, yet bash still prints its flags).
+        if (arest == "@a") {
+          std::string dn = sh_.deref(aoname);
+          auto vit = sh_.vars.find(dn);
+          if (vit != sh_.vars.end() && vit->second.invisible) {
+            items.push_back(var_attr_flags(vit->second));
+          } else {
+            items = sh_.array_values(aoname);
+            for (std::string &it : items)
+              it = apply_param_op(*this, sh_, aoname, it, true, arest, dq);
+          }
+        } else if (arest == "@A") {
           // Whole-array @A: a single `declare' statement recreating the array,
           // emitted as its three top-level words (`declare', `-flags',
           // `name=(...)') -- quoted it stays three words, unquoted the third is
@@ -3022,19 +3051,18 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (t == 'a' || t == 'A') {
       auto it = sh.vars.find(name);
       std::string flags;
-      bool is_arr = false, is_assoc = false;
+      bool invisible = false;
       if (it != sh.vars.end()) {
-        const Variable &var = it->second;
-        is_arr = var.kind == VarKind::Indexed;
-        is_assoc = var.kind == VarKind::Assoc;
-        if (is_arr) flags += 'a';
-        if (is_assoc) flags += 'A';
-        if (var.integer) flags += 'i';
-        if (var.readonly) flags += 'r';
-        if (var.exported) flags += 'x';
+        flags = var_attr_flags(it->second);
+        invisible = it->second.invisible;
       }
       if (t == 'a') return flags;
-      // @A: reproduce a declare/assignment statement.
+      // @A: reproduce a declare/assignment statement.  A declared-but-unset
+      // variable prints its attributes and name with NO value part; one with
+      // no attributes at all expands to nothing.
+      if (it == sh.vars.end()) return std::string();
+      if (invisible)
+        return flags.empty() ? std::string() : "declare -" + flags + " " + name;
       std::string q = atq_quote(val);
       if (flags.empty()) return name + "=" + q;
       return "declare -" + flags + " " + name + "=" + q;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -635,6 +635,11 @@ echo ok16'
   's=abcdefg; r="x&y"; echo ${s/abc/$r}; echo ${s/abc/"$r"}; r2="x\&y"; echo ${s/abc/$r2}'
   's=abcdefg; shopt -u patsub_replacement; echo ${s/abc/& }; echo ${s/abc/\&}; r="\\&"; echo ${s/abc/"$r"}'
   's=abcdefg; echo ${s/#abc/&-}; echo ${s/%efg/-&}'
+  # @A/@a report full attributes in bash order; declared-but-unset variables
+  # print attributes+name with no value (or nothing when attribute-free).
+  'declare -lr V1; echo "[${V1@A}][${V1@a}]"; declare -alr V3; echo "[${V3@A}][${V3[@]@A}][${V3[@]@a}]"'
+  'declare P; echo "[${P@A}][${P@a}]"; unset Z; echo "[${Z@A}]"; X=hi; echo "[${X@A}]"'
+  'A2=(x); declare -r A2; echo "[${A2[@]@A}]"; b=(x y); declare -r b; echo "[${b[@]@a}]"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #611.

## Root cause

`apply_param_op`'s scalar `@a`/`@A` branch rebuilt the attribute string from a stale subset (`a A i r x`) instead of the `declare_var_string` logic, always appended `=value` even for declared-but-unset variables, and the whole-array `[@]@a` form produced nothing for an invisible array.

## Fix

New shared `var_attr_flags()` helper with bash's `var_attribute_string` order (`a A i n r x c l u` for gnash's modeled subset), used by both the scalar branch and a new invisible-array `[@]@a` case. `@A` on a declared-but-unset variable renders attributes+name with no value part; with no attributes at all it expands to nothing, matching bash.

## Verification

- Probe matrix (unset with flags, plain declared, set scalar/array, readonly arrays, `-itux` combos) byte-identical to bash 5.3.
- Scoreboard: new-exp 118 → 94; exp/posixexp/more-exp/varenv/assoc/array stay 0.
- 3 new run_diff regression cases; all 412 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)