### PR TITLE
docs(test): explain posixtest's arg(1) in parenthesized sub-expressions

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -1074,6 +1074,12 @@ struct TestEval {
     switch (nargs) {
       case 0: return false;
       case 1: {
+        // arg(1), NOT arg(pos): bash's posixtest evaluates ONE_ARG_TEST
+        // (argv[1]) even when called recursively for a parenthesized
+        // sub-expression (term scans ahead and calls posixtest with pos > 1),
+        // so `test '(' '' ')' -a b' tests "(" -- not "" -- and succeeds.
+        // Deliberate bug-for-bug compatibility with bash 5.3 test.c; its
+        // CHANGES entry concedes "Such expressions remain ambiguous".
         bool value = one_arg(arg(1));
         advance(false);
         return value;


### PR DESCRIPTION
## Summary

Issue #670 reports that `TestEval::posixtest()` case 1 evaluates `arg(1)` instead of `arg(pos)`, producing a "wrong" result for `test '(' '' ')' -a b`.

Investigation shows this is **deliberate bug-for-bug compatibility with bash 5.3**, not an index bug:

- bash 5.3's `test.c` `posixtest()` does exactly the same thing: `case 1: value = ONE_ARG_TEST(argv[1]);` — even when `term()` calls it recursively for a parenthesized sub-expression with `pos > 1` (the forward-scan added in bash 5.3, CHANGES entry ee, which concedes *"Such expressions remain ambiguous"*).
- Reference bash 5.3.15 exits **0** for `test '(' '' ')' -a b` — the issue's expected exit 1 comes from an older bash (≤ 5.2, where `shell_compatibility_level > 52` routes the paren scan to `expr()` instead).
- Verified gnash matches bash 5.3.15 on 11 paren/`-a`/`-o` combinations, including `test '(' '' ')' -a b`, `test x -a '(' '' ')'`, `[ '(' '' ')' -a b ]`, and nested forms — all OK. Applying the proposed `arg(pos)` change makes 4 of the 11 diverge from bash.

This PR adds a comment documenting the quirk so it is not "fixed" into a divergence later. No behavior change.

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)