### PR TITLE
fix(complete): derive command completion from the runtime builtin table

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -6709,8 +6709,23 @@ bool command_is_valid(Shell &sh, const std::string &name) {
   if (name.empty()) return false;
   if (name.find('/') != std::string::npos) return access(name.c_str(), X_OK) == 0;
   if (is_builtin_name(name) || is_reserved_word(name)) return true;
+  if (sh.is_zsh() && name == "emulate") return true;  // zsh-only builtin (#662)
   if (sh.functions.count(name) || sh.aliases.count(name)) return true;
   return !find_in_path(sh, name).empty();
+}
+
+// Every builtin name the DISPATCH would accept in SH's current state: the
+// full runtime table -- including gnash's own `personality', which the
+// bash-compatible listings (compgen -b, `enable', complete -A builtin =
+// builtin_names_sorted) deliberately omit -- plus personality-conditional
+// names (zsh's `emulate').  Completion and highlighting use this view, so a
+// builtin added to the table is completable without touching a second list
+// (issue #662).
+static std::vector<std::string> dispatchable_builtin_names(Shell &sh) {
+  std::vector<std::string> v;
+  for (int i = 0; kBuiltinNames[i]; i++) v.emplace_back(kBuiltinNames[i]);
+  if (sh.is_zsh()) v.emplace_back("emulate");
+  return v;
 }
 
 std::vector<std::string> command_completions(Shell &sh, const std::string &prefix) {
@@ -6725,7 +6740,7 @@ std::vector<std::string> command_completions(Shell &sh, const std::string &prefi
   for (int i = 0; kw[i]; i++) consider(kw[i]);
   for (const auto &kv : sh.aliases) consider(kv.first);
   for (const auto &kv : sh.functions) consider(kv.first);
-  for (const auto &b : builtin_names_sorted())
+  for (const auto &b : dispatchable_builtin_names(sh))
     if (!sh.disabled_builtins.count(b)) consider(b);
   // Executable regular files on $PATH, matched by basename.
   std::string path = sh.get("PATH");

--- a/tests/command_complete_test.cpp
+++ b/tests/command_complete_test.cpp
@@ -65,6 +65,17 @@ int main() {
   sh.disabled_builtins.insert("echo");
   want(sh, "ech", "echo", false);
 
+  // gnash's own `personality' builtin completes even though the
+  // bash-compatible listings (compgen -b) omit it, and the zsh-only
+  // `emulate' appears exactly when that personality is active (#662).
+  want(sh, "person", "personality", true);
+  want(sh, "emul", "emulate", false);
+  sh.set_personality("zsh");
+  want(sh, "emul", "emulate", true);
+  want(sh, "person", "personality", true);
+  sh.set_personality("bash");
+  want(sh, "emul", "emulate", false);
+
   unlink(exe.c_str());
   unlink(noexe.c_str());
   rmdir(dir);


### PR DESCRIPTION
## Summary

TAB completion never offered the `personality` builtin (user report). `command_completions()` sourced its builtin candidates from `builtin_names_sorted()` — the bash-compatible *listing* view that deliberately omits `personality` so `compgen -b` / `complete -A builtin` / `enable` stay byte-identical to bash. Reusing the filtered listing for interactive completion silently dropped gnash's own builtin.

Closes #662

## Changes

- `core/src/builtins.cpp`: completion candidates now come from a `dispatchable_builtin_names(sh)` view — the full runtime builtin table (what dispatch actually accepts), plus personality-conditional names (`emulate` under the zsh personality), minus `enable -n`'d builtins. A builtin added to the table is completable with no second list to update. `command_is_valid` (syntax highlighting) recognizes zsh-mode `emulate` too. The bash-compatible listings are untouched.
- `tests/command_complete_test.cpp`: asserts `personality` completes, `emulate` completes exactly when the zsh personality is active, and the listing exclusion still holds.

## Verification

- Unit test exercises the exact function the REPL's TAB handler (`gnash_command_completion`) calls; ctest 23/23.
- `compgen -b` still omits `personality` (bash byte-compat preserved); `complete`/`builtins`/`type` scoreboard suites all 0; run_diff 525/525.