### PR TITLE
fix(expand): error on an unterminated $( in a here-document body

### DIFF
--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1242,17 +1242,19 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
     size_t end = sh_.aliases_active() ? comsub_span_end_aliased(t, i + 1, sh_.aliases)
                                       : comsub_span_end(t, i + 1);
     end = (end == std::string::npos) ? scan_balanced(t, i + 1, '(', ')') : end - 1;
-    if (end == std::string::npos && !heredoc) {
-      // An unterminated `$(' reaching expansion (a quoted one inside a
-      // ${...} operand, where single quotes are literal) is bash's
-      // command-substitution parse error, and the command aborts
-      // (braces.tests).
+    if (end == std::string::npos) {
+      // An unterminated `$(' reaching expansion is bash's command-substitution
+      // parse error, and the command aborts.  It happens for a quoted `$('
+      // inside a ${...} operand (single quotes are literal there -- braces.tests)
+      // and for one in a here-document body (comsub-eof6.sub).
       // bash's prefix names the failing context and the line where the
-      // substitution's text ran out (its own last line).
+      // substitution's text ran out (its own last line).  A here-document body
+      // is already positioned at its own first line, so it needs one less than
+      // the ${...}-operand form.
       int nl = static_cast<int>(std::count(t.begin() + static_cast<long>(i), t.end(), '\n'));
       std::fprintf(stderr, "%s: command substitution: line %d: "
                            "unexpected EOF while looking for matching `)'\n",
-                   sh_.shell_name.c_str(), sh_.cur_lineno + nl + 2);
+                   sh_.shell_name.c_str(), sh_.cur_lineno + nl + (heredoc ? 1 : 2));
       sh_.arith_error = true;
       i = t.size();
       return;


### PR DESCRIPTION
## Summary
An unterminated command substitution in an unquoted here-document body was left literal instead of raising bash's parse error:

```sh
read foo <<EOF
$(seq 10
EOF
echo "$foo"
```
bash → `command substitution: line 3: unexpected EOF while looking for matching )`; gnash printed `$(seq 10`.

The unterminated-`$(` diagnostic in `Expander::expand_dollar` was gated behind `!heredoc`, so it only fired for a `$(` inside a `${...}` operand. Dropping the gate makes a here-document body error too; the reported line is one less than the `${...}`-operand form because a here-document body's text already begins at its own first line.

comsub-eof: 8 → 5 diff lines.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- scoreboard: heredoc 0, comsub 0, braces 0, comsub-posix 0 (no regressions); multi-line comsubs in heredocs still work

Closes #641
