### PR TITLE
fix(parser): funsub `}' close, eval EOF line, function import name

### DIFF
--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -91,6 +91,7 @@ struct Lexer {
   // there, which is what the Eof token already carries.
   int unterm_line = 0;
   bool heredoc_eof = false;        // here-doc body delimited by end of input
+  bool trailing_bslash_eof = false;  // input ended on an unquoted backslash
   std::string heredoc_eof_delim;
   int heredoc_eof_line = 0;
   bool heredoc_eof_quoted = false;  // that here-doc's delimiter was quoted
@@ -490,6 +491,12 @@ struct Lexer {
     bool wasdol = false;
     bool funsub = pos + 1 < n &&
                   (std::isspace(static_cast<unsigned char>(in[pos + 1])) || in[pos + 1] == '|');
+    // In a funsub the closing `}' is the reserved word, valid only in command
+    // position: after a terminator (`;' `&' newline) or a compound's own `}'.
+    // `${ echo x }' has no terminator before the brace, so the `}' is an
+    // argument to echo and bash reads on to end of input (`unexpected EOF
+    // while looking for matching `}'').  `cmd_term' tracks that position.
+    bool cmd_term = true;
     do {
       char c = in[pos];
       if (c == '{') {
@@ -497,18 +504,43 @@ struct Lexer {
         w += c;
         pos++;
         wasdol = false;
+        cmd_term = true;
       } else if (c == '}') {
+        if (funsub && depth == 1 && !cmd_term) {
+          // Not a close: a literal `}' argument inside the command list.
+          w += c;
+          pos++;
+          wasdol = false;
+          cmd_term = false;
+          continue;
+        }
         depth--;
         w += c;
         pos++;
         wasdol = false;
+        cmd_term = true;  // a compound just closed -- command position again
+      } else if ((c == ';' || c == '&' || c == '\n' || c == '(' || c == ')') &&
+                 funsub) {
+        // A command terminator, or a subshell's `(' / `)', leaves the scan in
+        // command position -- so a following `}' closes the funsub even with
+        // no explicit `;' (`${ ( shift) }', comsub2's parse_comsub note).
+        w += c;
+        pos++;
+        wasdol = false;
+        cmd_term = true;
+      } else if (std::isspace(static_cast<unsigned char>(c)) && funsub) {
+        w += c;
+        pos++;
+        wasdol = false;  // blank keeps the current command position
       } else if (c == '$' && pos + 1 < n && in[pos + 1] == '\'') {
+        cmd_term = false;
         scan_dollar_single(w);  // $'...' inside ${...}: backslash-aware
         wasdol = false;
       } else if (c == '$' && pos + 1 < n && in[pos + 1] == '(') {
         // A nested command/arith substitution `$( ... )' / `$(( ... ))' is
         // scanned by paren balancing so any `{'/`}' inside it are consumed as
         // its content rather than counted against this ${...}'s brace depth.
+        cmd_term = false;
         w += c;
         pos++;  // the `$'
         scan_paren(w);
@@ -517,27 +549,40 @@ struct Lexer {
         // POSIX mode: inside a DOUBLE-QUOTED ${...} a single quote is an
         // ordinary character, not a quote (`"${IFS+'}'z}"` ends at the first
         // `}`), matching bash's parse_matched_pair posix handling.
+        cmd_term = false;
         if (posix && in_dq) { w += c; pos++; }
         else scan_single(w);
         wasdol = false;
       } else if (c == '"') {
+        cmd_term = false;
         scan_double(w);
         wasdol = false;
       } else if (c == '`') {
+        cmd_term = false;
         scan_backtick(w);
         wasdol = false;
       } else if (c == '\\') {
+        cmd_term = false;
         w += c;
         pos++;
         if (pos < n) w += in[pos++];
         wasdol = false;
       } else {
+        cmd_term = false;
         wasdol = (c == '$');
         w += c;
         pos++;
       }
     } while (pos < n && depth > 0);
-    if (depth > 0) { unterminated = true; if (!unterm_close) { unterm_close = '}'; unterm_line = startln; } }
+    if (depth > 0) {
+      unterminated = true;
+      if (!unterm_close) {
+        unterm_close = '}';
+        // A funsub reads a command list, so bash reports where input ran out
+        // (like `$('), not the opening line; leave open_line 0 to signal that.
+        unterm_line = funsub ? 0 : startln;
+      }
+    }
   }
   void scan_square(std::string &w) {  // pos at '[' of $[...] arithmetic
     int depth = 0;
@@ -740,6 +785,11 @@ struct Lexer {
           pos += 2;
           continue;
         }
+        // A backslash ending the input stays literal in the word, but bash's
+        // reader first splices it with the (virtual) terminating newline and
+        // then synthesizes another, so an EOF error reports one line further
+        // (`eval 'X() { (a)>\'' blames eval_line+2, not +1).
+        if (pos + 1 >= n) trailing_bslash_eof = true;
         w += c;
         pos++;
         if (pos < n) w += in[pos++];
@@ -1032,8 +1082,10 @@ struct Lexer {
     eof.start = n;
     eof.end = n;
     // bash parses input with a guaranteed trailing newline, so EOF falls on the
-    // line after the last content -- add one when the input has no final newline.
-    eof.line = line_for(n) + ((n > 0 && in[n - 1] != '\n') ? 1 : 0);
+    // line after the last content -- add one when the input has no final newline,
+    // and one more when a trailing backslash consumed that virtual newline.
+    eof.line = line_for(n) + ((n > 0 && in[n - 1] != '\n') ? 1 : 0) +
+               (trailing_bslash_eof ? 1 : 0);
     eof.lex_error = unterminated;
     eof.lex_close = unterm_close;
     eof.lex_open_line = unterm_line;

--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -293,7 +293,14 @@ struct Parser {
     }
     advance();
     if (cur().type != Tok::Word) {
-      fail("expected redirection target");
+      // bash names the offending token (`echo >' -> `newline'); end of input
+      // reads as the virtual terminating newline, unless a backslash splice
+      // consumed it and the grammar's EOF-from-open report wins (`X() {
+      // (a)>\' + newline at end of file).
+      if (is(Tok::Eof) && eof_from_open()) return false;
+      std::string tk =
+          (is(Tok::Newline) || is(Tok::Eof)) ? "newline" : tok_to_text(cur());
+      fail("near unexpected token `" + tk + "'");
       return false;
     }
     r.target = Word{cur().text, cur().quoted ? W_QUOTED : 0};

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1947,7 +1947,13 @@ void Shell::import_env_functions() {
     // Parse `name value' (value is "() {...}").  Accept only a lone function
     // definition -- any trailing command (a Shellshock payload) is rejected.
     ParseResult r = parse(name + " " + f.second);
-    if (r.ok && r.command && dynamic_cast<const FunctionDef *>(r.command.get())) {
+    // The definition must name exactly this function.  A payload that hides
+    // the intended name -- whitespace in the env name (`BASH_FUNC_<NL>foo%%'),
+    // or a `#'-commented first line that leaves a different `foo () {...}'
+    // behind (`BASH_FUNC_#badname%%') -- parses to a function with the WRONG
+    // name and is refused, as bash's importer refuses it.
+    if (r.ok && r.command && dynamic_cast<const FunctionDef *>(r.command.get()) &&
+        static_cast<const FunctionDef *>(r.command.get())->name == name) {
       const auto *fd = static_cast<const FunctionDef *>(r.command.get());
       functions[fd->name] = fd->body.get();
       func_lineno_base[fd->name] = 0;
@@ -2356,6 +2362,11 @@ int Shell::run_script_lines(const std::string &text) {
   int st = last_status;
 
   auto flush = [&]() {
+    // A continuation on the input's last line already consumed the final
+    // newline: the parser must see plain end-of-input there, as bash's
+    // reader does (`X() { (a)>\' + newline at end of file reports
+    // `unexpected end of file from `{'' on the line after, not `newline').
+    bool ate_final_nl = cont_bslash;
     cont_bslash = false;
     first_line_saved = false;
     in_heredoc = false;
@@ -2374,7 +2385,7 @@ int Shell::run_script_lines(const std::string &text) {
       // where bash keeps it literal (`sh -c 'echo escape\'' -- quote.tests).
       size_t tb = 0;
       while (tb < pending.size() && pending[pending.size() - 1 - tb] == '\\') tb++;
-      if (pending.back() != '\n' && tb % 2 == 0) pending += '\n';
+      if (pending.back() != '\n' && tb % 2 == 0 && !ate_final_nl) pending += '\n';
     }
     st = run_string(pending, cont_lines.empty() ? nullptr : &cont_lines);
     lineno_base = 0;


### PR DESCRIPTION
## Summary
Fixes the last 5 exportfunc.tests diff lines — three independent bugs:

1. **Funsub `${ cmd; }` close.** `}` closes only in command position (after `;`/`&`/newline, a subshell `)`, or a compound `}`). gnash closed at the first balanced brace, so `${ echo x }` ran and `>_[${ $() }] { ...; }` executed where bash reports `unexpected EOF while looking for matching \`}'`. Unterminated funsubs now report the end-of-input line like `$(`.
2. **eval EOF-line off-by-one.** A trailing backslash consumes bash's virtual terminating newline, pushing an EOF-from-open report one line further (`eval 'X() { (a)>\'` → eval line + 2). Missing redirect target at EOF now reads as the virtual `newline` token.
3. **Shellshock-style import.** Refuse `BASH_FUNC_<name>%%` whose payload defines a differently-named function (whitespace name, `#`-commented first line hiding a trailing `foo () {...}`). Require the parsed function name to equal the env-var name.

exportfunc is now byte-perfect.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- full scoreboard: exportfunc 5→0, comsub2 unchanged at 4, no regressions (remaining: comsub-eof 8, comsub2 4)

Closes #635
