### PR TITLE
fix(release): realign tracking refs after token-URL pushes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,7 +72,11 @@ git_push() {  # git_push DIR [REFSPEC...]
     https://github.com/*)
       local slug=${url#https://github.com/}; slug=${slug%.git}
       git -C "$dir" push "https://x-access-token:$(gh auth token)@github.com/$slug.git" \
-        "${@:-HEAD:$(git -C "$dir" symbolic-ref --short HEAD)}" ;;
+        "${@:-HEAD:$(git -C "$dir" symbolic-ref --short HEAD)}"
+      # A token-URL push does not move origin's remote-tracking refs, so the
+      # repo then looks out of date; `brew update` later rebases the tap onto
+      # a remote that already has these commits and conflicts.  Realign.
+      git -C "$dir" fetch -q origin || true ;;
     *) git -C "$dir" push origin "${@:-HEAD}" ;;
   esac
 }


### PR DESCRIPTION
## Summary

Cutting 2.1.3, the release run died mid-pipeline: `brew`'s auto-update rebased the tap onto its remote and conflicted on `Formula/gnash.rb`. Root cause: `git_push` pushes through an `x-access-token` URL, which never updates `origin`'s remote-tracking refs, so after a release the tap (and main repo) permanently look out of date to any subsequent `git pull --rebase` — including the one `brew update` runs on taps.

This adds a `git fetch -q origin` after every token-URL push in `git_push`, keeping the tracking refs aligned with what was just pushed. Failure of the fetch is non-fatal (`|| true`) — it's housekeeping, not part of the release.

## Testing

- `bash -n scripts/release.sh` passes.
- The equivalent manual `git fetch origin` in the tap after the 2.1.3 release brought `main...origin/main` back in sync, which is exactly the state this keeps automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)