### PR TITLE
fix: errors-suite fatal-error divergences (bad substitutions, POSIX fatality, builtin argument validation)

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -6034,6 +6034,11 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
   }
   if (rd || nw) { read_history((rest.empty() ? hist_file(sh) : rest[0]).c_str()); return 0; }
 
+  if (rest.size() > 1) {
+    // The listing form takes at most one count (`history 10 42' errors).
+    std::fprintf(stderr, "%shistory: too many arguments\n", sh.err_prefix().c_str());
+    return 2;
+  }
   if (!rest.empty()) {
     char *e = nullptr;
     long v = std::strtol(rest[0].c_str(), &e, 10);
@@ -6849,8 +6854,11 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       // treat it as a no-op success rather than a numeric-argument error.
       st = 0;
     } else if (argv.size() - ai > 1) {
+      // Extra arguments: status 2, and bash DISCARDS the rest of the command
+      // list (the reader continues at the next line) in both modes.
       std::fprintf(stderr, "%sshift: too many arguments\n", sh.err_prefix().c_str());
-      st = 1;
+      st = 2;
+      sh.arith_abort = true;
     } else {
       long n = 1;
       std::string a;
@@ -6865,6 +6873,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         std::fprintf(stderr, "%sshift: %s: numeric argument required\n",
                      sh.err_prefix().c_str(), a.c_str());
         st = 2;
+        sh.posix_special_builtin_error(st);  // posix: fatal (errors10.sub)
       } else if (n == 0) {
         st = 0;
       } else if (n < 0) {
@@ -6874,8 +6883,9 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
                      sh.err_prefix().c_str(), a.c_str());
         st = 1;
       } else if (n > static_cast<long>(sh.positional.size())) {
-        // Too large: silent failure unless `shopt -s shift_verbose'.
-        if (sh.shopt_opts["shift_verbose"])
+        // Too large: silent failure unless `shopt -s shift_verbose' -- which
+        // POSIX mode implies (`command shift 12' reports in errors8.sub).
+        if (sh.shopt_opts["shift_verbose"] || sh.opt_posix)
           std::fprintf(stderr, "%sshift: %s: shift count out of range\n",
                        sh.err_prefix().c_str(), a.c_str());
         st = 1;
@@ -6890,7 +6900,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     const std::string a = ci < argv.size() ? argv[ci] : std::string();
     char *end = nullptr;
     long v = a.empty() ? sh.last_status : std::strtol(a.c_str(), &end, 10);
-    if (!a.empty() && (end == a.c_str() || *end != '\0')) {
+    if (argv.size() - ci > 1) {
+      // Extra arguments: the shell does NOT exit; status 2 and the rest of
+      // the command list is discarded (both modes -- errors.tests).
+      std::fprintf(stderr, "%sexit: too many arguments\n", sh.err_prefix().c_str());
+      st = 2;
+      sh.arith_abort = true;
+    } else if (!a.empty() && (end == a.c_str() || *end != '\0')) {
       // A non-numeric argument is no longer a fatal error: bash reports it
       // and the shell CONTINUES with status 2 (posix mode still treats the
       // special-builtin error as fatal).
@@ -6907,9 +6923,43 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       if (sh.in_function()) { sh.exit_src_frames = sh.src_frames; sh.have_exit_frames = true; }
     }
   } else if (cmd == "return") {
-    // `return' is only meaningful in a function or a sourced script; elsewhere
-    // it is an error and must not unwind the current input (bash).
-    if (!sh.in_function() && sh.source_depth == 0) {
+    // Argument validation runs FIRST (bash's get_exitstat): extra arguments
+    // and a non-numeric status are reported even at top level, before the
+    // can-only-return check.
+    size_t ri = 1;
+    if (ri < argv.size() && argv[ri] == "--") ri++;
+    char *rend = nullptr;
+    long rv = 0;
+    bool badnum = false;
+    if (ri < argv.size()) {
+      rv = std::strtol(argv[ri].c_str(), &rend, 10);
+      badnum = argv[ri].empty() || rend == argv[ri].c_str() || *rend != '\0';
+    }
+    if (argv.size() - ri > 1) {
+      // Extra arguments: status 2, rest of the command list discarded (the
+      // function is NOT returned from -- errors.tests, both modes).
+      std::fprintf(stderr, "%sreturn: too many arguments\n", sh.err_prefix().c_str());
+      st = 2;
+      sh.arith_abort = true;
+    } else if (badnum) {
+      // Non-numeric: report, then RETURN with status 2 in default mode (the
+      // function body after it never runs); at top level the can-only-return
+      // report still follows.  POSIX: fatal (errors10.sub).
+      std::fprintf(stderr, "%sreturn: %s: numeric argument required\n",
+                   sh.err_prefix().c_str(), argv[ri].c_str());
+      st = 2;
+      sh.posix_special_builtin_error(st);
+      if (sh.in_function() || sh.source_depth > 0) {
+        sh.returning = true;
+        sh.exit_status = 2;
+      } else if (!sh.exiting) {
+        std::fprintf(stderr,
+                     "%sreturn: can only `return' from a function or sourced script\n",
+                     sh.err_prefix().c_str());
+      }
+    } else if (!sh.in_function() && sh.source_depth == 0) {
+      // `return' is only meaningful in a function or a sourced script;
+      // elsewhere it is an error and must not unwind the current input (bash).
       std::fprintf(stderr, "%sreturn: can only `return' from a function or sourced script\n",
                    sh.err_prefix().c_str());
       st = 1;
@@ -6923,14 +6973,40 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       int bare = (sh.trap_ret_depth >= 0 && sh.nest_depth() == sh.trap_ret_depth)
                      ? sh.trap_saved_status
                      : sh.last_status;
-      sh.exit_status = argv.size() > 1 ? (std::atoi(argv[1].c_str()) & 0xff) : bare;
+      sh.exit_status = ri < argv.size() ? (static_cast<int>(rv) & 0xff) : bare;
       st = sh.exit_status;
     }
   } else if (cmd == "break" || cmd == "continue") {
+    // Argument validation runs before the loop-level check (bash): extra
+    // arguments discard the rest of the list with status 2, and a
+    // non-numeric count is FATAL to any non-interactive shell in BOTH modes
+    // (`break x' ends the script -- errors4.sub, errors10.sub).
+    size_t bi = 1;
+    if (bi < argv.size() && argv[bi] == "--") bi++;
+    char *bend = nullptr;
+    bool bbad = false;
+    if (bi < argv.size()) {
+      std::strtol(argv[bi].c_str(), &bend, 10);
+      bbad = argv[bi].empty() || bend == argv[bi].c_str() || *bend != '\0';
+    }
+    if (argv.size() - bi > 1) {
+      std::fprintf(stderr, "%s%s: too many arguments\n", sh.err_prefix().c_str(),
+                   cmd.c_str());
+      st = 2;
+      sh.arith_abort = true;
+    } else if (bbad) {
+      std::fprintf(stderr, "%s%s: %s: numeric argument required\n",
+                   sh.err_prefix().c_str(), cmd.c_str(), argv[bi].c_str());
+      st = 2;
+      if (!sh.interactive) {
+        sh.exiting = true;
+        sh.exit_status = 2;
+      }
+    }
     // Outside any loop bash prints a diagnostic (suppressed under `set -o
     // posix') and succeeds without unwinding, rather than silently swallowing
     // the rest of the input.  Mirrors builtins/break.def check_loop_level().
-    if (sh.loop_depth == 0) {
+    else if (sh.loop_depth == 0) {
       if (!sh.opt_posix)
         std::fprintf(stderr, "%s%s: only meaningful in a `for', `while', or `until' loop\n",
                      sh.err_prefix().c_str(), cmd.c_str());

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7106,7 +7106,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
                      cmd.c_str(), argv[ai].c_str());
         std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
                      cmd.c_str(), cmd.c_str());
-        return 2;
+        if (status) *status = 2;
+        return true;
       }
       break;
     }
@@ -7115,13 +7116,15 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
                    cmd.c_str());
       std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
                    cmd.c_str(), cmd.c_str());
-      return 2;
+      if (status) *status = 2;
+      return true;
     }
     const std::string &fname = argv[ai];
     if (sh.opt_restricted && fname.find('/') != std::string::npos) {
       std::fprintf(stderr, "%s%s: %s: restricted\n", sh.err_prefix().c_str(),
                    cmd.c_str(), fname.c_str());
-      return 1;
+      if (status) *status = 1;
+      return true;
     }
     // Resolve the file: a name with a slash is used as-is; otherwise search the
     // `-p' path, or $PATH when the `sourcepath' shopt is on, falling back to the
@@ -7609,7 +7612,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         else if (o[k] == 'p') {  // default PATH; disallowed under restricted
           if (sh.opt_restricted) {
             std::fprintf(stderr, "%scommand: -p: restricted\n", sh.err_prefix().c_str());
-            return 2;
+            if (status) *status = 2;
+            return true;
           }
         }
         else { bad = true; badopt = std::string("-") + o[k]; break; }
@@ -7661,7 +7665,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   } else if (cmd == "exec") {
     if (sh.opt_restricted) {
       std::fprintf(stderr, "%sexec: restricted\n", sh.err_prefix().c_str());
-      return 2;
+      if (status) *status = 2;
+      return true;
     }
     // Options: -a NAME (argv[0] for the command), -c (empty environment),
     // -l (login: prefix argv[0] with '-').

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1751,6 +1751,20 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
         auto it = sh.vars.find(sh.deref(a.substr(0, eq)));
         if (it != sh.vars.end()) it->second.exported = false;
       }
+    } else if (!sh.is_zsh() &&
+               (a.empty() ||
+                !(std::isalpha(static_cast<unsigned char>(a[0])) || a[0] == '_') ||
+                a.find_first_not_of("abcdefghijklmnopqrstuvwxyz"
+                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_") !=
+                    std::string::npos)) {
+      // A bare NAME must be a valid identifier: `export non-identifier' is an
+      // error with status 1, each bad name reported (errors11.sub).  POSIX:
+      // fatal at the first bad name (`command' shields).
+      std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
+                   sh.err_prefix().c_str(), a.c_str());
+      st = 1;
+      sh.posix_special_builtin_error(1);
+      if (sh.exiting) return 1;
     } else {
       // `export ref' where ref resolves to an array element is rejected like
       // `export a[5]': the resolved `var[0]' is not a valid identifier (bash).
@@ -3192,6 +3206,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
                    argv[0].c_str(), tgt.c_str());
       ret = 1;
+      // POSIX: fatal at the FIRST bad name -- later names are not reported
+      // (errors11.sub); `command' shields via posix_builtin_shield.
+      sh.posix_special_builtin_error(1);
+      if (sh.exiting) return 1;
       continue;
     }
     // A nameref cannot itself be an array element (`declare -n a[128]'): bash
@@ -3215,6 +3233,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
                    sh.err_prefix().c_str(), argv[0].c_str(), a.c_str());
       ret = 1;
+      // POSIX readonly/export: fatal at the FIRST bad name (errors11.sub).
+      if (argv[0] == "readonly" || argv[0] == "export") {
+        sh.posix_special_builtin_error(1);
+        if (sh.exiting) return 1;
+      }
       continue;
     }
     bool scalar_pre = eq != std::string::npos && !arraylit0 && !subscript0 && !nameref;
@@ -6837,7 +6860,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   else if (cmd == "pushd") st = bi_pushd(sh, argv);
   else if (cmd == "popd") st = bi_popd(sh, argv);
   else if (cmd == "mapfile" || cmd == "readarray") st = bi_mapfile(sh, argv);
-  else if (cmd == "export") st = bi_export(sh, argv);
+  else if (cmd == "export") {
+    st = bi_export(sh, argv);
+    // POSIX: a failing export (invalid identifier, assignment error) is a
+    // special-builtin error, fatal to a non-interactive shell unless run via
+    // `command' (errors11.sub).
+    if (st != 0) sh.posix_special_builtin_error(st);
+  }
   else if (cmd == "unset") st = bi_unset(sh, argv);
   else if (cmd == "set") st = bi_set(sh, argv);
   // `personality' is always available; `emulate' is its zsh-mode alias.
@@ -7233,6 +7262,8 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     st = bi_declare(sh, argv, sh.in_function(), false);
   } else if (cmd == "readonly") {
     st = bi_declare(sh, argv, false, true);
+    // POSIX: like export, a failing readonly is fatal unless `command'-run.
+    if (st != 0) sh.posix_special_builtin_error(st);
   } else if (cmd == "let") {
     st = bi_let(sh, argv);
   } else if (cmd == "type") {

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -2719,8 +2719,10 @@ int Executor::run_funcdef(const FunctionDef *c) {
 
 int Executor::run_cond(const CondCommand *c) {
   // A conditional is a leaf command, not a wrapper: like a simple command it
-  // sets $BASH_COMMAND and, failing, fires the ERR trap.
+  // sets $BASH_COMMAND, fires the DEBUG trap (errors9.sub) and, failing, the
+  // ERR trap.
   sh_.bash_command = to_string(c);
+  if (!debug_trap_for(c, c->line)) return sh_.last_status;
   // Minimal [[ ]] evaluation delegated to the test builtin semantics via a
   // small dispatch here.  For now, evaluate simple `a OP b`, unary, and !/&&/||
   // by reusing the expression string tokens is complex; approximate with the

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -1573,6 +1573,13 @@ int Executor::run_simple(const SimpleCommand *c) {
     restore_fds(saved);
     if (assign_failed) {
       sh_.arith_abort = true;
+      // In POSIX mode an assignment error is FATAL to a non-interactive
+      // shell: `-o posix ./errors4.sub' ends at its first readonly
+      // assignment rather than carrying on at the next line.
+      if (sh_.opt_posix && !sh_.interactive) {
+        sh_.exiting = true;
+        sh_.exit_status = 1;
+      }
       return (sh_.last_status = 1);
     }
     int st = sh_.cmdsub_ran ? sh_.last_cmdsub_status : 0;
@@ -1643,7 +1650,48 @@ int Executor::run_simple(const SimpleCommand *c) {
         sh_.exit_status = st;
       }
     }
+    // POSIX: a redirection error on a SPECIAL builtin exits a non-interactive
+    // shell -- even on the LHS of `||' (errors3.sub) -- unless shielded by a
+    // `command' prefix.  Other commands just fail.
+    if (st != 0 && sh_.opt_posix && !sh_.interactive && !skip_functions &&
+        !argv.empty() && is_special_builtin_name(argv[0])) {
+      sh_.exiting = true;
+      sh_.exit_status = st;
+    }
     return st;
+  }
+
+  // POSIX: a temporary-assignment error on a command WITH a command word
+  // suppresses the command (status 1; bash follows ksh93 rather than exiting)
+  // -- except for a SPECIAL builtin, where it is fatal to a non-interactive
+  // shell (errors7.sub).  Outside posix mode the command still runs, as bash
+  // (apply_temp prints the diagnostic there).  A nameref target is shadowed
+  // for the command's duration and never fails.
+  if (sh_.opt_posix && !assigns.empty()) {
+    bool temp_fail = first_bad_assign != std::string::npos;  // already reported
+    for (size_t ai = 0; ai < assigns.size() && !temp_fail; ai++) {
+      auto nit = sh_.vars.find(assigns[ai].first);
+      if (nit != sh_.vars.end() && nit->second.nameref) continue;
+      auto it = sh_.vars.find(sh_.deref(assigns[ai].first));
+      if (it != sh_.vars.end() && it->second.readonly) {
+        std::fprintf(stderr, "%s%s: readonly variable\n", sh_.err_prefix().c_str(),
+                     assigns[ai].first.c_str());
+        temp_fail = true;
+      }
+    }
+    if (temp_fail) {
+      restore_fds(saved);
+      int st = (c->flags & CMD_INVERT_RETURN) ? 0 : 1;
+      sh_.last_status = st;
+      // The suppression also DISCARDS the rest of the list (the reader
+      // continues at the next line -- `px=8 echo word; echo x' skips both).
+      sh_.arith_abort = true;
+      if (!sh_.interactive && !skip_functions && is_special_builtin_name(argv[0])) {
+        sh_.exiting = true;
+        sh_.exit_status = 1;
+      }
+      return st;
+    }
   }
 
   // Temporary assignments: set as shell vars for the command and *exported* so
@@ -2212,6 +2260,10 @@ int Executor::run_subshell(const Subshell *c) {
     if (dynamic_cast<const SimpleCommand *>(c->body.get())) sh_.can_exec_replace = true;
     Executor ex(sh_);
     int s = ex.run(c->body.get());
+    // A DISCARD unwind (arith_abort) that reaches the end of a subshell exits
+    // it with plain failure: bash's `(exit 42 43)' subshell reports 1 even
+    // though $? on the line after the discard would read 2.
+    if (sh_.arith_abort) s = 1;
     sh_.can_exec_replace = false;
     // Run the subshell's own EXIT trap, if it installed one, with $? set to the
     // status of the last command (bash semantics).
@@ -2390,8 +2442,14 @@ int Executor::run_for(const ForCommand *c) {
         vit->second.value = item;
     } else if (!sh_.set(c->var, item)) {
       // A readonly loop variable aborts the whole loop with status 1, after
-      // ONE diagnostic (bash: `for VAR in 1 2 3' with VAR readonly).
+      // ONE diagnostic (bash: `for VAR in 1 2 3' with VAR readonly).  In
+      // POSIX mode the assignment error is FATAL to a non-interactive shell
+      // (errors4.sub).
       st = 1;
+      if (sh_.opt_posix && !sh_.interactive) {
+        sh_.exiting = true;
+        sh_.exit_status = 1;
+      }
       break;
     }
     st = run(c->body.get());
@@ -2541,7 +2599,16 @@ int Executor::run_select(const ForCommand *c) {
     if (!have_sel) break;
     // Bind NAME (write-through a nameref, honoring readonly); a failed bind
     // aborts the select without running the body, as bash does.
-    if (!sh_.set(c->var, selection)) { st = 1; break; }
+    if (!sh_.set(c->var, selection)) {
+      // Like `for': a readonly select variable fails the loop, and in POSIX
+      // mode the assignment error is fatal to a non-interactive shell.
+      st = 1;
+      if (sh_.opt_posix && !sh_.interactive) {
+        sh_.exiting = true;
+        sh_.exit_status = 1;
+      }
+      break;
+    }
     st = run(c->body.get());
     if (sh_.break_count) { sh_.break_count--; break; }
     if (sh_.continue_count) { if (--sh_.continue_count) break; }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -2919,12 +2919,19 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     return std::string();
   }
 
-  // Text left after a `name[sub]' reference must be an operator: bash rejects
-  // `${a[0]junk}' and `${a[0] + b[y]}' as `bad substitution' rather than
-  // silently reading the element and dropping the rest (issue #459).
-  if (have_sub && p < b.size() && !sh.is_zsh() &&
-      !std::strchr(":-+=?#%/^,@", b[p])) {
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+  // Text left after ANY parameter reference must be an operator: bash rejects
+  // `${a[0]junk}' (issue #459), `${x!y}', `${$NO_SUCH_VAR}', `${-3}', `${1x}'
+  // and `${#x%}' alike as `bad substitution' rather than silently expanding
+  // the name and dropping the rest (issue #658).  `~' is the (undocumented)
+  // case-invert operator, so `${a[0]~}' / `${x~}' stay valid.  The whole-body
+  // text is bash's diagnostic for the plain forms; the subscript form keeps
+  // naming the rewritten `name[sub]' body.
+  // (`!' is exempt: `${!@}'/`${!*}' indirect through the positional list and
+  // any malformed `!' form was already rejected by the listing validation.)
+  if (!name.empty() && name != "!" && p < b.size() && !sh.is_zsh() &&
+      !std::strchr(":-+=?#%/^,@~", b[p])) {
+    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
+                 have_sub ? b.c_str() : body.c_str());
     sh.arith_error = true;
     return std::string();
   }

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -3112,7 +3112,16 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
             bool ok = true;
             w = std::to_string(eval_arith(sh, w, &ok));
           }
+          // A refused store (readonly array; array_set printed the message)
+          // is an assignment ERROR: bash abandons the command list, and in
+          // posix mode it is fatal (errors7.sub).  A bad subscript already
+          // aborted inside array_set itself.
+          bool ro = it != sh.vars.end() && it->second.readonly;
           sh.array_set(name, sub, w);
+          if (ro) {
+            sh.arith_error = true;
+            return std::string();
+          }
           return sh.array_get(name, sub);
         }
         // A scalar assignment honors the variable's attributes exactly like a
@@ -3124,7 +3133,13 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
           bool iok = true;
           w = std::to_string(eval_arith(sh, w, &iok));
         }
-        sh.set(name, w);
+        // A refused assignment (readonly; sh.set printed the message) is an
+        // assignment ERROR: bash abandons the command list (`readonly v;
+        // : ${v:=val}; echo x' never echoes), fatal in posix (errors7.sub).
+        if (!sh.set(name, w)) {
+          sh.arith_error = true;
+          return std::string();
+        }
         std::string stored;
         return sh.get_if_set(name, stored) ? stored : w;
       }

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -734,6 +734,60 @@ E'
   'arr=(a b); until echo ${arr[]}; do break; done; echo A'
   'arr=(a b); for i in ${arr[]}; do echo L; done; echo A'
   'arr=(a b); select i in ${arr[]}; do :; done; echo A'
+  # Trailing text after ANY parameter reference is a bad substitution (#658):
+  # special/positional/length names too, not only name[sub].  `~' (case
+  # invert) is a valid operator.
+  'x=abc; echo ${x!y}; echo A'
+  'x=abc; echo ${x }; echo A'
+  'set -- a; echo ${1x}; echo A'
+  'echo ${@x}; echo A'
+  'echo ${$NO_SUCH_VAR}; echo A'
+  'echo ${-3}; echo A'
+  'echo "${-3:-${-3}}"; echo A'
+  'x=abc; echo ${#x%}; echo A'
+  'x=abc; echo ${#x-y}; echo A'
+  'echo ${#-y}; echo A'
+  'x=aB; echo ${x~} ${x~~}'
+  'a=(xy); echo ${a[0]~}'
+  # ${v:=val} on a readonly target is an assignment error: report + abandon
+  # the list; fatal in posix mode.
+  'readonly v; : ${v:=val}; echo after'
+  'readonly -a ra; : ${ra[0]=y}; echo after'
+  'set -o posix; readonly pv; : ${pv:=val}; echo after'
+  # POSIX-mode fatal errors: standalone/loop-var/temp-env assignment errors
+  # and special-builtin redirection failures end a non-interactive shell.
+  '(set -o posix; readonly pv; pv=2; echo in); echo rc=$?'
+  '(set -o posix; readonly pv; for pv in 1 2; do echo $pv; done; echo in); echo rc=$?'
+  'readonly nv; for nv in 1 2; do echo $nv; done; echo after; echo st=$?'
+  '(set -o posix; readonly px; px=8 :; echo in); echo rc=$?'
+  '(set -o posix; readonly px; px=8 echo word; echo in: $?); echo rc=$?'
+  'set -o posix; exec 9</nonexistent-653; echo after'
+  'exec 9</nonexistent-653 || echo TEST'
+  'set -o posix; readonly pz; command export pz=foo || echo shielded'
+  # Numeric-argument and argument-count validation (errors4/10, #658):
+  # break/continue non-numeric are fatal in both modes; return reports then
+  # returns 2; too many arguments discard the list with status 2.
+  'for f in _; do break x; done; echo after'
+  'for f in _; do continue x; done; echo after'
+  'f(){ return abcde; echo in; }; f; echo after: $?'
+  'return abcde; echo after: $?'
+  'shift abcde; echo after: $?'
+  'for f in _; do exit abcde; done; echo after: $?'
+  '(f(){ return 42 43; echo in; }; f); echo rc=$?'
+  '(exit 42 43); echo rc=$?'
+  '(shift 1 2; echo in); echo rc=$?'
+  '(for f in _; do break 1 2; done; echo in); echo rc=$?'
+  'set -- a b c; shift 12; echo st=$?'
+  'set -o posix; set -- a b c; shift 12; echo st=$?'
+  # export validates bare names like readonly; posix exits at the FIRST bad
+  # name; `command' shields; `.'/source option errors report status 2.
+  'export non-ident; echo after: $?'
+  'export a1=1 non-ident b1=2; echo after: $? b=$b1'
+  'set -o posix; export non-ident invalid+i; echo after'
+  'set -o posix; command export non-ident; echo command: $?'
+  'false; . -x /dev/null 2>/dev/null; echo st=$?'
+  # The DEBUG trap fires for [[ ]] like any leaf command.
+  'trap "echo D" DEBUG; [[ a = a ]]; echo x'
   'foo=@; set -- a "b c" d; f(){ echo n=$#; for a; do echo "[$a]"; done; }; f ${!foo}; f "${!foo}"'
   'arr_1=(x "y z"); set -- "arr_1[@]"; a=("${!1}"); printf "<%s>" "${a[@]}"; echo'
   # Patsub parsing: anchors and // are exclusive, the // delimiter scan skips


### PR DESCRIPTION
## Summary

Fixes every family of issue #658 — the `errors.tests` divergences that became visible once the suite ran in a correct `OLDPWD` environment. The suite now scores **0** (byte-identical to bash 5.3); it was 125 before this PR and 126 at release 2.1.1.

Closes #658

## Changes (one commit per family)

- **`fix(expand)`: trailing text after any parameter reference** — `${x!y}`, `${$NO_SUCH_VAR}`, `${-3}`, `${1x}`, `${@x}`, `${#x%}` are bad substitutions, generalizing the `name[sub]` junk check from #459. Fixes a latent bug (the `~` case-invert operator was missing from the allowed set, wrongly rejecting `${a[0]~}`) and exempts `!` (`${!@}`/`${!*}` indirect through the positionals).
- **`fix(expand)`: `${v:=val}` readonly store** — now an assignment error: reported, list abandoned, fatal in posix.
- **`fix(executor)`: POSIX fatality** — assignment errors (standalone, for/select loop variable, `var=x cmd` temp prefix) and special-builtin redirection failures exit a non-interactive posix shell; the temp-prefix form on a non-special command suppresses the command with a discard instead (ksh93 emulation, as bash); `command` shields; a DISCARD unwind leaving a subshell exits 1.
- **`fix(executor)`: DEBUG trap fires for `[[ ]]`**.
- **`fix(builtins)`: numeric arguments and argument counts** — break/continue non-numeric counts are fatal in both modes; return validates before can-only-return and returns 2; exit with extra args doesn't exit (status 2, discard); shift posix behaviors; history count validation.
- **`fix(builtins)`: export validates bare names** — was silently status 0; posix exits at the *first* bad name for export/readonly, `command`-shielded.
- **`fix(builtins)`: `*status` on early `run_builtin` returns** — five paths returned bare numerics from the bool dispatch, leaving `*status` unwritten (the real cause of the errors8 `command . -x` divergence).
- **`test(harness)`**: 41 new differential cases (525 total).

## Verification

- `errors` scoreboard: **125 → 0** with fresh oracles in a correct environment.
- Full 83-suite sweep: everything 0 except comsub-eof (5, bash's own acknowledged bug) — including `read`, and no regressions anywhere.
- `run_diff` 525/525; `ctest` 23/23.
- Each family verified against bash 5.3 with targeted probes (file-mode semantics as ground truth; bash's `-c`-mode discard/exit-code quirks documented and excluded from tests where bash itself is inconsistent).