### PR TITLE
fix(expand): set -u interaction of @a/@A and indirection

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -65,6 +65,18 @@ static std::string var_attr_flags(const Variable &var) {
   return flags;
 }
 
+// `set -u' set-ness for the @a/@A attribute transforms: an array counts as
+// set when ANY element exists (bash exempts `${foo@a}' with foo=([1]=one)
+// but not with foo=()); scalars use their visible value.
+static bool attr_op_set(const Shell &sh, const std::string &name) {
+  auto it = sh.vars.find(sh.deref(name));
+  if (it == sh.vars.end()) return false;
+  const Variable &v = it->second;
+  if (v.kind == VarKind::Indexed) return !v.idx.empty();
+  if (v.kind == VarKind::Assoc) return !v.assoc.empty();
+  return !v.invisible;
+}
+
 bool pat_match(const std::string &pattern, const std::string &text, int extra_flags = 0) {
   std::string p = pattern, t = text;
   return strmatch(p.data(), t.data(), FNM_EXTMATCH | extra_flags) == 0;
@@ -1463,6 +1475,40 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (ni2 < target.size() && !(target[ni2] == '[' && target.back() == ']'))
             okname = false;
           if (okname) {
+            // Under `set -u' an indirect expansion whose TARGET value is
+            // unset reports the ORIGINAL `!name' text, not the target
+            // (`${!bar@a}' with foo an empty array -> `!bar: unbound
+            // variable' -- even where the direct form would be exempt).
+            // A defaulting operator handles the unset target itself.
+            bool dfl = !rest2.empty() &&
+                       (std::strchr("-=+?", rest2[0]) != nullptr ||
+                        (rest2[0] == ':' && rest2.size() > 1 &&
+                         std::strchr("-=+?", rest2[1]) != nullptr));
+            // The target's SCALAR context decides: a subscripted target tests
+            // that element; a splat target never trips (an empty "${!v}"
+            // with v='arr[@]' is fine under -u, like "$@" -- varenv18.sub).
+            // For the @a/@A transforms an array with ANY element counts as
+            // set, matching the direct forms.
+            bool tset;
+            size_t tbr = target.find('[');
+            if (rest2 == "@a" || rest2 == "@A") {
+              tset = attr_op_set(sh_, tbr == std::string::npos ? target : target.substr(0, tbr));
+            } else if (tbr != std::string::npos) {
+              std::string tsub2 = target.substr(tbr + 1, target.size() - tbr - 2);
+              tset = tsub2 == "@" || tsub2 == "*" ||
+                     sh_.array_elem_set(target.substr(0, tbr), tsub2);
+            } else {
+              std::string tmpv;
+              tset = sh_.get_if_set(target, tmpv);
+            }
+            if (sh_.opt_nounset && !dfl && !tset) {
+              std::fprintf(stderr, "%s!%s: unbound variable\n", sh_.err_prefix().c_str(),
+                           iname2.c_str());
+              sh_.exiting = true;
+              sh_.exit_status = 127;
+              i = end + 1;
+              return;
+            }
             std::string nb = "${" + target + rest2 + "}";
             size_t ni3 = 0;
             expand_dollar(nb, ni3, dq, out, mask, heredoc);
@@ -2750,6 +2796,12 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     else if (c0 == ':' && rest.size() > 1 &&
              (rest[1] == '-' || rest[1] == '=' || rest[1] == '+' || rest[1] == '?'))
       defaulting_op = true;
+    // @a/@A report attributes of a variable whose ARRAY has elements even
+    // when its scalar context ([0]) is unset, so `set -u' must not trip the
+    // unbound check there; a completely empty array or a missing table
+    // entry still errors (new-exp15.sub).
+    else if ((rest == "@a" || rest == "@A") && attr_op_set(sh, name))
+      defaulting_op = true;
   }
 
   bool set = false;
@@ -3196,11 +3248,12 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
         invisible = it->second.invisible;
       }
       if (t == 'a') return flags;
-      // @A: reproduce a declare/assignment statement.  A declared-but-unset
-      // variable prints its attributes and name with NO value part; one with
-      // no attributes at all expands to nothing.
+      // @A: reproduce a declare/assignment statement.  When the scalar
+      // context is unset -- a declared-but-unset variable, or an array with
+      // no element 0 (`declare -ia foo=()') -- print the attributes and name
+      // with NO value part; with no attributes at all, expand to nothing.
       if (it == sh.vars.end()) return std::string();
-      if (invisible)
+      if (invisible || !set)
         return flags.empty() ? std::string() : "declare -" + flags + " " + name;
       std::string q = atq_quote(val);
       if (flags.empty()) return name + "=" + q;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -650,6 +650,13 @@ echo ok16'
   # Pattern substitution honors nocasematch (removal and case-mod do not).
   's=abcd; shopt -s nocasematch; echo ${s//A/z}; echo ${s//BC/x}; echo ${s//[BC]/x}; echo ${s//[bC]/x}'
   's=ABCdef; shopt -s nocasematch; echo "[${s#abc}]"; echo "[${s%DEF}]"; echo "[${s^^[ab]}]"; echo ${s/def/&!}'
+  # set -u vs @a/@A: an array with ANY element is set for the transforms;
+  # an empty array errors (naming !name through indirection), and @A on an
+  # elem-0-unset array prints attributes+name with no value.
+  'declare -a foo=([1]=one); set -u; echo "[${foo@a}][${foo@A}]"; bar=foo; echo "[${!bar@A}]"'
+  'set -u; declare -ia foo=(); echo "[${foo@a}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'set -u; declare -ia foo=(); bar=foo; echo "[${!bar@a}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'set -u; arr=(zero one); name="arr[@]"; f(){ echo n=$#; }; f "${!name}"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #617.

## Fix

- New `attr_op_set()`: for `@a`/`@A` under `set -u`, an array with any element counts as set (bash exempts `${foo@a}` with `foo=([1]=one)` but errors on `foo=()`); scalars use their visible value. Wired into the defaulting-op exemption and the indirect pre-check.
- `@A` with the scalar context unset (empty array / declared-but-unset) renders `declare -flags name` with no value part.
- The indirection re-dispatch pre-checks the target under `-u` and reports the original `!name` text; defaulting operators suppress it and splat targets never trip it (varenv18.sub regression caught mid-review and covered).

## Verification

- new-exp15.sub byte-identical (new-exp 59 → 49); varenv/exp/nameref/assoc/array/posixexp/more-exp all stay 0.
- 4 new run_diff regression cases; all 422 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)