### PR TITLE
fix(expand): patsub anchors vs //, leading-slash patterns, empty values

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3151,14 +3151,20 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     };
     bool global = rest.size() > 1 && rest[1] == '/';
     std::string body2 = rest.substr(global ? 2 : 1);
-    // A leading `#'/`%' anchors the pattern to the start/end of the value.
+    // A leading `#'/`%' anchors the pattern to the start/end of the value --
+    // but bash's dispatch is an else-if chain: global and the anchors are
+    // mutually exclusive, so `//#pat' is a global replace of the LITERAL
+    // `#pat' (new-exp.tests).
     char anchor = 0;
-    if (!body2.empty() && (body2[0] == '#' || body2[0] == '%')) {
+    if (!global && !body2.empty() && (body2[0] == '#' || body2[0] == '%')) {
       anchor = body2[0];
       body2 = body2.substr(1);
     }
+    // Under `//' the delimiter scan starts at the SECOND character: the first
+    // is always pattern content, so `${a///a/}' is the global removal of
+    // `/a' and `${b////-}' replaces `/' with `-' (bash, probed).
     size_t slash = std::string::npos;
-    for (size_t k = 0; k < body2.size(); k++) {
+    for (size_t k = global ? 1 : 0; k < body2.size(); k++) {
       if (body2[k] == '\\') { k++; continue; }
       if (body2[k] == '/') { slash = k; break; }
     }
@@ -3224,6 +3230,9 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       return val;
     }
     if (pat.empty()) return val;
+    // An EMPTY value still gets one match attempt: a pattern matching the
+    // empty string (`*') produces one replacement (`${var/*/x}' -> x).
+    if (val.empty()) return pat_match(pat, val, mflags) ? apply_rep(val) : val;
     std::string result;
     size_t k = 0;
     bool did = false;

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -673,6 +673,10 @@ echo ok16'
   'v=bad-var; echo "${!v}" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'foo=@; set -- a "b c" d; f(){ echo n=$#; for a; do echo "[$a]"; done; }; f ${!foo}; f "${!foo}"'
   'arr_1=(x "y z"); set -- "arr_1[@]"; a=("${!1}"); printf "<%s>" "${a[@]}"; echo'
+  # Patsub parsing: anchors and // are exclusive, the // delimiter scan skips
+  # the first char, empty values get one match attempt.
+  'v=(abcde abcfg); echo "${v[*]//#abc/foo}"; echo "${v[*]/#abc/foo}"; a=/a; echo "/${a///a/}"; b=x/y; echo "${b////-}"'
+  'var=; echo "[${var/#/x}][${var/\*/x}][${var//\*/x}]"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #625.

## Fix

Three rules in the substitution handler, each probed against bash 5.3: anchors only apply without `//` (else-if dispatch, so `//#pat` is literal); the `//` delimiter scan starts at index 1 (`${a///a/}` → pattern `/a`, `${b////-}` → pattern `/` rep `-`, `${c////%}` → pattern `/` rep `%`); and an empty value gets one match attempt so `${var/*/x}` yields `x`.

## Verification

- 13-case probe matrix byte-identical to bash.
- new-exp 23 → 15; exp/posixexp/more-exp/quote/glob stay 0.
- 2 new run_diff regression cases; all 434 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)