### PR TITLE
fix(printf): %(fmt)T timezone, empty/invalid/nested formats, LC_TIME

### DIFF
--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -727,36 +727,78 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
         if (j >= fmt.size()) { missing_fmt_char(); break; }
         char conv = fmt[j];
         // %(DATEFMT)T: format an epoch-seconds argument through strftime.  The
-        // conversion char sits after the parenthesized format, so it is scanned
-        // separately from the ordinary single-letter conversions below.
+        // conversion char sits after the parenthesized format -- scanned to
+        // the BALANCED closing paren (`%((%Y))T' formats `(1969)') -- so it
+        // is handled separately from the single-letter conversions below.
         if (conv == '(') {
-          size_t close = fmt.find(")T", j);
-          if (close != std::string::npos) {
-            std::string datefmt = fmt.substr(j + 1, close - (j + 1));
-            // Field width and precision apply to the strftime result like
-            // `%s' (bash formats it through printstr); `*' values are
-            // fetched BEFORE the seconds argument.
-            std::string tfwp = resolve_fwp(i + 1, j);
-            // The argument is seconds since the epoch, with two special
-            // values (bash printf.def): -1 (the default when no argument is
-            // given) is the current time, and -2 is the shell's start time.
-            // Every other value -- INCLUDING other negatives -- is a literal
-            // time_t, so a pre-1970 date like -86400 formats as 1969-12-31.
-            std::string a = next();
-            long long v = a.empty() ? -1 : std::strtoll(a.c_str(), nullptr, 10);
-            time_t when = (v == -1) ? std::time(nullptr)
-                        : (v == -2) ? static_cast<time_t>(sh.seconds_base)
-                                    : static_cast<time_t>(v);
-            struct tm tmv;
-            localtime_r(&when, &tmv);
-            char tbuf[256];
-            tbuf[0] = '\0';
-            std::strftime(tbuf, sizeof tbuf, datefmt.c_str(), &tmv);
-            out += printstr_pad(tbuf, tfwp);
-            consumed_any = true;
-            i = close + 1;  // land on the 'T'; the loop ++ steps past it
-            continue;
+          size_t p = j + 1;
+          int depth = 1;
+          std::string datefmt;
+          while (p < fmt.size()) {
+            if (fmt[p] == '(') depth++;
+            else if (fmt[p] == ')' && --depth == 0) break;
+            datefmt += fmt[p++];
           }
+          if (p >= fmt.size() || p + 1 >= fmt.size() || fmt[p + 1] != 'T') {
+            // Not `)T': bash warns with the character after the paren scan
+            // (a NUL byte when the format simply ran out), prints the `%'
+            // literally and rescans the rest of the spec as ordinary text.
+            char bad = (p + 1 < fmt.size()) ? fmt[p + 1] : '\0';
+            flush_out();
+            std::fprintf(stderr,
+                         "%sprintf: warning: `%c': invalid time format specification\n",
+                         sh.err_prefix().c_str(), bad);
+            out += '%';
+            continue;  // the loop ++ resumes at the character after `%'
+          }
+          // Field width and precision apply to the strftime result like `%s'
+          // (bash formats it through printstr); `*' values are fetched
+          // BEFORE the seconds argument.
+          std::string tfwp = resolve_fwp(i + 1, j);
+          // An empty DATEFMT means the locale's time, %X (bash printf.def).
+          if (datefmt.empty()) datefmt = "%X";
+          // The argument is seconds since the epoch, with two special values
+          // (bash printf.def): -1 (the default when no argument is given) is
+          // the current time, and -2 is the shell's start time.  Every other
+          // value -- INCLUDING other negatives -- is a literal time_t, so a
+          // pre-1970 date like -86400 formats as 1969-12-31.  A present
+          // argument is validated like %d's (getintmax).
+          bool have_arg = argi < argv.size();
+          std::string a = next();
+          long long v = -1;
+          if (have_arg) {
+            if (!a.empty() && (a[0] == '\'' || a[0] == '"')) {
+              v = char_code(a);
+            } else {
+              errno = 0;
+              char *ep = nullptr;
+              v = std::strtoll(a.c_str(), &ep, 0);
+              chk_num(a, ep, errno == ERANGE);
+            }
+          }
+          time_t when = (v == -1) ? std::time(nullptr)
+                      : (v == -2) ? static_cast<time_t>(sh.seconds_base)
+                                  : static_cast<time_t>(v);
+          // bash sv_tz: hand the shell's EXPORTED TZ to libc before
+          // localtime, so `export TZ=EST5EDT' (or `unset TZ') mid-script
+          // takes effect.  An unexported TZ assignment does NOT (bash).
+          {
+            auto tzit = sh.vars.find("TZ");
+            if (tzit != sh.vars.end() && tzit->second.exported)
+              setenv("TZ", sh.get("TZ").c_str(), 1);
+            else if (tzit == sh.vars.end())
+              unsetenv("TZ");
+            tzset();
+          }
+          struct tm tmv;
+          localtime_r(&when, &tmv);
+          char tbuf[256];
+          tbuf[0] = '\0';
+          std::strftime(tbuf, sizeof tbuf, datefmt.c_str(), &tmv);
+          out += printstr_pad(tbuf, tfwp);
+          consumed_any = true;
+          i = p + 1;  // land on the 'T'; the loop ++ steps past it
+          continue;
         }
         // A C length modifier (l, ll, h, hh, L, j, z, t) before a numeric or
         // floating conversion is accepted and ignored: bash formats through

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -1541,9 +1541,10 @@ static bool is_locale_var(const std::string &n) {
 
 // Re-apply the locale from the shell's own LC_ALL/LC_*/LANG variables, in
 // POSIX precedence order, so a runtime `export LC_ALL=en_US.UTF-8' makes
-// subsequent ${#var}/substring operations count characters.  Two categories
-// are tracked: LC_CTYPE (MB_CUR_MAX / mbrtowc / \u encoding) and LC_NUMERIC
-// (printf's radix character -- de_DE formats %.4f as `1,0000').
+// subsequent ${#var}/substring operations count characters.  Three categories
+// are tracked: LC_CTYPE (MB_CUR_MAX / mbrtowc / \u encoding), LC_NUMERIC
+// (printf's radix character -- de_DE formats %.4f as `1,0000') and LC_TIME
+// (strftime for printf %(fmt)T).
 static void apply_ctype_locale(Shell &sh) {
   auto val = [&](const char *k) -> std::string {
     auto it = sh.vars.find(k);
@@ -1558,6 +1559,12 @@ static void apply_ctype_locale(Shell &sh) {
   if (loc.empty()) loc = val("LC_NUMERIC");
   if (loc.empty()) loc = lang;
   if (!loc.empty()) std::setlocale(LC_NUMERIC, loc.c_str());
+  // LC_TIME drives strftime -- printf %(%x)T under `LC_ALL=C' must print
+  // the C locale's 05/30/10, not the startup locale's date format.
+  loc = all;
+  if (loc.empty()) loc = val("LC_TIME");
+  if (loc.empty()) loc = lang;
+  if (!loc.empty()) std::setlocale(LC_TIME, loc.c_str());
 }
 
 // Public re-application hook: the executor calls this after a temporary


### PR DESCRIPTION
## Summary

Fixes #688 — the `%(DATEFMT)T` branch's six divergences, which were the entire remaining printf.tests diff:

- **TZ**: bash's `sv_tz` hands the shell's **exported** TZ to libc (`setenv` + `tzset`) before every `localtime`, so `export TZ=EST5EDT` or `unset TZ` mid-script takes effect; an unexported TZ assignment deliberately does not (matches bash, verified).
- empty `DATEFMT` → `%X` (locale time)
- a spec that isn't `)T` warns ``C': invalid time format specification`` (NUL byte when the format ran out), prints `%` literally and rescans the rest as text, exit status unchanged
- balanced-paren scan: `%((%Y))T` → `(1969)`
- the seconds argument is validated like `%d`'s (`foo` → `invalid number`, formats 0, exit 1; missing argument still means −1/current time; char-codes work)
- `apply_ctype_locale` gains **LC_TIME**, so `LC_ALL=C` makes `%(%x)T` print `05/30/10`

## Verification

14-case matrix byte-identical vs reference bash 5.3.15 (all TZ scenarios incl. temp-env and unexported, warnings, nested parens, width, validation, format reuse). **printf.tests scoreboard 19 → 0** — gnash printf output is now byte-identical to bash across the whole suite (real `diff -a` zero, unlike the earlier false zero). builtins/errors/varenv/quote/new-exp/heredoc/redir/intl all hold at 0; smoke passes.

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)