### PR TITLE
docs(release): draft gnash 2.1.3 notes with per-arch tarball footer

### DIFF
--- a/scripts/notes/gnash-2.1.3.md
+++ b/scripts/notes/gnash-2.1.3.md
@@ -1,0 +1,20 @@
+# gnash 2.1.3
+
+_(draft — summarize the release here before cutting it)_
+
+## Build
+
+- macOS releases now ship per-architecture binary tarballs
+  (`gnash-X.Y.Z-macos-arm64.tar.gz` for Apple Silicon,
+  `gnash-X.Y.Z-macos-x86_64.tar.gz` for Intel) instead of a single
+  universal tarball, roughly halving the download (#667). Homebrew
+  installs are unaffected.
+
+## Install
+
+```
+brew tap brianjfox/tools && brew trust brianjfox/tools && brew install gnash
+```
+
+Or download the macOS tarball for your architecture (arm64 for
+Apple Silicon, x86_64 for Intel) below.


### PR DESCRIPTION
## Summary

Creates `scripts/notes/gnash-2.1.3.md` as the draft notes file for the next release, so it carries the updated **Install** footer that points users at the per-architecture macOS tarballs introduced in #667 (arm64 for Apple Silicon, x86_64 for Intel) instead of the old universal-tarball wording. The footer matches the fallback text `release.sh` now generates, and the Build section already records the release-pipeline change itself.

The summary line is a marked draft placeholder to be filled in when 2.1.3 is actually cut — `release.sh` picks this file up automatically as `scripts/notes/gnash-2.1.3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)