### PR TITLE
fix(parser): reject bare `in'; end case span at stray `done'

### DIFF
--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -197,6 +197,7 @@ struct Lexer {
     bool after_pipe = false;      // the previous separator was `|' (a pattern
                                   // alternative: `in|esac)' keeps its case open)
     std::vector<int> case_stack;  // paren depths of open `case' bodies
+    int do_depth = 0;             // open `do'...`done' bodies (loops)
     std::string word;             // current unquoted identifier word
     bool word_plain = true;       // word is only identifier chars (a keyword?)
     bool saw_word = false;        // any word content since the last delimiter
@@ -251,6 +252,18 @@ struct Lexer {
           // leaving the grammar to report the real error.  A pattern
           // ALTERNATIVE (`in|esac)') stays open.
           case_stack.pop_back();
+        else if (cmd_pos && word_plain && !after_pipe && word == "do")
+          do_depth++;
+        else if (cmd_pos && word_plain && !after_pipe && word == "done") {
+          // A `done' with no open `do' aborts bash's recursive comsub parse
+          // where it stands; the effect is that an enclosing `case' no longer
+          // guards its pattern `)'s, so the next `)' closes the substitution
+          // and the inner parse reports `near unexpected token `done''
+          // (`: $(case x in x) ;; x) done)').  A matched `done' just closes
+          // its loop; a pattern alternative (`else|done)') is not a keyword.
+          if (do_depth > 0) do_depth--;
+          else if (!case_stack.empty()) case_stack.pop_back();
+        }
         // Most words consume the command slot; a few reopen command position.
         cmd_pos = word_plain && (word == "then" || word == "do" ||
                                  word == "else" || word == "elif");

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -502,8 +502,10 @@ struct Parser {
     if (reserved("function")) return parse_function();
     if (reserved("coproc")) return parse_coproc();
 
-    // Reserved terminators here mean a misplaced keyword.
-    if (reserved_in({"then", "do", "done", "fi", "elif", "else", "esac", "}"})) {
+    // Reserved terminators here mean a misplaced keyword.  `in' can never
+    // start a command either (bash rejects `in', `time in', `in() ...'; an
+    // assignment prefix `x=5 in' runs it, but that word is parse_simple's).
+    if (reserved_in({"then", "do", "done", "fi", "elif", "else", "esac", "}", "in"})) {
       fail(is(Tok::Eof) ? std::string("unexpected end of file")
                         : std::string("near unexpected token `") + tok_to_text(cur()) + "'");
       return nullptr;


### PR DESCRIPTION
## Summary
- reject an unquoted `in` wherever a command may start, matching bash's `syntax error near unexpected token `in'` (`in`, `time in`, `echo x | in`, `in() ...`; `x=5 in` / `echo in` / `in=5` unaffected)
- track `do`...`done` nesting in the comsub span scanner; a stray `done` (command position, no open `do`) ends the enclosing `case`'s guard so the next `)` closes the substitution and the inner parse blames `done`

Together these fix the last 5 comsub-posix.tests diff lines:
```
: $(case x in esac|in) foo;; esac)   → near unexpected token `in' while looking for matching `)'
: $(case x in x) ;; x) done)         → near unexpected token `done' while looking for matching `)'
```

comsub-posix is now byte-perfect — 80 of 83 suites at 0.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- full scoreboard sweep: no regressions (remaining: comsub-eof 8, comsub2 4, exportfunc 5)

Closes #633
