### PR TITLE
fix(lexer): a `#' inside $(( )) never starts a comment

### DIFF
--- a/core/src/lexer.cpp
+++ b/core/src/lexer.cpp
@@ -187,6 +187,11 @@ struct Lexer {
                   bool array_lit = false) {  // pos at '('
     int startln = line_for(pos);  // the open line, reported for an unterminated array literal
     int depth = 0;
+    // A span opening with `((' is scanned by bash as an arithmetic expansion
+    // (parse_comsub -> parse_matched_pair with P_ARITH), which knows nothing
+    // of comments: a `#' there is an ordinary character (`$(( 2#101 ))',
+    // `$(( $(echo 1)#1 ))'), never the start of a comment.
+    const bool arith = comsub_ctx && pos + 1 < n && in[pos + 1] == '(';
     struct PHd { std::string delim; bool strip; int depth; bool quoted; };
     std::vector<PHd> paren_heredocs;  // pending heredocs inside the parens
     // A `)' that terminates a `case' pattern (`case x in x)') must not be
@@ -397,7 +402,7 @@ struct Lexer {
         if (depth == 0) break;  // an alias body supplied the closer (see above)
         w += c;
         pos++;
-      } else if (c == '#' && !saw_word) {
+      } else if (c == '#' && !saw_word && !arith) {
         // A comment runs to the end of the line: a `)' in it is not the closer.
         while (pos < n && in[pos] != '\n') { w += in[pos]; pos++; }
       } else if (array_lit && c == '[' && !saw_word) {

--- a/tests/harness/errfmt.sh
+++ b/tests/harness/errfmt.sh
@@ -32,6 +32,7 @@ cases=(
   'echo $(( $(echo "(1" ) ))'
   'echo $(( $(echo ")") ))'
   'echo $((echo hi))'
+  'echo $(( $(echo 1)#1 ))'
 )
 
 # Replace the leading "<program name>:" token (which legitimately differs --

--- a/tests/harness/run_diff.sh
+++ b/tests/harness/run_diff.sh
@@ -836,6 +836,9 @@ E'
   'echo $((echo hi)); echo rc=$?'
   'echo $(( "(" )); echo rc=$?'
   'echo $(( (1+2) * 3 )) $(( 1 << 2 )) $(( x=(1) )) $(( 1 ? (2) : (3) )) $(( a[$(echo 0)] )) $(())'
+  # A `#' inside `$(( ))' is never a comment, even right after a nested `$(...)'.
+  'echo $(( $(echo 16)#ff )) $(( 2#101 )); x=$(( $(echo 2)#10 )); echo $x'
+  'echo $(( $(echo 1)#1 )); echo rc=$?'
 )
 
 fails=0

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -56,6 +56,11 @@ int main() {
   expect("{ a; }", "{ a ; }");
   expect("a |& b", "a |& b");
   expect("case x in a) b;; esac", "case x in a ) b ;; esac");
+  // Inside `$((' a `#' is never a comment (bash scans the span with P_ARITH):
+  // the word ends at the matching `))', and the rest is still tokenized.
+  expect("echo $(( $(echo 1)#1 ))\nnext", "echo $(( $(echo 1)#1 )) <NL> next");
+  expect("echo $(( 2#101 )); y\nz", "echo $(( 2#101 )) ; y <NL> z");
+  expect("echo $(echo a #c\n) z", "echo $(echo a #c\n) z");  // `$(cmd)' keeps comments
 
   // Here-document body is collected and attached to the delimiter word.
   {


### PR DESCRIPTION
## Summary
- `echo $(( $(echo 1)#1 ))` failed to parse in gnash (`unexpected EOF while looking for matching `)'`, exit 2); bash parses it and reports `1#1: invalid arithmetic base`, exit 1.
- `scan_paren` applied its comment rule (`#` at word start runs to end of line) inside `$(( ))`, so the `#` after the nested substitution swallowed the closing `))`.
- bash scans a `$((` span with `parse_matched_pair(P_ARITH)`, which knows nothing of comments. The comment rule is now skipped for any span opening with `((`; `$(cmd)` spans keep their comments.

## Test plan
- [x] `tests/lexer_test.cpp`: 3 new tokenization cases (one fails on the old scanner)
- [x] `tests/harness/run_diff.sh`: 2 new differential scripts; `tests/harness/errfmt.sh`: 1 new stderr case
- [x] Multi-line `#`-in-`$((` cases from a script file: byte-identical to bash
- [x] Scoreboard arith, comsub, comsub-posix, heredoc, exp, quote, nquote, parser unchanged at 0; comsub-eof at its pre-existing 5

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173DebhGJ2mwo3JCKHihSpB