### PR TITLE
fix(expand): accept non-identifier prefixes in ${!pre*}/${!pre@}

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1383,9 +1383,11 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       if (body.size() > 2 && body[0] == '!' &&
           (body.back() == '@' || body.back() == '*')) {
         std::string pre = body.substr(1, body.size() - 2);
-        bool ident = std::isalpha(static_cast<unsigned char>(pre[0])) || pre[0] == '_';
-        for (size_t k = 1; ident && k < pre.size(); k++)
-          if (!std::isalnum(static_cast<unsigned char>(pre[k])) && pre[k] != '_') ident = false;
+        // Only the FIRST prefix character must be a name-start (bash's
+        // `legal_variable_starter(name[1])'); the rest is unrestricted, so
+        // `${!a.*}' lists the (possibly empty) set of names beginning `a.'.
+        bool ident = !pre.empty() &&
+                     (std::isalpha(static_cast<unsigned char>(pre[0])) || pre[0] == '_');
         if (ident) {
           std::vector<std::string> names;
           for (const auto &kv : sh_.vars) {
@@ -2619,11 +2621,13 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     size_t sp = b.find_first_of("*@", 1);
     if (sp != std::string::npos && (bracket == std::string::npos || sp < bracket)) {
       std::string pre = b.substr(1, sp - 1);
-      // A valid identifier prefix starts with a letter or `_' (not a digit).
+      // bash (subst.c: `legal_variable_starter(name[1])') only requires the
+      // FIRST prefix character to be a name-start (letter or `_'); the rest is
+      // unrestricted, so `${!a.*}' / `${!a b*}' list nothing rather than
+      // erroring.  A digit/special/blank first char (`${!1*}', `${!@*}',
+      // `${! *}') still falls through to the bad-substitution report.
       bool ident = !pre.empty() &&
                    (std::isalpha(static_cast<unsigned char>(pre[0])) || pre[0] == '_');
-      for (char c : pre)
-        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) ident = false;
       // An `@' that is NOT the final character introduces an operator on the
       // INDIRECTED parameter (`${!var@Q}' -> `${VAR2@Q}'), not a malformed
       // listing -- leave it to the indirection path below.  A bare trailing


### PR DESCRIPTION
## Summary
gnash validated the entire prefix of a `${!PREFIX*}`/`${!PREFIX@}` name listing as an identifier, so `${!a.*}` reported `bad substitution`. bash (subst.c:9980) requires only the *first* prefix character to be a name-start (`legal_variable_starter(name[1])`); the rest is unrestricted, and a prefix matching nothing expands to the empty list.

```
echo ${!a.*}foo     # bash: foo   gnash before: bad substitution   gnash after: foo
echo ${!a b*}foo    # bash: foo   after: foo
```

Fixed both listing paths (the field-aware form in `expand_dollar` and the validation gate in `expand_brace_body`) by dropping the per-character loop. A digit/special/blank first character (`${!1*}`, `${!@*}`, `${! *}`) still reports `bad substitution`, as in bash.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- scoreboard: new-exp 0, exp 0, more-exp 0, posixexp 0 (no regressions)

Closes #589
