### PR TITLE
fix(personality): make -l, -R and -c work as documented

### DIFF
--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -389,6 +389,9 @@ class Shell {
   enum class Persona { Bash, Zsh, Ash, Ksh, Csh };
   Persona persona = Persona::Bash;
   std::string personality_name = "gnash";  // exposed as $GNASH_PERSONALITY
+  // The personality the shell STARTED with (recorded by the first
+  // set_personality call, i.e. startup): `personality -R' resets to it.
+  std::string invoked_personality;
   bool is_zsh() const { return persona == Persona::Zsh; }
   bool is_ash() const { return persona == Persona::Ash; }
   bool is_ksh() const { return persona == Persona::Ksh; }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4872,7 +4872,7 @@ static const BuiltinHelp kBuiltinHelp[] = {
     {"enable", "enable [-a] [-dnps] [-f filename] [name ...]", "Enable and disable shell builtins."},
     {"caller", "caller [expr]", "Return the context of the current subroutine call."},
     {"alias", "alias [-p] [name[=value] ... ]", "Define or display aliases."},
-    {"personality", "personality [-lLR] [{bash|strict-bash|zsh|sh|ksh|csh} [-c command]]", "Switch the shell's personality at runtime (zsh `emulate' syntax)."},
+    {"personality", "personality [-lLR] [{bash|strict-bash|zsh|sh|ksh|csh}] [-c command ...]", "Switch the shell's personality at runtime (zsh `emulate' syntax)."},
     {"unalias", "unalias [-a] name [name ...]", "Remove each NAME from the list of defined aliases."},
     {"history", "history [-c] [-d offset] [n] or history -anrw [filename] or history -ps arg [arg...]", "Display or manipulate the history list."},
     {"fc", "fc [-e ename] [-lnr] [first] [last] or fc -s [pat=rep] [command]", "Display or execute commands from the history list."},
@@ -5071,9 +5071,11 @@ static const struct { const char *name, *body; } kBuiltinLongDoc[] = {
      "  csh\t\tC shell\n\n"
      "Options:\n"
      "  -l\tlist the available personalities, one per line\n"
-     "  -L\tlist them, marking the current personality\n"
+     "  -L\tmake the switch local to the enclosing function, restored when\n"
+     "\t\tit returns (as zsh's `emulate -L')\n"
      "  -R\treset to the personality the shell was invoked with\n"
-     "  -c command\trun COMMAND under PERSONALITY, then restore the previous one\n\n"
+     "  -c command ...\trun the remaining words as a command under\n"
+     "\t\tPERSONALITY (or the current one), then restore\n\n"
      "Exit Status:\n"
      "Returns success unless an invalid personality or option is given."},
 };
@@ -6775,50 +6777,75 @@ std::vector<std::string> command_completions(Shell &sh, const std::string &prefi
 // the switch local to the enclosing function (restored on return); `-R'/`-l'
 // are accepted (a personality switch is already a full reconfiguration).
 int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
-  static const std::set<std::string> kNames = {
-      "bash", "strict-bash", "zsh",  "sh",    "dash", "ash",
-      "ksh",  "ksh93",       "mksh", "pdksh", "rksh", "csh", "tcsh"};
+  // Accepted names, in the listing order `-l' prints (canonical first, then
+  // each personality's aliases).
+  static const char *const kListOrder[] = {
+      "bash", "strict-bash", "sh",    "dash", "ash",  "zsh", "ksh",
+      "ksh93", "mksh",       "pdksh", "rksh", "csh",  "tcsh"};
+  static const std::set<std::string> kNames(std::begin(kListOrder),
+                                            std::end(kListOrder));
   bool opt_l = false, opt_L = false, opt_R = false;
-  size_t i = 1;
-  for (; i < argv.size(); i++) {
+  bool have_mode = false, have_c = false;
+  std::string mode, cmd;
+  bool no_more_opts = false;
+  for (size_t i = 1; i < argv.size(); i++) {
     const std::string &a = argv[i];
-    if (a == "--") { i++; break; }
-    if (a.size() < 2 || a[0] != '-') break;
-    bool ok = true;
-    for (size_t k = 1; k < a.size(); k++) {
-      if (a[k] == 'l') opt_l = true;
-      else if (a[k] == 'L') opt_L = true;
-      else if (a[k] == 'R') opt_R = true;
-      else { ok = false; break; }
+    if (!no_more_opts && a == "--") { no_more_opts = true; continue; }
+    if (!no_more_opts && a == "-c") {
+      // `-c' takes the REST of the words as the command line (joined), so
+      // `personality -c echo hi' and `personality zsh -c "echo hi"' both
+      // work; a missing PERSONALITY runs under the current one (#660).
+      have_c = true;
+      for (size_t k = i + 1; k < argv.size(); k++) {
+        if (!cmd.empty()) cmd += ' ';
+        cmd += argv[k];
+      }
+      break;
     }
-    if (!ok) {
-      std::fprintf(stderr, "%s: bad option: %s\n", argv[0].c_str(), a.c_str());
-      return 1;
+    if (!no_more_opts && a.size() >= 2 && a[0] == '-') {
+      bool ok = true;
+      for (size_t k = 1; k < a.size(); k++) {
+        if (a[k] == 'l') opt_l = true;
+        else if (a[k] == 'L') opt_L = true;
+        else if (a[k] == 'R') opt_R = true;
+        else { ok = false; break; }
+      }
+      if (!ok) {
+        std::fprintf(stderr, "%s: bad option: %s\n", argv[0].c_str(), a.c_str());
+        return 1;
+      }
+      continue;
     }
+    if (!have_mode) { mode = a; have_mode = true; continue; }
+    std::fprintf(stderr, "%s: unknown argument: %s\n", argv[0].c_str(), a.c_str());
+    return 1;
   }
-  (void)opt_R;
-
-  if (i >= argv.size()) {  // no mode -> report the current personality
-    std::printf("%s\n", sh.personality_name.c_str());
-    return 0;
-  }
-
-  std::string mode = argv[i++];
-  if (!kNames.count(mode)) {
+  if (have_mode && !kNames.count(mode)) {
     std::fprintf(stderr, "%s: unknown personality: %s\n", argv[0].c_str(), mode.c_str());
     return 1;
   }
-  // Trailing `-c command' (and any other option-flags, which we accept quietly).
-  std::string cmd;
-  bool have_c = false;
-  for (; i < argv.size(); i++) {
-    if (argv[i] == "-c" && i + 1 < argv.size()) { cmd = argv[++i]; have_c = true; }
+
+  // `-l': list the available personalities, one per line, without switching.
+  if (opt_l) {
+    for (const char *n : kListOrder) std::printf("%s\n", n);
+    return 0;
+  }
+  // `-R': reset to the personality the shell was invoked with.
+  if (opt_R && !have_mode) {
+    mode = sh.invoked_personality.empty() ? "bash" : sh.invoked_personality;
+    have_mode = true;
   }
 
-  if (have_c) {  // run under MODE, then restore
+  if (have_c) {
+    if (cmd.empty()) {
+      std::fprintf(stderr, "%s: -c: command required\n", argv[0].c_str());
+      return 1;
+    }
+    if (!have_mode) return sh.run_string(cmd);  // current personality: no switch
+    // Run under MODE, then restore.  `strict-bash' leaves $BASHLY_CORRECT on,
+    // and restoring the personality name alone would not undo that -- so put
+    // the switch back as well.
     std::string saved = sh.personality_name;
-    // `strict-bash' leaves $BASHLY_CORRECT on, and restoring the personality
-    // name alone would not undo that -- so put the switch back as well.
     bool had_bc = sh.is_set("BASHLY_CORRECT");
     std::string saved_bc = sh.get("BASHLY_CORRECT");
     sh.set_personality(mode);
@@ -6828,10 +6855,16 @@ int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
     else sh.unset("BASHLY_CORRECT");
     return st;
   }
+
+  if (!have_mode) {  // no mode -> report the current personality
+    std::printf("%s\n", sh.personality_name.c_str());
+    return 0;
+  }
+  // `-L': make the switch local to the enclosing function (zsh's emulate -L),
+  // restored when it returns.
   if (opt_L && !sh.persona_restore.empty() && !sh.persona_restore.back())
-    sh.persona_restore.back() = sh.personality_name;  // restore when the function returns
+    sh.persona_restore.back() = sh.personality_name;
   sh.set_personality(mode);
-  (void)opt_l;
   return 0;
 }
 

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1969,6 +1969,8 @@ void Shell::set_personality(const std::string &name) {
   // up bash's startup files while the stricter limits apply.  Selecting any
   // other personality turns the switch back off.
   bool strict = name == "strict-bash";
+  // The first call is startup's: remember it so `personality -R' can reset.
+  if (invoked_personality.empty()) invoked_personality = name;
   personality_name = strict ? "bash" : name;
   const std::string &nm = personality_name;
   if (nm == "zsh") persona = Persona::Zsh;

--- a/tests/harness/personality_test.sh
+++ b/tests/harness/personality_test.sh
@@ -71,6 +71,26 @@ check "non-exported var does not cross to csh" "0" bash \
 check "unknown name is an error" "1" bash \
   'personality nonesuch >/dev/null 2>&1; echo $?'
 
+# -l lists the available personalities, one per line, without switching (#660)
+check "-l lists without switching" $'bash\nstrict-bash\nbash' bash \
+  'personality -l | head -2; personality'
+
+# -c without a personality runs under the current one, joining the words
+check "-c without a name runs the words" "bash" bash \
+  'personality -c echo $GNASH_PERSONALITY'
+check "-c joins multiple words" "a b" bash 'personality -c echo a b'
+check "bare -c is an error" "1" bash 'personality -c 2>/dev/null; echo $?'
+
+# -R resets to the personality the shell was invoked with
+check "-R resets to invoked (zsh)" $'sh\nzsh' zsh \
+  'personality sh; personality; personality -R; personality'
+check "-R resets to invoked (bash)" $'csh\nbash' bash \
+  'personality csh; personality; personality -R; personality'
+
+# a stray extra argument is rejected
+check "extra argument is an error" "1" bash \
+  'personality sh extra >/dev/null 2>&1; echo $?'
+
 if [ $fails -eq 0 ]; then
   echo "personality_test: all checks passed"
   exit 0


### PR DESCRIPTION
## Summary

The `personality` builtin's help advertised `-l`, `-L`, `-R` and `-c` behaviors it didn't implement — `personality -c echo $SHELL` errored with `bad option: -c`, and `-l`/`-R` were accepted but ignored (worse, `personality -l sh` silently *switched*).

Closes #660

## Changes

- **`-l`** lists the available personalities (canonical names then aliases), one per line, without switching.
- **`-R`** resets to the personality the shell was invoked with (a new `Shell::invoked_personality`, recorded by startup's `set_personality` call).
- **`-c`** works without a personality name (runs under the current one) and takes the rest of the words as the command line, joined — so the issue's exact repro `personality -c echo $SHELL` now prints the shell path with status 0. `personality zsh -c "cmd"` keeps working. A bare `-c` and stray extra arguments are errors now instead of being silently ignored.
- **`-L`** keeps its existing local-to-function switch (zsh's `emulate -L` semantics, already covered by tests and relied on by zsh-mode scripts); the help now documents that instead of the unimplemented "list marking current" wording, and the usage/`-c` lines match the implementation.

## Verification

- `tests/harness/personality_test.sh` grew 8 checks (listing without switching, `-c` with/without name, word joining, bare `-c` error, `-R` from both bash and zsh invocations, extra-argument rejection) — all pass.
- ctest 23/23; run_diff 525/525; `builtins`/`type`/`errors` scoreboard suites still 0.