### PR TITLE
fix(arith): parse the true branch of ?: as a comma expression

### DIFF
--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -315,7 +315,7 @@ struct Parser {
       skip();
       if (peek() == ':' || peek() == '\0')  // empty true branch
         note(arith_err::kExprExpected, pos);
-      n->b = assignment();
+      n->b = comma();  // bash: the true branch is a full comma expression
       skip();
       if (peek() == ':') { mark_op(); pos++; }
       else note(arith_err::kColonExpected, last_tok);

--- a/tests/arith_test.cpp
+++ b/tests/arith_test.cpp
@@ -89,6 +89,14 @@ int main() {
   eq("-5 + 3", -2);
   eq("3 > 2 ? 10 : 20", 10);
   eq("0 ? 10 : 20", 20);
+  // The true branch of `?:' is a full comma expression in bash (expcond
+  // parses it with EXP_HIGHEST); the false branch binds tighter than `,'.
+  eq("1 ? 2 , 3 : 4", 3);
+  eq("0 ? 2 , 3 : 4", 4);
+  eq("1 ? 2 : 3 , 4", 4);
+  eq("1 ? 2 , 3 : 4 , 5", 5);
+  eq("1 ? 2 ? 3 , 4 : 5 : 6", 4);
+  eq("0 ? 1 / 0 , 2 : 3", 3);
   eq("1, 2, 3", 3);
   eq("7 ^ 3", 4);
 

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -819,6 +819,9 @@ E'
   'echo $((2#)); echo rc=$?'
   'echo $((2#1#1)); echo rc=$?'
   'echo $((0x)) $((0)) $((0x1f)) $((017))'
+  # The true branch of `? :' is a comma expression; the false branch is not.
+  'echo $((1 ? 2 , 3 : 4)) $((0 ? 2 , 3 : 4)) $((1 ? 2 : 3 , 4)) $((1 ? x=5 , 3 : 4)) $x'
+  'echo $((1 ? 2 , : 4)); echo rc=$?'
 )
 
 fails=0


### PR DESCRIPTION
## Summary
- `$((1 ? 2 , 3 : 4))` errored in gnash with `` `:' expected for conditional expression``; bash prints `3`.
- bash's `expcond` reads the operand between `?` and `:` at comma precedence (`EXP_HIGHEST`), so a comma sequence there is one operand. gnash parsed it at assignment precedence and stopped at the `,`.
- `Parser::ternary()` now calls `comma()` for the true branch. The false branch is unchanged (it binds tighter than `,`, matching bash).

## Test plan
- [x] `tests/arith_test.cpp`: 6 new ternary/comma cases
- [x] `tests/harness/run_diff.sh`: 2 new differential scripts (including the `1 ? 2 , : 4` error case)
- [x] 17-case ternary battery comparing stdout, stderr and exit status against bash 5.3: all identical
- [x] Scoreboard `arith`, `arith-for` stay at 0

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173DebhGJ2mwo3JCKHihSpB