### PR TITLE
fix(expand): reject an empty array subscript as a bad substitution

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -577,9 +577,10 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
         // errors on `xy^?z', not `x^Ay^?z'.  An ASSOCIATIVE key keeps its
         // bytes intact (exp8.sub tests both).
         if (!assoc)
-          for (size_t cb = 0; cb < sub.size();)
+          for (size_t cb = 0; cb < sub.size();) {
             if (sub[cb] == '\001') sub.erase(cb, 1), cb++;
             else cb++;
+          }
         // The value of a `[sub]=value' element is an assignment RHS, so a `~'
         // tilde-expands at the start and after each unquoted `:' (bash); a bare
         // word element, handled below, only gets leading-tilde expansion.

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2717,6 +2717,14 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       if (bd == 0) {
         std::string sub = b.substr(q + 1, close - q - 2);
         std::string after = b.substr(close);
+        // An empty subscript on the indirection target (`${!arr[]}') is a
+        // bad substitution naming the whole body, as bash (issue #653).
+        if (sub.empty() && !sh.is_zsh()) {
+          std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
+                       body.c_str());
+          sh.arith_error = true;
+          return std::string();
+        }
         bool splat = sub == "@" || sub == "*";
         if (!(splat && after.empty())) {
           // The subscripted value: a splat space-joins EVERY element (so an
@@ -2877,6 +2885,17 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       p = b.size();
     }
     have_sub = true;
+  }
+
+  // bash rejects an EMPTY subscript in parameter expansion outright:
+  // `${arr[]}', `${#arr[]}' and `${arr[]:-x}' are all `bad substitution',
+  // for associative arrays too, rather than reading index 0 (issue #653).
+  // The assignment form (`arr[]=x') has its own check in the executor.
+  if (have_sub && sub.empty() && !sh.is_zsh()) {
+    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
+                 body.c_str());
+    sh.arith_error = true;
+    return std::string();
   }
 
   // Text left after a `name[sub]' reference must be an operator: bash rejects

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -671,6 +671,15 @@ echo ok16'
   # error, special-parameter targets keep $@ fields, digit inames re-dispatch.
   'z=ZV; echo "[${!9:-$z}]"; echo "[${!9-$z}]"; unset x; echo "[${!x-$z}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'v=bad-var; echo "${!v}" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  # An EMPTY subscript in any expansion form is a bad substitution (#653);
+  # a whitespace-only subscript still arithmetics to index 0.
+  'arr=(a b); echo "[${arr[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'arr=(a b); echo "[${#arr[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'arr=(a b); echo "[${arr[]:-def}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'arr=(a b); echo "[${!arr[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'declare -A aa=([k]=v); echo "[${aa[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'unset q; echo "[${q[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
+  'arr=(a b); echo "[${arr[ ]}]"'
   'foo=@; set -- a "b c" d; f(){ echo n=$#; for a; do echo "[$a]"; done; }; f ${!foo}; f "${!foo}"'
   'arr_1=(x "y z"); set -- "arr_1[@]"; a=("${!1}"); printf "<%s>" "${a[@]}"; echo'
   # Patsub parsing: anchors and // are exclusive, the // delimiter scan skips


### PR DESCRIPTION
## Summary

bash rejects an empty subscript in parameter expansion outright: `${arr[]}`, `${#arr[]}`, `${arr[]:-x}`, `${!arr[]}` and the associative `${A[]}` all report `bad substitution` and fail the command with status 1. gnash's `expand_brace_body` accepted the zero-length subscript, evaluated it as arithmetic 0 and read element 0 instead.

Closes #653

## Changes

- `core/src/expand.cpp`: reject an empty subscript where the `name[sub]` reference is parsed in `expand_brace_body`, naming the full brace body in the diagnostic as bash does; a matching check in the `${!name[sub]}` indirection path keeps the `!` form in the message (`${!arr[]}: bad substitution`). The zsh personality keeps its own subscript semantics.
- `tests/harness/run_diff.sh`: differential cases for every rejected form, plus `${arr[ ]}` (whitespace-only subscript still arithmetics to index 0).
- `core/src/executor.cpp` (separate commit): add explicit braces to satisfy newer Apple clang's `-Werror,-Wdangling-else`, which broke the build.

## Verification

- Before/after against bash 5.3 on the issue repro: gnash now prints `${arr[]}: bad substitution` to stderr and exits 1, byte-identical message.
- `ctest`: 23/23 pass (`run_diff` now 448 differential cases, all match bash).
- Full 83-suite scoreboard sweep: no regressions — only the standing comsub-eof (5, bash's own acknowledged bug) and the read-suite bash-baseline timing flake remain; `errors` scores 0 after refreshing its stale cached oracle.