### PR TITLE
fix(expand): reject ${N=word} on positionals; scalar [@]-slices

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2148,6 +2148,20 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       // ${a[@]:off:len} / ${@:off:len}: array/positional slice.
       std::string slname, soffx, slenx; char ssel; bool shaslen = false;
       if (slice_ref(body, slname, ssel, soffx, slenx, shaslen)) {
+        // `${var[@]:off}' on a variable that is NOT an array behaves exactly
+        // like the scalar substring `${var:off}' -- bash's "these had better
+        // agree" (new-exp.tests: var=blah -> ${var[@]:3} is `h').
+        if (!slname.empty() && slname != "@" && slname != "*") {
+          auto scv = sh_.vars.find(sh_.deref(slname));
+          if (scv == sh_.vars.end() || (scv->second.kind != VarKind::Indexed &&
+                                        scv->second.kind != VarKind::Assoc)) {
+            std::string nb2 = "${" + slname + body.substr(body.find(':')) + "}";
+            size_t ni4 = 0;
+            expand_dollar(nb2, ni4, dq, out, mask, heredoc);
+            i = end + 1;
+            return;
+          }
+        }
         bool ok = true;
         long long off = eval_arith(sh_, expand_no_split(soffx, false, false), &ok);
         if (!ok) off = 0;
@@ -3000,6 +3014,17 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (op == '+') return empty ? std::string() : ex.expand_op_word(word, dq, top_level);
     if (op == '=') {
       if (empty) {
+        // A positional or special parameter cannot be assigned by `=':
+        // bash's `$N: cannot assign in this way', aborting the command.
+        if (!have_sub &&
+            (std::isdigit(static_cast<unsigned char>(name[0])) || name == "@" ||
+             name == "*" || name == "#" || name == "?" || name == "$" ||
+             name == "!" || name == "-")) {
+          std::fprintf(stderr, "%s$%s: cannot assign in this way\n", sh.err_prefix().c_str(),
+                       name.c_str());
+          sh.arith_error = true;
+          return std::string();
+        }
         std::string w = expand_word(word);
         if (have_sub) {
           // Assign to the array element, not a scalar named `name'.  Mirror a
@@ -3164,13 +3189,18 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       anchor = body2[0];
       body2 = body2.substr(1);
     }
-    // Under `//' the delimiter scan starts at the SECOND character: the first
-    // is always pattern content, so `${a///a/}' is the global removal of
-    // `/a' and `${b////-}' replaces `/' with `-' (bash, probed).
+    // Under `//' a slash in the FIRST position is pattern content, not the
+    // delimiter, so `${a///a/}' is the global removal of `/a' and
+    // `${b////-}' replaces `/' with `-' (bash, probed).  Escapes are still
+    // processed from the start (`${x//\//^}' keeps its escaped slash).
     size_t slash = std::string::npos;
-    for (size_t k = global ? 1 : 0; k < body2.size(); k++) {
+    for (size_t k = 0; k < body2.size(); k++) {
       if (body2[k] == '\\') { k++; continue; }
-      if (body2[k] == '/') { slash = k; break; }
+      if (body2[k] == '/') {
+        if (global && k == 0) continue;
+        slash = k;
+        break;
+      }
     }
     std::string pat = ex.expand_pattern(slash == std::string::npos ? body2 : body2.substr(0, slash));
     // The replacement undergoes full quote removal like a normal word --

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -679,6 +679,11 @@ echo ok16'
   'var=; echo "[${var/#/x}][${var/\*/x}][${var//\*/x}]"'
   # Process substitution is live inside an unquoted substitute word.
   'foo=; cat ${foo:-<(echo a)}'
+  # ${N=word} on positionals/specials errors; ${var[@]:off} on a scalar is
+  # the string slice; escaped slashes in // patterns keep working.
+  'set -- a; echo ${2="x"} 2>&1 | sed -E "s/.*: .[$]/\$/"; echo "[${1=z}]"'
+  'var=blah; echo "[${var[@]:3}]" "[${var[@]:1:2}]" "[${var[*]:3}]"'
+  'p=(/usr/bin /bin); echo "${p[@]//\//^}"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #629.

## Fix

- `=`/`:=` firing on an unset positional or special parameter errors `$N: cannot assign in this way` and aborts, matching bash; set positionals never fire it.
- `[@]`/`[*]` slices of non-array variables re-dispatch to the scalar substring path.
- The #625 delimiter scan now processes escapes from position 0 and only refuses the *delimiter* reading of a first-position `/` — the first draft broke `${x//\//^}` (caught by array/assoc going non-zero mid-review; both verified back to 0).

## Verification

- new-exp 12 → 8; full sweep shows only the deferred nested-parse suites, the read flake, and new-exp's last 8 lines.
- 3 new run_diff regression cases; all 438 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)