### PR TITLE
fix(release): repour the bottle after building it

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -275,6 +275,18 @@ fi
 step "Push tap $TAP_REPO"
 git_push "$TAP_DIR"
 
+# ---- 8. repour: leave this machine on the poured bottle --------------------
+# The `brew install --build-bottle' above leaves a from-source install whose
+# receipt (built_as_bottle, poured_from_bottle: false) makes every later
+# install/reinstall/upgrade on this machine compile from source again and
+# skip post_install (#671).  Swap it for the bottle that was just uploaded
+# and recorded in the formula.
+if [ "$SKIP_BOTTLE" != 1 ]; then
+  step "Reinstall $FORMULA from the new bottle"
+  brew uninstall --force "$FORMULA" >/dev/null 2>&1 || true
+  brew install "$TAP_SLUG/$FORMULA"
+fi
+
 step "Done: $TAG released"
 info "main release: https://github.com/$MAIN_REPO/releases/tag/$TAG"
 [ "$SKIP_BOTTLE" = 1 ] || info "bottle:       https://github.com/$TAP_REPO/releases/tag/$TAG"


### PR DESCRIPTION
## Summary

Diagnoses and fixes #671 (`brew install gnash` compiling from source instead of pouring).

## Diagnosis

- The formula, bottle block (`arm64_golden_gate`), and uploaded release asset for 2.1.3 are all correct — `brew fetch brianjfox/tools/gnash` downloads the bottle, and a clean `brew install` pours it (verified: `poured_from_bottle: true`, no cmake run).
- The compile-from-source behavior only happens on the **release machine**: `scripts/release.sh` builds the bottle with `brew install --build-bottle` and leaves that install in place. Its receipt records `built_as_bottle: true, poured_from_bottle: false`, and Homebrew re-applies that state on every later `install`/`reinstall`/`upgrade` — so gnash kept compiling from source (and skipped `post_install` with "Not running 'post_install' as we're building a bottle").

## Fix

- `release.sh` now finishes by uninstalling the `--build-bottle` artifact and reinstalling normally after the tap is pushed, so the release machine ends on the bottle it just published. Guarded by `--skip-bottle`.
- The current machine state was repaired the same way: gnash 2.1.3 is now poured from `gnash-2.1.3.arm64_golden_gate.bottle.tar.gz`.

`bash -n` passes on the script.

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)