### PR TITLE
fix(expand): new-exp remainder -- $(< glob), fd overflow, backquoted }

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -205,6 +205,16 @@ size_t scan_balanced(const std::string &t, size_t i, char open, char close,
       wasdol = false;
       continue;
     }
+    if (c == '`') {
+      // Old-style command substitution is opaque to this scan: the `}' in
+      // `"${HOME:`echo }`}"' is backquote content, not the closer.  A
+      // backslash escapes the next character inside.
+      contaminate();
+      while (++i < t.size() && t[i] != '`')
+        if (t[i] == '\\') i++;
+      wasdol = false;
+      continue;
+    }
     // A nested `$( ... )' / `$(( ... ))' is skipped by paren balancing so its
     // inner `{'/`}' (e.g. brace expansion `$(echo a{b,c})') do not disturb this
     // scan's `{' depth -- unless we are ourselves scanning a `(...)' group.

--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -791,10 +791,16 @@ struct Lexer {
     bool all_digits = !w.empty() && !quoted;
     for (char c : w)
       if (!std::isdigit(static_cast<unsigned char>(c))) all_digits = false;
-    if (all_digits && pos < n && (in[pos] == '<' || in[pos] == '>'))
-      t.type = Tok::IoNumber;
-    else
+    if (all_digits && pos < n && (in[pos] == '<' || in[pos] == '>')) {
+      // bash: a number too large for an int is not a file descriptor -- the
+      // digits stay a command WORD, so `$(11111111111111111111</dev/stdin)'
+      // runs (and fails to find) that command (new-exp2.sub).
+      errno = 0;
+      long long fv = std::strtoll(w.c_str(), nullptr, 10);
+      t.type = (errno == 0 && fv <= 2147483647LL) ? Tok::IoNumber : Tok::Word;
+    } else {
       t.type = Tok::Word;
+    }
     return t;
   }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2791,7 +2791,10 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
       bool only = script.find_first_not_of(" \t\n", p) == std::string::npos;
       if (simple && only && !raw.empty()) {
         Expander ex(*this);
-        std::string path = ex.expand_no_split(raw);
+        // The redirect target GLOBS like any redirection word when the glob
+        // resolves to one file -- except in POSIX mode, which disables glob
+        // expansion in redirections (new-exp2.sub).
+        std::string path = ex.expand_no_split(raw, /*do_glob=*/!opt_posix);
         FILE *f = std::fopen(path.c_str(), "r");
         if (!f) {
           std::fprintf(stderr, "%s%s: %s\n", err_prefix().c_str(), path.c_str(),

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -684,6 +684,11 @@ echo ok16'
   'set -- a; echo ${2="x"} 2>&1 | sed -E "s/.*: .[$]/\$/"; echo "[${1=z}]"'
   'var=blah; echo "[${var[@]:3}]" "[${var[@]:1:2}]" "[${var[*]:3}]"'
   'p=(/usr/bin /bin); echo "${p[@]//\//^}"'
+  # $(< glob) resolves; oversize fd numbers are command words; a `}' inside
+  # backquotes does not close the ${...} scan at expansion time.
+  'd=$(mktemp -d); echo hi > "$d/f.x1"; echo "[$(< "$d"/f.x*)]"; set -o posix; echo "[$(< "$d"/f.x*)]" 2>&1 | sed -E "s/.*line [0-9]+: //"; rm -rf "$d"'
+  '{ echo "$(1111111111111111111111</dev/stdin)"; } <<<hi 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'echo "${HOME:-`echo }`}" >/dev/null && echo scan-ok; x=abcdef; echo "${x:`echo 2`}"'
 )
 
 fails=0


### PR DESCRIPTION
Fixes #631.

## Fix

- `$(< file)` fast path globs its target (single-match resolution) except in posix mode.
- Lexer: digit runs before `<`/`>` are fds only when they fit an int; oversize numbers stay command words.
- `scan_balanced` treats backquote content as opaque (matching the lexer's `scan_brace`), so `"${HOME:`echo }`}"` scans correctly and reports bash's arithmetic error instead of a cascading unterminated-quote failure.

## Verification

- **new-exp.tests: 8 → 0 — byte-perfect vs bash 5.3** (started this campaign at 269).
- Full scoreboard sweep: only the four deliberately-deferred nested-parse suites (comsub-eof 8, comsub-posix 5, comsub2 4, exportfunc 5) and the known read baseline flake remain.
- 3 new run_diff regression cases; all 441 match. ctest 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)