### PR TITLE
fix(readline): C-n at the current line dings instead of clearing it

### DIFF
--- a/libreadline/src/readline.cpp
+++ b/libreadline/src/readline.cpp
@@ -258,6 +258,10 @@ extern "C" int rl_get_previous_history(int count, int key) {
 extern "C" int rl_get_next_history(int count, int key) {
   if (count < 0) return rl_get_previous_history(-count, key);
   if (count == 0) return 0;
+  // Already on the line being edited (not navigated up into history): there is
+  // no next entry, so ding and leave the line untouched -- as bash does --
+  // rather than replacing it with the (empty) saved line.
+  if (where_history() == history_length) return rl_ding();
   HIST_ENTRY *e = nullptr;
   while (count-- > 0) {
     HIST_ENTRY *t = next_history();
@@ -267,7 +271,7 @@ extern "C" int rl_get_next_history(int count, int key) {
   if (e)
     put_line(e->line);
   else
-    put_line(saved_line.c_str());
+    put_line(saved_line.c_str());  // stepped past the last entry: restore the typed line
   return 0;
 }
 


### PR DESCRIPTION
## Summary
At a fresh prompt, typing text then pressing `C-n` (next-history / down arrow) cleared the line. It should do nothing when there's no next entry to move to.

`rl_get_next_history` didn't check whether the cursor was already on the line being edited. With no forward entry, `next_history()` returned null and the code restored `saved_line` — empty at a fresh prompt — wiping the text. Now it returns `rl_ding()` when already at the bottom (`where_history() == history_length`), leaving the line untouched, as bash does.

## Testing (pty + pyte, vs bash)
- `hello` then `C-n` → line still `hello` (was cleared) ✓
- type draft, `C-p` (up), `C-n` (down) → draft restored ✓
- `C-p C-p C-n` (mid-history) → correct middle entry ✓
- ctest 23/23; run_diff all 441 match (non-interactive corpus unaffected).

Closes #651
