### PR TITLE
fix(expand): unwind the command list on fatal ${...} expansion errors

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -97,8 +97,18 @@ static bool expand_redir_target(Shell &sh, const Word &w, std::string &out) {
   // splitting that still makes a multi-word target ambiguous.
   bool saved_noglob = sh.opt_noglob;
   if (sh.opt_posix && !sh.interactive) sh.opt_noglob = true;
+  bool saved_ae = sh.arith_error;
+  sh.arith_error = false;
   std::vector<std::string> words = ex.expand_args({w});
   sh.opt_noglob = saved_noglob;
+  // An expansion error in the target (`> x-${arr[]}') fails the redirection
+  // -- and with it the command, status 1 -- rather than opening the partial
+  // name.  The diagnostic is already printed and any arith_abort raised
+  // unwinds the rest of the list (bash); consume arith_error here so it
+  // cannot leak into the next command.
+  bool expfail = sh.arith_error;
+  sh.arith_error = saved_ae;
+  if (expfail) return false;
   if (words.size() != 1) {
     std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
                  w.text.c_str());
@@ -299,17 +309,20 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       case RedirOp::HereDoc:
       case RedirOp::HereDocStrip: {
         bool saved_ae = sh.arith_error;
+        bool saved_ab = sh.arith_abort;
         sh.arith_error = false;
+        sh.arith_abort = false;
         std::string body = r.heredoc_quoted ? r.heredoc_body : ex.expand_heredoc(r.heredoc_body);
         // An expansion failure in the body (`${'x1'%'t'}: bad substitution')
         // aborts the redirection -- and with it the command -- as bash does
         // (posixexp7.sub); the diagnostic was already printed, and later
-        // commands are unaffected.
-        if (sh.arith_error) {
-          sh.arith_error = saved_ae;
-          return false;
-        }
+        // commands are unaffected.  That containment covers arith_abort too:
+        // a $((...)) error in the body must not unwind the enclosing list
+        // (bash runs `cat <<E; echo A' with a bad body's A).
+        bool failed = sh.arith_error || sh.arith_abort;
         sh.arith_error = saved_ae;
+        sh.arith_abort = saved_ab;
+        if (failed) return false;
         int f = heredoc_fd(body);
         if (f < 0) return false;
         return assign_fd(f);
@@ -442,14 +455,16 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
     case RedirOp::HereDoc:
     case RedirOp::HereDocStrip: {
       bool saved_ae = sh.arith_error;
+      bool saved_ab = sh.arith_abort;
       sh.arith_error = false;
+      sh.arith_abort = false;
       std::string body = r.heredoc_quoted ? r.heredoc_body : ex.expand_heredoc(r.heredoc_body);
-      // A bad substitution in the body aborts the redirection (bash).
-      if (sh.arith_error) {
-        sh.arith_error = saved_ae;
-        return false;
-      }
+      // A bad substitution in the body aborts the redirection (bash); the
+      // containment covers arith_abort too (see the fd-variant above).
+      bool failed = sh.arith_error || sh.arith_abort;
       sh.arith_error = saved_ae;
+      sh.arith_abort = saved_ab;
+      if (failed) return false;
       int f = heredoc_fd(body);
       if (f < 0) return false;
       redir_to(f, target_fd < 0 ? 0 : target_fd);
@@ -2213,6 +2228,10 @@ int Executor::run_loop(const LoopCommand *c) {
     if (sh_.continue_count) { if (--sh_.continue_count) break; else continue; }
   }
   sh_.loop_depth--;
+  // An unwind that began inside the loop -- a fatal expansion error in the
+  // condition, a return/exit from the body -- carries ITS status out, not the
+  // last completed body's: `while echo ${arr[]}; do :; done' is 1 (bash).
+  if (unwinding()) return sh_.last_status;
   return st;
 }
 
@@ -2301,6 +2320,12 @@ int Executor::run_for(const ForCommand *c) {
     items = ex.expand_args(c->words);
   else
     items = sh_.positional;
+  // A fatal expansion error in the word list fails the loop itself with
+  // status 1 (any arith_abort raised unwinds the enclosing list too).
+  if (sh_.arith_error) {
+    sh_.arith_error = false;
+    return (sh_.last_status = 1);
+  }
   // bash re-emits the `for NAME in WORDS' trace before EVERY iteration (not
   // once for the whole loop), so build it once and print it at the top of each.
   std::string xtrace_line;
@@ -2372,6 +2397,12 @@ int Executor::run_select(const ForCommand *c) {
   Expander ex(sh_);
   std::vector<std::string> items =
       c->words_present ? ex.expand_args(c->words) : sh_.positional;
+  // A fatal expansion error in the word list fails the select itself with
+  // status 1, like `for' (any arith_abort raised unwinds the enclosing list).
+  if (sh_.arith_error) {
+    sh_.arith_error = false;
+    return (sh_.last_status = 1);
+  }
   if (items.empty()) return (sh_.last_status = 0);  // empty list: no loop (bash)
   const int n = static_cast<int>(items.size());
 

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3411,7 +3411,11 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       std::string bodytxt = name + (have_sub ? "[" + sub + "]" : "") + rest;
       std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
                    bodytxt.c_str());
-      sh.arith_error = true;
+      // Unlike the other bad substitutions (DISCARD, status 1), an invalid
+      // transform operator is fatal like `${x?}': bash exits a
+      // non-interactive shell with 127 (issue #655).
+      sh.exiting = true;
+      sh.exit_status = 127;
       return std::string();
     }
     char t = rest[1];

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -1321,6 +1321,27 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   }
   // ${...}
   if (n1 == '{') {
+    // A fatal `${...}' expansion error -- bad substitution, bad array
+    // subscript, invalid indirection, a failed transform -- unwinds the whole
+    // command LIST in bash (the DISCARD longjmp): the rest of the current
+    // input line is abandoned and the reader continues at the next line,
+    // while in POSIX mode the error is fatal to a non-interactive shell
+    // outright (exit 127), like the $((...)) branch above.  A here-document
+    // body is the exception: bash only aborts the redirection there, which
+    // the executor's heredoc containment already models.  Escalating on exit
+    // from this branch covers every error site inside it at once (issue #655).
+    struct AbortGuard {
+      Shell &sh;
+      bool prior, heredoc;
+      ~AbortGuard() {
+        if (prior || !sh.arith_error || heredoc) return;
+        sh.arith_abort = true;
+        if (sh.opt_posix && !sh.interactive) {
+          sh.exiting = true;
+          sh.exit_status = 127;
+        }
+      }
+    } abort_guard{sh_, sh_.arith_error, heredoc};
     size_t end = scan_balanced(t, i + 1, '{', '}', /*firstclose=*/true,
                                /*squote_literal=*/dq && sh_.opt_posix);
     if (end != std::string::npos) {

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -680,6 +680,38 @@ echo ok16'
   'declare -A aa=([k]=v); echo "[${aa[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'unset q; echo "[${q[]}]" 2>&1 | sed -E "s/.*line [0-9]+: //"'
   'arr=(a b); echo "[${arr[ ]}]"'
+  # A fatal ${...} expansion error unwinds the WHOLE command list (bash
+  # DISCARD longjmp, #655): the rest of the line is abandoned -- through
+  # && chains, compounds and function calls -- while a subshell, pipeline
+  # element, eval string or trap body contains the unwind.
+  'arr=(a b); echo ${arr[]} && echo and; echo semi'
+  'arr=(a b); echo ${arr[0]junk}; echo after'
+  'arr=(a b); f(){ echo ${arr[]}; echo in-f; }; f; echo after-f'
+  'arr=(a b); (echo ${arr[]}; echo in-sub); echo st=$?'
+  'arr=(a b); echo out-$(echo ${arr[]})end; echo A'
+  'arr=(a b); eval "echo \${arr[]}; echo in-eval"; echo A'
+  'arr=(a b); echo ${arr[]} | cat; echo A'
+  'arr=(a b); if echo ${arr[]}; then echo T; else echo F; fi; echo A'
+  'arr=(a b); { echo ${arr[]}; echo in-grp; }; echo A'
+  'arr=(a b); ! echo ${arr[]}; echo A'
+  'arr=(a b); x=${arr[]}; echo A'
+  'arr=(a b); echo hi > /tmp/never-${arr[]}; echo A'
+  'v=abc; echo ${v@Z}; echo A'
+  'arr=(a); echo ${arr[1+]}; echo A'
+  # ...but a here-document body only aborts the redirection: the enclosing
+  # list keeps running, for $((...)) errors too.
+  'arr=(a b); cat <<E; echo A
+x${arr[]}x
+E'
+  'cat <<E; echo A
+x$((1+))x
+E'
+  # A fatal expansion error in a loop/select word list or condition is the
+  # construct'\''s own status 1, not the last body status.
+  'arr=(a b); while echo ${arr[]}; do break; done; echo A'
+  'arr=(a b); until echo ${arr[]}; do break; done; echo A'
+  'arr=(a b); for i in ${arr[]}; do echo L; done; echo A'
+  'arr=(a b); select i in ${arr[]}; do :; done; echo A'
   'foo=@; set -- a "b c" d; f(){ echo n=$#; for a; do echo "[$a]"; done; }; f ${!foo}; f "${!foo}"'
   'arr_1=(x "y z"); set -- "arr_1[@]"; a=("${!1}"); printf "<%s>" "${a[@]}"; echo'
   # Patsub parsing: anchors and // are exclusive, the // delimiter scan skips

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -706,6 +706,10 @@ E'
   'cat <<E; echo A
 x$((1+))x
 E'
+  # An invalid @ transform is FATAL like ${x?}: a non-interactive shell
+  # exits 127, not the usual DISCARD status 1.
+  'v=abc; echo ${v@Z}; echo A'
+  'v=abc; echo ${v@}; echo A'
   # A fatal expansion error in a loop/select word list or condition is the
   # construct'\''s own status 1, not the last body status.
   'arr=(a b); while echo ${arr[]}; do break; done; echo A'


### PR DESCRIPTION
## Summary

A fatal `${...}` expansion error — bad substitution, bad array subscript, invalid indirection — unwinds the whole command list in bash (the DISCARD longjmp): the rest of the current input line is abandoned, through `&&` chains, compound commands and function calls, and the reader continues at the next line. In POSIX mode the error is fatal to a non-interactive shell outright (exit 127). gnash reported the error and failed the command, but ran the rest of the list.

Closes #655

## Changes

- **`core/src/expand.cpp`**: a scope guard on `expand_dollar`'s `${...}` branch escalates any arith_error newly raised inside it to the existing `arith_abort` unwind (the mechanism fatal assignment errors already use), covering every error site in the branch at once. Containment falls out of existing machinery: subshells and pipeline elements fork; eval strings, funsubs, in-process command substitutions and trap bodies run through `run_string`, which already ends the unwind.
- **Here-document exception**: bash only aborts the redirection for an expansion error in a heredoc body. The executor's heredoc containment now saves/restores `arith_abort` too — which also stops the `$((...))` branch's abort from escaping a heredoc (`cat <<E; echo A` with a bad `$((1+))` body now runs the `echo A`, as bash does).
- **Redirect targets**: an expansion error in a redirection target now fails the redirection (and the command, status 1) instead of opening the partially-expanded filename.
- **Loops/select**: a fatal expansion error in a `while`/`until` condition or a `for`/`select` word list is the construct's own status 1, not the last completed body's.
- **Invalid `@` transform** (separate commit): `${v@Z}` / `${v@}` are fatal like `${x?}` — a non-interactive shell exits 127, not the DISCARD's status 1. This also stops `${arr[@]@Z}` printing its diagnostic once per element.
- **`tests/harness/run_diff.sh`**: 22 new differential cases covering the unwind, every containment boundary, the heredoc exception, and the loop/transform statuses (470 total).

## Verification

- 47-case probe battery vs bash 5.3 matches on stdout **and** exit status: all `${...}` error classes, `&&`/`;` chains, functions, subshells, pipelines, cmdsubs/backticks, eval, traps, heredocs, redirect targets, assignments, loops, `[[`, background jobs, POSIX mode (127), and the non-fatal classes (`(( ))`, `let`, `${x-}`, `${v/%%/x}`) staying non-fatal.
- `ctest` 23/23; `run_diff` 470/470.
- Full 83-suite scoreboard sweep with fresh oracles: no regressions — comsub-eof (5, bash's own bug) and the read timing flake are unchanged, and `errors` improves 126 → 125 vs the pre-change binary; the remaining 125 lines are pre-existing divergences (readonly-assignment abort family, `${$VAR}`), to be filed separately.