### PR TITLE
fix(expand): ${@@A} reconstructs the positional parameters

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -534,6 +534,8 @@ std::string ansi_c(const std::string &s) {
 
 }  // namespace
 
+static std::string atq_quote(const std::string &s);  // defined with the @-transforms
+
 // Character-aware whole-string case folding (exported for `declare -u/-l/-c').
 // mb_capitalize upper-cases the first character and lower-cases the rest, as in
 // bash's att_capcase.  mb_case_fold above (anonymous namespace) is visible here.
@@ -1841,9 +1843,21 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
            body[1] == ',' || body[1] == '~' || body[1] == '@')) {
         char psel = body[0];
         std::string prest = body.substr(1);
-        std::vector<std::string> items = sh_.positional;
-        for (std::string &it : items)
-          it = apply_param_op(*this, sh_, std::string(1, psel), it, true, prest, dq);
+        std::vector<std::string> items;
+        if (prest == "@A") {
+          // ${@@A}/${*@A}: one `set -- 'arg' ...' command reconstructing the
+          // positional parameters, as separate words (empty when there are
+          // no positionals) -- new-exp10.sub.
+          if (!sh_.positional.empty()) {
+            items.push_back("set");
+            items.push_back("--");
+            for (const std::string &p2 : sh_.positional) items.push_back(atq_quote(p2));
+          }
+        } else {
+          items = sh_.positional;
+          for (std::string &it : items)
+            it = apply_param_op(*this, sh_, std::string(1, psel), it, true, prest, dq);
+        }
         if (psel == '*' && dq) {
           std::string is = sh_.ifs();
           std::string j = mb_first_char(is);

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -657,6 +657,9 @@ echo ok16'
   'set -u; declare -ia foo=(); echo "[${foo@a}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'set -u; declare -ia foo=(); bar=foo; echo "[${!bar@a}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'set -u; arr=(zero one); name="arr[@]"; f(){ echo n=$#; }; f "${!name}"'
+  # ${@@A}/${*@A} reconstruct the positional parameters as a set command.
+  'set -- ab "cd ef" "" gh; printf "<%s> " "${@@A}"; echo; printf "<%s> " "${*@A}"; echo'
+  'set --; printf "<%s> " "${@@A}"; echo'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #619.

## Fix

`@A` on `${@}`/`${*}` now builds the `set -- 'arg' …` item list (empty with no positionals) before the usual `@`/`*` field emission, instead of applying the scalar transform per positional.

## Verification

- Probe matrix (quoted/unquoted `@`/`*`, empty positionals, no positionals) byte-identical to bash 5.3.
- new-exp 49 → 47; exp/posixexp/more-exp/varenv stay 0.
- 2 new run_diff regression cases; all 424 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)