### PR TITLE
fix(expand): process substitution in a substitute word

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1655,7 +1655,9 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
                 // and vanish, and nothing word-splits -- the heredoc rules.
                 process("\"" + w2 + "\"", out, mask, false, false);
               } else {
-                // Unquoted default word: a leading `~' tilde-expands (bash).
+                // Unquoted default word: a leading `~' tilde-expands (bash),
+                // and <(cmd)/>(cmd) undergo process substitution like any
+                // ordinary word (`cat ${foo:-<(echo a)}' -- new-exp1.sub).
                 // While the word expands, an unquoted @-splat is space-JOINED
                 // (splittable) rather than emitted as hard fields -- bash's
                 // acknowledged inconsistency (posixexp4.sub): under IFS=: the
@@ -1665,7 +1667,9 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
                 size_t m0 = mask.size();
                 bool sw0 = subst_word_;
                 subst_word_ = true;
-                process(expand_leading_tilde(sh_, word), out, mask, false, false);
+                std::string tw = expand_leading_tilde(sh_, word);
+                extract_procsubs(tw);
+                process(tw, out, mask, false, false);
                 subst_word_ = sw0;
                 // The replacement is EXPANSION OUTPUT: its unquoted literal
                 // text IFS-splits like a parameter's value (`${IFS+foo 'b c'

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -677,6 +677,8 @@ echo ok16'
   # the first char, empty values get one match attempt.
   'v=(abcde abcfg); echo "${v[*]//#abc/foo}"; echo "${v[*]/#abc/foo}"; a=/a; echo "/${a///a/}"; b=x/y; echo "${b////-}"'
   'var=; echo "[${var/#/x}][${var/\*/x}][${var//\*/x}]"'
+  # Process substitution is live inside an unquoted substitute word.
+  'foo=; cat ${foo:-<(echo a)}'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #627.

## Fix

The unquoted default-word branch runs `extract_procsubs` on the word before processing, so `cat ${foo:-<(echo a)}` reads the /dev/fd path like bash.

## Verification

new-exp1.sub byte-identical (new-exp 15 → 12); exp/posixexp/more-exp stay 0; 1 new run_diff case, all 435 match; ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)