### PR TITLE
fix(parser): keep `(( a; b ))' arithmetic instead of a subshell

### DIFF
--- a/core/src/parser.cpp
+++ b/core/src/parser.cpp
@@ -839,12 +839,13 @@ struct Parser {
         fail("unexpected EOF while looking for matching `)'");
         return nullptr;
       }
-      if (is(Tok::Semi) || is(Tok::Newline)) {
-        okexpr = false;  // not an arithmetic expression -> nested subshell
-        break;
-      }
       if (is(Tok::Rparen) && depth == 0) {
-        if (peek(1).type == Tok::Rparen) {
+        // bash (parse_arith_cmd): the inner `(' is arithmetic only when its
+        // matching `)' is IMMEDIATELY followed by `)' with no blank between.
+        // `(( x ))' is arithmetic (even `(( a; b ))', which becomes a runtime
+        // arithmetic error); `(( echo hi ) )' and `((echo hi); (echo bye))'
+        // are nested subshells because a blank or another token intervenes.
+        if (peek(1).type == Tok::Rparen && !peek(1).preceded_by_blank) {
           // Keep a blank before `))' so an arithmetic error diagnostic
           // reproduces bash's raw expression (`((: 7++ : ...', token `"+ "');
           // the single-line printer trims it back off for display.
@@ -855,6 +856,15 @@ struct Parser {
         }
         okexpr = false;
         break;
+      }
+      // A `;' or newline is ordinary content of the arithmetic string (bash's
+      // parse_matched_pair only balances parens); the arithmetic evaluator
+      // rejects it later.  `(( a; b ))' therefore stays arithmetic.
+      if (is(Tok::Semi) || is(Tok::Newline)) {
+        if (cur().preceded_by_blank) expr += ' ';
+        expr += is(Tok::Newline) ? '\n' : ';';
+        advance();
+        continue;
       }
       if (is(Tok::Lparen)) {
         depth++;


### PR DESCRIPTION
## Summary
gnash's `parse_arith_command` bailed to `parse_subshell` on the first `;`/newline inside `(( ))`, so `(( true; true ))` and `(( echo hi; echo bye ))` executed their contents as a subshell where bash reports an arithmetic syntax error.

Now follows bash's `parse_arith_cmd` rule: the construct is arithmetic exactly when the inner `(`'s matching `)` is *immediately* followed by `)` (no blank). `(( x ))` — including `(( a; b ))` — is arithmetic; `(( echo hi ) )` and `((echo hi); (echo bye))` remain nested subshells. `;`/newline is accumulated as expression text so the evaluator emits bash's `invalid arithmetic operator` diagnostic.

All four issue cases now match bash's stdout and exit status:

| Input | Before | After |
|-------|--------|-------|
| `(( true; true ))` | ran (st 0, no err) | arith error, st 1 ✓ |
| `(( echo hi; echo bye ))` | printed `hi`/`bye` | arith error ✓ |
| `(( 1; echo done ))` | printed `done` | arith error ✓ |
| `((echo hi); (echo bye))` | subshell ✓ | subshell ✓ (unchanged) |

Error-message text matches bash byte-for-byte for 5 of 6 probed cases. One residual: `(( echo hi; echo bye ))` blames token `hi; echo bye` where bash blames `; echo bye` — an inconsistent arith-evaluator error-token quirk (bash blames `2` in `(( 1 2; 3 ))` but `;` in `(( a b; c ))`), independent of this routing fix.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- scoreboard: arith 0, errors 0, comsub 0, comsub2 4 (unchanged), no regressions

Closes #604
