### PR TITLE
fix(interactive): default to emacs editing mode

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -547,6 +547,13 @@ int main(int argc, char **argv) {
     bool interactive = force_interactive || isatty(STDIN_FILENO);
     if (interactive) {
       sh.interactive = true;
+      // Interactive shells edit in emacs mode by default, as bash does (and as
+      // readline's rl_editing_mode already assumes): record it so `set -o'
+      // reports it and the prompt emits its invisible \[ \] markers.  An
+      // explicit vi choice already made (`-o vi', `+o emacs', $SHELLOPTS) is
+      // left alone, and this runs before the startup files so a `set -o vi'
+      // there still overrides.
+      if (!sh.opt_vi) sh.opt_emacs = true;
       sh.init_job_control(true);
       // Default prompts (set before startup files so an rc file can override):
       // user@host:cwd followed by `$' (or `#' for root), and `> ' for


### PR DESCRIPTION
## Summary
Interactive gnash now defaults to **emacs editing mode**, matching bash. readline's `rl_editing_mode` already defaulted to emacs, but the shell's `opt_emacs` flag stayed `false`, so:

- the prompt never emitted its invisible `\001`/`\002` (`\[ \]`) markers, so a coloured prompt's visible width was mis-counted and the cursor column was wrong when a wide line wrapped/scrolled;
- the stored option disagreed with the actual editing mode.

The interactive path now sets `opt_emacs` before startup files run, guarded on `!opt_vi` so an explicit vi choice (`-o vi`, `+o emacs`, `$SHELLOPTS`) is preserved and a startup file's `set -o vi` still overrides. Non-interactive shells are untouched.

This resolves the coloured-prompt caveat noted in #648 (the line-wrapping PR).

## Testing
- Colored prompt at width 20 now positions the cursor exactly like bash by default (verified via pty + pyte).
- `set -o` reports `emacs on / vi off` by default; `-o vi` and `SHELLOPTS=vi` still yield `emacs off / vi on`.
- ctest 23/23; run_diff all 441 scripts match (non-interactive behaviour unchanged).

Closes #649
