### PR TITLE
fix(redir): validate the fd word of a {var} dup redirect

### DIFF
--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -294,16 +294,37 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
         // `{v}<&N-' moves: duplicate N then close it.
         bool move = w.size() > 1 && w.back() == '-';
         if (move) w.pop_back();
-        int src = std::atoi(w.c_str());
-        int f = fcntl(src, F_DUPFD_CLOEXEC, 10);
-        if (f < 0) {
-          // The diagnostic names the UNEXPANDED word (`$fd: Bad file
-          // descriptor'), as bash does.
-          std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), r.target.text.c_str(),
-                       std::strerror(errno));
+        // The word must be a plain fd number.  bash rejects anything else --
+        // `foo', `0junk', `-1', `+1', an empty expansion -- as an ambiguous
+        // redirect naming the VARIABLE, which stays untouched (issue #656).
+        // (For a quoted-empty or set-variable non-move target bash's own
+        // report prints an uninitialized number; the ambiguous/converted
+        // reports here cover those deterministically.)
+        if (w.empty() || w.find_first_not_of("0123456789") != std::string::npos) {
+          std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
+                       r.fd_var.c_str());
           return false;
         }
-        if (move) close(src);
+        errno = 0;
+        long long src = std::strtoll(w.c_str(), nullptr, 10);
+        bool inrange = errno != ERANGE && src <= INT_MAX;
+        int f = -1;
+        if (inrange) f = fcntl(static_cast<int>(src), F_DUPFD_CLOEXEC, 10);
+        else errno = EBADF;  // a number no descriptor can have
+        if (f < 0) {
+          // bash reports a failed dup on the {var} form twice: the generic
+          // `cannot duplicate fd' line (no line number), then the CONVERTED
+          // number -- `010' reports as `10' -- or the raw digits when the
+          // value does not fit an intmax.
+          int e = errno;
+          std::string shown = inrange ? std::to_string(src) : w;
+          std::fprintf(stderr, "%s: redirection error: cannot duplicate fd: %s\n",
+                       sh.shell_name.c_str(), std::strerror(e));
+          std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), shown.c_str(),
+                       std::strerror(e));
+          return false;
+        }
+        if (move) close(static_cast<int>(src));
         return store_var(f);
       }
       case RedirOp::HereDoc:

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1631,7 +1631,19 @@ int Executor::run_simple(const SimpleCommand *c) {
       (!argv.empty() && argv[0] == "exec") ? "exec" : nullptr;
   if (!apply_redirects(sh_, c->redirects, saved, fdvar_ctx)) {
     restore_fds(saved);
-    return (sh_.last_status = 1);
+    // A redirection failure runs the ERR trap and is fatal under `set -e',
+    // like any failing simple command (the compound-command path above
+    // already does this); `!' inverts it to success as usual.
+    int st = (c->flags & CMD_INVERT_RETURN) ? 0 : 1;
+    sh_.last_status = st;
+    if (st != 0 && sh_.errexit_suppress == 0 && !unwinding()) {
+      sh_.run_err_trap(st);
+      if (sh_.opt_errexit) {
+        sh_.exiting = true;
+        sh_.exit_status = st;
+      }
+    }
+    return st;
   }
 
   // Temporary assignments: set as shell vars for the command and *exported* so

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -721,6 +721,13 @@ E'
   'v=5; exec {v}<&foo; echo v=$v'
   'exec {v}<&0 && echo dup-ok'
   'exec {v}<&9999999999999999999999999; echo st=$?'
+  # A redirection failure on a simple command runs the ERR trap and is fatal
+  # under set -e, like a failing command; `!` inverts it to success.
+  'set -e; exec {v}<&foo; echo unreached'
+  'set -e; echo hi > /nonexistent-dir/f; echo unreached'
+  'trap "echo E" ERR; echo hi > /nonexistent-dir/f; echo after'
+  '! echo hi > /nonexistent-dir/f; echo st=$?'
+  'set -e; if echo hi > /nonexistent-dir/f; then echo T; else echo F; fi; echo reached'
   # A fatal expansion error in a loop/select word list or condition is the
   # construct'\''s own status 1, not the last body status.
   'arr=(a b); while echo ${arr[]}; do break; done; echo A'

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -710,6 +710,17 @@ E'
   # exits 127, not the usual DISCARD status 1.
   'v=abc; echo ${v@Z}; echo A'
   'v=abc; echo ${v@}; echo A'
+  # A {var} dup redirect needs a plain NUMERIC fd word: anything else is an
+  # ambiguous redirect naming the VARIABLE, which stays untouched (#656).
+  'exec {v}<&foo; echo st=$? v=${v-unset}'
+  'exec {v}>&foo; echo st=$?'
+  'exec {v}<&0junk; echo st=$?'
+  'exec {v}<&-1; echo st=$?'
+  'exec {v}<&+1; echo st=$?'
+  'unset x; exec {v}<&$x; echo st=$?'
+  'v=5; exec {v}<&foo; echo v=$v'
+  'exec {v}<&0 && echo dup-ok'
+  'exec {v}<&9999999999999999999999999; echo st=$?'
   # A fatal expansion error in a loop/select word list or condition is the
   # construct'\''s own status 1, not the last body status.
   'arr=(a b); while echo ${arr[]}; do break; done; echo A'


### PR DESCRIPTION
## Summary

`{v}<&word` / `{v}>&word` converted the target word with `atoi`, so a non-numeric word (`exec {v}<&foo`) silently duplicated fd 0 and succeeded. bash rejects any word that is not a plain fd number as an ambiguous redirect naming the **variable** (`v: ambiguous redirect`), leaves the variable untouched, and fails the redirection with status 1.

Closes #656

## Changes

- **`core/src/executor.cpp` (dup path)**: validate the word before converting — `foo`, `0junk`, `-1`, `+1`, and empty expansions are `v: ambiguous redirect`. Conversion uses `strtoll` with a range check: an fd beyond `INT_MAX` cannot exist and reports `Bad file descriptor` instead of being truncated into a valid fd. A failed dup prints bash's two-line report for the `{var}` form — the generic `cannot duplicate fd` line, then the **converted** number (`010` reports as `10`), or the raw digits when the value doesn't fit an intmax. Two bash-side quirks (it prints an uninitialized garbage number for `<&""` and for set-variable non-move targets — nondeterministic across runs) are deliberately not replicated; gnash reports deterministically.
- **`core/src/executor.cpp` (separate commit)**: the issue's repro (`set -e; exec {v}<&foo; echo success`) exposed that a failed redirection on a **simple** command returned status 1 but skipped the ERR trap and `set -e` entirely — a pre-existing gap affecting every redirect failure (`set -e; echo hi > /nonexistent-dir/f; ...` also kept going). It now mirrors the compound-command path, including `!` inverting the failure to success.
- **`tests/harness/run_diff.sh`**: 14 differential cases (484 total).

## Verification

- The issue's exact repro now matches bash byte-for-byte: `v: ambiguous redirect`, exit 1, no `success`.
- 26-case probe matrix vs bash 5.3 matches on stdout and exit status (ambiguous forms, valid dups and moves, converted-number failure reports, overflow, ERR trap, `set -e`, `!` inversion, errexit-suppressed contexts).
- `run_diff` 484/484 (three consecutive clean runs); `ctest` 23/23; full 83-suite scoreboard sweep with fresh oracles: no regressions (`redir`/`vredir` 0; only the standing comsub-eof=5 and the pre-existing errors=125 of #658 remain).