### PR TITLE
fix(expand): execute the reprinted funsub body so $LINENO matches bash

### DIFF
--- a/core/include/gnash/core/ast.hpp
+++ b/core/include/gnash/core/ast.hpp
@@ -93,6 +93,11 @@ std::string canonical_word_text(const std::string &w);
 std::string named_function_string(const std::string &name, const Command *body,
                                   bool posix = false);  // full canonical rendering
 
+// bash's print_comsub rendering: a command list with each `;' kept inline and
+// each newline advancing a line, matching the text bash re-executes for a
+// funsub/command substitution (so its runtime $LINENO tracks bash's).
+std::string comsub_reprint_string(const Command *cmd);
+
 struct SimpleCommand : Command {
   std::vector<Word> words;  // assignment prefix + argv, in order
   void print(std::string &out) const override;

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -247,6 +247,7 @@ std::string canonical_word(const std::string &w);
 struct MPrinter {
   std::string out;
   bool pretty = false;  // --pretty-print (top level): `;' lists join inline
+  bool comsub = false;  // print_comsub: preserve `;' (inline) vs newline connectors
   std::vector<const Redirect *> pending_heredocs;
   bool last_was_heredoc = false;   // a simple command ended with a here-document
   bool compound_heredoc = false;   // a for/while/if body ended with a here-document
@@ -323,6 +324,13 @@ struct MPrinter {
         if (last_was_heredoc) { out += '\n'; nl(I); }  // simple heredoc: blank line
         else if (compound_heredoc) { nl(I); }          // compound heredoc: no `;', no blank
         else if (last_was_amp) { nl(I); }
+        // print_comsub preserves the original separator: a `;' stays on the
+        // same line (`; '), a newline advances (`\n').  This is what makes a
+        // funsub body's executed line numbers match bash (comsub2.tests).
+        else if (comsub) {
+          if (cn->conn == Connector::Newline) { out += '\n'; ind(I); }
+          else { out += "; "; }
+        }
         // Outside a function definition bash joins a `;'/newline list inline
         // (`done <<< a; echo done;'); inside one, each command starts its own
         // line (print_cmd.c: the_printed_command's inside_function_def test).
@@ -880,6 +888,20 @@ std::string pretty_print_string(const Command *c) {
   p.inline_cmd(c, 0);
   p.flush_heredocs();
   p.out += "\n\n";
+  return p.out;
+}
+
+// bash's parse_comsub renders the parsed body with print_comsub and executes
+// THAT reprinted text, so a funsub/command-substitution body's runtime line
+// numbers follow the canonical rendering (each `;' inline, each newline a new
+// line) rather than the physical source layout.  Reproducing it here lets a
+// funsub's $LINENO and error lines match bash (comsub2.tests).
+std::string comsub_reprint_string(const Command *c) {
+  if (c == nullptr) return std::string();
+  MPrinter p;
+  p.comsub = true;
+  p.list(c, 0);
+  p.flush_heredocs();
   return p.out;
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -2735,8 +2735,23 @@ std::string Shell::run_and_capture_inproc(const std::string &script, int *status
   // echo after; }' still runs the echo under `set -e' (comsub22.sub).
   bool saved_errexit = opt_errexit;
   if (opt_errexit && !opt_posix && !shopt_opts["inherit_errexit"]) opt_errexit = false;
+  // bash's parse_comsub parses the body (without expanding aliases) and
+  // re-executes its print_comsub RENDERING, so runtime line numbers follow the
+  // canonical layout (`;' inline, newline advancing) rather than the physical
+  // source -- a command inside a for/while/if body reports bash's line
+  // (comsub2.tests).  Reprint here, then run_string re-parses (with aliases)
+  // and executes, exactly as bash does.  Fall back to the raw body if it does
+  // not parse cleanly on this alias-free pass.
+  std::string body_to_run = script;
+  {
+    ParseResult rp = parse(script, opt_posix);
+    if (rp.ok && rp.command) {
+      std::string reprinted = comsub_reprint_string(rp.command.get());
+      if (!reprinted.empty()) body_to_run = reprinted;
+    }
+  }
   push_scope();
-  int st = run_string(script);
+  int st = run_string(body_to_run);
   pop_scope();
   opt_errexit = saved_errexit;
   if (returning) { st = exit_status; returning = false; }


### PR DESCRIPTION
## Summary
A command inside a `for`/`while`/`until`/`if` body that is itself inside a function substitution `${ ...; }` reported the wrong line number — `comsub2.tests` printed `p: command not found` at line 74 where bash prints 75.

bash's `parse_comsub` parses the body, renders it with `print_comsub`, and re-executes *that* text, so runtime line numbers follow the canonical layout (each `;` inline, each newline advancing a line). A `do`/`then` lands on its own line, shifting nested commands down. gnash executed the raw body text, so nested-compound commands reported the physical line.

## Fix
- `MPrinter` gains a `comsub` mode that preserves the Semi-vs-Newline connector (`; ` inline / `\n` advancing), exposed as `comsub_reprint_string()`.
- `run_and_capture_inproc` parses the body on an alias-free pass (as `parse_comsub` does), reprints it, and runs that; the existing `lineno_base = open_line - 1` then yields bash's numbers. `run_string` re-parses with aliases and executes, exactly as bash does.

comsub2 → 0 (was 4). This is a general correctness fix — funsub `$LINENO` and error lines now match bash regardless of physical layout.

## Testing
- ctest 23/23; run_diff all 441 scripts match
- **Full 83-suite scoreboard sweep: no regressions** (only comsub-eof 5 and the read baseline flake remain non-zero)
- Verified funsub line numbers across semicolon/newline/blank-line layouts

Closes #643
