### PR TITLE
fix(readline): paint the prompt after output that has no trailing newline

### DIFF
--- a/libreadline/include/gnash/readline_internal.hpp
+++ b/libreadline/include/gnash/readline_internal.hpp
@@ -59,6 +59,18 @@ void stuff_input(const std::string &keys);
 // A key is readable within TIMEOUT_MS (pushback queue or the input fd).
 bool input_pending(int timeout_ms);
 
+// Ask the terminal where its cursor is (CSI 6 n) and return the 0-based
+// column, or -1 when it cannot be learned (no terminal, a dumb/unset $TERM, or
+// no reply within TIMEOUT_MS -- after which no further queries are sent).
+// Typed-ahead bytes read while waiting go back on the pushback queue.
+int query_cursor_column(int timeout_ms);
+
+// Column where the prompt starts on its row (readline.cpp).  Normally 0; when
+// the previous command left the cursor mid-line, the prompt is painted right
+// there, as readline does, and every repaint's column math adds this offset.
+// Anything that clears the row from column 0 resets it.
+extern int prompt_start_col;
+
 extern bool macro_recording;   // C-x ( .. C-x ): tap keys into macro_keys
 extern std::string macro_keys;
 extern bool redo_capturing;    // vi change command in progress: tap keys

--- a/libreadline/src/input.cpp
+++ b/libreadline/src/input.cpp
@@ -17,9 +17,12 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <string>
 #include <sys/select.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include "gnash/readline_internal.hpp"
@@ -57,6 +60,67 @@ bool input_pending(int timeout_ms) {
   tv.tv_sec = timeout_ms / 1000;
   tv.tv_usec = (timeout_ms % 1000) * 1000;
   return select(fd + 1, &rfds, nullptr, nullptr, &tv) > 0;
+}
+
+// Cursor Position Report: send `ESC [ 6 n' and read the terminal's
+// `ESC [ row ; col R' reply.  The terminal answers in input order, so any
+// bytes the user typed ahead arrive BEFORE the reply; they are collected and
+// stuffed back for rl_read_key.  A terminal that never answers (the test
+// harness pty, some emulators) costs the timeout once: the failure is
+// remembered and no further queries are sent this session.
+int query_cursor_column(int timeout_ms) {
+  static bool unsupported = false;
+  if (unsupported) return -1;
+  if (rl_instream == nullptr) rl_instream = stdin;
+  if (rl_outstream == nullptr) rl_outstream = stdout;
+  int fd = fileno(rl_instream);
+  int ofd = fileno(rl_outstream);
+  if (!isatty(fd) || !isatty(ofd)) return -1;
+  const char *term = std::getenv("TERM");
+  if (term == nullptr || *term == '\0' || std::strcmp(term, "dumb") == 0) return -1;
+  std::fflush(rl_outstream);
+  if (write(ofd, "\033[6n", 4) != 4) return -1;
+
+  std::string buf;  // everything read while waiting for the reply
+  struct timeval deadline;
+  gettimeofday(&deadline, nullptr);
+  deadline.tv_sec += timeout_ms / 1000;
+  deadline.tv_usec += (timeout_ms % 1000) * 1000;
+  if (deadline.tv_usec >= 1000000) { deadline.tv_sec++; deadline.tv_usec -= 1000000; }
+  int col = -1;
+  for (;;) {
+    if (rl_sigint_flag) break;
+    struct timeval now, tv;
+    gettimeofday(&now, nullptr);
+    long left_us = (deadline.tv_sec - now.tv_sec) * 1000000L + (deadline.tv_usec - now.tv_usec);
+    if (left_us <= 0) break;
+    tv.tv_sec = left_us / 1000000L;
+    tv.tv_usec = left_us % 1000000L;
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    int r = select(fd + 1, &rfds, nullptr, nullptr, &tv);
+    if (r < 0) {
+      if (errno == EINTR) continue;
+      break;
+    }
+    if (r == 0) break;  // timed out
+    unsigned char ch;
+    if (read(fd, &ch, 1) != 1) break;
+    buf += static_cast<char>(ch);
+    if (ch != 'R') continue;
+    size_t e = buf.rfind("\033[");
+    if (e == std::string::npos) continue;
+    int row = 0, c = 0;
+    if (std::sscanf(buf.c_str() + e, "\033[%d;%dR", &row, &c) == 2 && c >= 1) {
+      col = c - 1;
+      buf.erase(e);  // what precedes the reply is typeahead
+      break;
+    }
+  }
+  if (col < 0) unsupported = true;
+  stuff_input(buf);
+  return col;
 }
 
 }  // namespace gnash::readline

--- a/libreadline/src/misc.cpp
+++ b/libreadline/src/misc.cpp
@@ -183,6 +183,7 @@ extern "C" int rl_insert_comment(int /*count*/, int key) {
 extern "C" int rl_clear_display(int /*count*/, int /*key*/) {
   FILE *o = rl_outstream ? rl_outstream : stdout;
   std::fputs("\033[H\033[2J\033[3J", o);  // home + clear screen + clear scrollback
+  gnash::readline::prompt_start_col = 0;
   rl_redisplay();
   return 0;
 }

--- a/libreadline/src/readline.cpp
+++ b/libreadline/src/readline.cpp
@@ -388,7 +388,23 @@ int ml_oldpoint = 0;  // rl_point at the last paint (fixes the cursor's row)
 
 void wrap_reset() { ml_oldrows = 1; ml_oldpoint = 0; }
 
+// How long readline() waits for the terminal's cursor-position reply before
+// assuming the prompt starts at column 0 (and never asking again).
+constexpr int kCprTimeoutMs = 500;
+
+// Cursor to the start of the prompt on its row: column 0, then right to the
+// prompt's start column.  Text the previous command left before the prompt
+// (output without a trailing newline) stays on the screen, as with readline.
+std::string row_start() {
+  std::string s = "\r";
+  int col = gnash::readline::prompt_start_col;
+  if (col > 0) { s += "\033["; s += std::to_string(col); s += "C"; }
+  return s;
+}
+
 }  // namespace
+
+int gnash::readline::prompt_start_col = 0;
 
 // The terminal width in columns (from TIOCGWINSZ, else $COLUMNS, else 80).
 extern "C" int rl_get_screen_width(void) { return screen_width(); }
@@ -398,14 +414,14 @@ extern "C" int rl_get_screen_width(void) { return screen_width(); }
 // `horizontal-scroll-mode' is on.
 static void refresh_scrolled(FILE *o, const std::string &pemit, int plen) {
   int width = screen_width();
-  int avail = width - plen - 1;
+  int avail = width - gnash::readline::prompt_start_col - plen - 1;
   if (avail < 1) avail = 1;
 
   int off = (rl_point > avail) ? rl_point - avail : 0;
   int shown = rl_end - off;
   if (shown > avail) shown = avail;
 
-  std::fputc('\r', o);
+  std::fputs(row_start().c_str(), o);
   std::fwrite(pemit.data(), 1, pemit.size(), o);
   if (shown > 0) {
     if (rl_highlight_function && rl_end > 0) {
@@ -441,16 +457,18 @@ static void refresh_wrapped(FILE *o, const std::string &pemit, int plen) {
   int W = screen_width();
   if (W < 1) W = 1;
 
-  int rows = (plen + rl_end + W - 1) / W;             // rows the buffer needs (ceil)
+  const int pre = gnash::readline::prompt_start_col + plen;  // columns before the buffer
+  int rows = (pre + rl_end + W - 1) / W;              // rows the buffer needs (ceil)
   if (rows < 1) rows = 1;
-  int rpos = (plen + ml_oldpoint + W) / W;            // cursor's row last time (1-based)
+  int rpos = (pre + ml_oldpoint + W) / W;             // cursor's row last time (1-based)
   int old_rows = ml_oldrows;
 
   std::string out;
   // 1. Erase the previous paint: drop to its last row, clear each row going up.
   if (old_rows - rpos > 0) { out += "\033["; out += std::to_string(old_rows - rpos); out += "B"; }
   for (int j = 0; j < old_rows - 1; j++) out += "\r\033[K\033[A";
-  out += "\r\033[K";
+  out += row_start();
+  out += "\033[K";
 
   // 2. Prompt + buffer; the terminal wraps at the right edge on its own.
   out += pemit;
@@ -459,15 +477,15 @@ static void refresh_wrapped(FILE *o, const std::string &pemit, int plen) {
   // 3. If the cursor is at the very end and lands exactly on the right edge,
   //    emit a newline so it sits at the start of a fresh row (else it would
   //    hang in the last column with the wrap pending).
-  if (rl_point > 0 && rl_point == rl_end && (plen + rl_point) % W == 0) {
+  if (rl_point > 0 && rl_point == rl_end && (pre + rl_point) % W == 0) {
     out += "\r\n";
     rows++;
   }
 
   // 4. Move the cursor up to its target row, then to its column.
-  int rpos2 = (plen + rl_point + W) / W;              // cursor's row now (1-based)
+  int rpos2 = (pre + rl_point + W) / W;               // cursor's row now (1-based)
   if (rows - rpos2 > 0) { out += "\033["; out += std::to_string(rows - rpos2); out += "A"; }
-  int colpos = (plen + rl_point) % W;
+  int colpos = (pre + rl_point) % W;
   out += '\r';
   if (colpos) { out += "\033["; out += std::to_string(colpos); out += "C"; }
 
@@ -499,7 +517,7 @@ static void wrap_move_below(FILE *o) {
   std::string pemit;
   int plen;
   prompt_metrics(rl_prompt ? rl_prompt : "", pemit, plen);
-  int cur_row = (plen + ml_oldpoint) / W;   // 0-based cursor row
+  int cur_row = (gnash::readline::prompt_start_col + plen + ml_oldpoint) / W;  // 0-based
   int last_row = ml_oldrows - 1;
   std::string out;
   if (last_row - cur_row > 0) { out += "\033["; out += std::to_string(last_row - cur_row); out += "B"; }
@@ -514,6 +532,7 @@ extern "C" int rl_clear_screen(int /*count*/, int /*key*/) {
   if (rl_outstream == nullptr) rl_outstream = stdout;
   std::fputs(clear_screen_seq(), rl_outstream);
   wrap_reset();     // the screen is now blank: no prior rows to erase
+  gnash::readline::prompt_start_col = 0;
   rl_redisplay();   // repaint prompt + buffer at row 0
   return 0;
 }
@@ -530,7 +549,7 @@ extern "C" void rl_clear_current_line(void) {
     std::string pemit;
     int plen;
     prompt_metrics(rl_prompt ? rl_prompt : "", pemit, plen);
-    int cur_row = (plen + ml_oldpoint) / W;
+    int cur_row = (gnash::readline::prompt_start_col + plen + ml_oldpoint) / W;
     std::string out;
     if ((ml_oldrows - 1) - cur_row > 0) {
       out += "\033[";
@@ -542,11 +561,13 @@ extern "C" void rl_clear_current_line(void) {
     std::fwrite(out.data(), 1, out.size(), o);
     std::fflush(o);
     wrap_reset();
+    gnash::readline::prompt_start_col = 0;  // the row is clear from column 0
     return;
   }
   std::fputc('\r', o);
   std::fputs(clear_eol(), o);
   std::fflush(o);
+  gnash::readline::prompt_start_col = 0;
 }
 
 // ---- top level ------------------------------------------------------------
@@ -614,6 +635,11 @@ extern "C" char *readline(const char *prompt) {
     if (sigaction(SIGINT, &sa, &old_int) == 0) int_installed = true;
     prep_terminal(fd);
     wrap_reset();  // a fresh line: no previous wrapped rows to erase
+    // Where is the cursor?  When the last command's output did not end in a
+    // newline, readline paints the prompt right after it (`line2$ ') rather
+    // than erasing that text; learn the column so the repaint math holds.
+    int col = gnash::readline::query_cursor_column(kCprTimeoutMs);
+    gnash::readline::prompt_start_col = (col > 0 && col < screen_width()) ? col : 0;
     rl_redisplay();
   } else {
     // Interactive on a non-terminal (bash -i on a pipe): the prompt goes to

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,15 @@ if(NOT APPLE)
 endif()
 add_test(NAME job_notify_test COMMAND job_notify_test $<TARGET_FILE:gnash>)
 
+# The prompt after output without a trailing newline (cursor-position query),
+# driven over a pty against the built shell.
+add_executable(prompt_column_test prompt_column_test.cpp)
+target_link_libraries(prompt_column_test PRIVATE gnash_warnings)
+if(NOT APPLE)
+  target_link_libraries(prompt_column_test PRIVATE util)  # forkpty lives in libutil
+endif()
+add_test(NAME prompt_column_test COMMAND prompt_column_test $<TARGET_FILE:gnash>)
+
 # Differential execution check vs bash over the implemented feature set.
 if(BASH_EXECUTABLE)
   add_test(

--- a/tests/prompt_column_test.cpp
+++ b/tests/prompt_column_test.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// prompt_column_test.cpp -- the prompt after output without a trailing newline.
+// Runs the built gnash on a pty, plays terminal far enough to answer the
+// cursor-position query (CSI 6 n) with the column tracked from the output
+// stream, and checks that a partial last line (`printf abc') is NOT erased:
+// the prompt is painted right after it, as bash/readline do (`abcP$ ').
+// A second run answers nothing and checks the fallback: the prompt starts at
+// column 0 and the query is not repeated once it went unanswered.
+//
+// Usage: prompt_column_test <path-to-gnash>
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+
+static int failures = 0;
+
+// A minimal terminal: tracks the cursor column over the shell's output and,
+// when `answer' is set, replies to `ESC [ 6 n' with `ESC [ 1 ; col R'.
+struct Term {
+  int fd;
+  bool answer;
+  int col = 0;
+  std::string pending;  // bytes of an escape sequence not yet complete
+
+  void feed(const char *buf, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+      char c = buf[i];
+      if (!pending.empty()) {
+        pending += c;
+        if (pending.size() == 2) {
+          if (c != '[') pending.clear();
+          continue;
+        }
+        if (std::isdigit(static_cast<unsigned char>(c)) || c == ';') continue;
+        std::string arg = pending.substr(2, pending.size() - 3);
+        if (c == 'n' && arg == "6") {
+          if (answer) {
+            std::string reply = "\033[1;" + std::to_string(col + 1) + "R";
+            (void)!write(fd, reply.data(), reply.size());
+          }
+        } else if (c == 'C') {
+          col += arg.empty() ? 1 : std::atoi(arg.c_str());
+        } else if (c == 'D') {
+          col -= arg.empty() ? 1 : std::atoi(arg.c_str());
+        }
+        pending.clear();
+        continue;
+      }
+      if (c == '\033') pending = "\033";
+      else if (c == '\r' || c == '\n') col = 0;
+      else if (c == '\b') col = col > 0 ? col - 1 : 0;
+      else if (static_cast<unsigned char>(c) >= ' ') col++;
+    }
+  }
+};
+
+// Read everything the shell writes until it stays quiet for `settle_ms'.
+static bool drain(Term &t, std::string &out, int settle_ms) {
+  for (;;) {
+    struct pollfd p = {t.fd, POLLIN, 0};
+    int r = poll(&p, 1, settle_ms);
+    if (r <= 0) return true;
+    char buf[4096];
+    ssize_t n = read(t.fd, buf, sizeof buf);
+    if (n <= 0) return false;
+    out.append(buf, static_cast<size_t>(n));
+    t.feed(buf, static_cast<size_t>(n));
+  }
+}
+
+static void send(Term &t, const char *s, std::string &out, int settle_ms = 400) {
+  (void)!write(t.fd, s, std::strlen(s));
+  drain(t, out, settle_ms);
+}
+
+static size_t count_of(const std::string &hay, const std::string &needle) {
+  size_t n = 0;
+  for (size_t at = hay.find(needle); at != std::string::npos;
+       at = hay.find(needle, at + needle.size()))
+    n++;
+  return n;
+}
+
+// Run one interactive session: `printf abc', then `echo hi', then exit.
+static std::string session(const char *gnash, bool answer) {
+  int master = -1;
+  pid_t pid = forkpty(&master, nullptr, nullptr, nullptr);
+  if (pid < 0) {
+    perror("forkpty");
+    std::exit(2);
+  }
+  if (pid == 0) {
+    setenv("PS1", "P$ ", 1);
+    setenv("TERM", "xterm", 1);
+    unsetenv("ENV");
+    execl(gnash, gnash, "--norc", "-i", static_cast<char *>(nullptr));
+    _exit(127);
+  }
+  Term t{master, answer, 0, {}};
+  std::string out;
+  drain(t, out, 900);  // initial prompt (the unanswered query times out first)
+  send(t, "printf abc\r", out, 900);
+  send(t, "echo hi\r", out, 900);
+  send(t, "exit\r", out);
+  close(master);
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+  return out;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: %s <gnash>\n", argv[0]);
+    return 2;
+  }
+
+  // 1. The terminal answers: after `abc' the shell asks where the cursor is,
+  //    moves to column 3 and paints the prompt there.  `abc' stays visible.
+  {
+    std::string out = session(argv[1], /*answer=*/true);
+    if (out.find("abc\033[6n") == std::string::npos) {
+      std::fprintf(stderr, "FAIL expected a cursor-position query right after `abc'\n%s\n",
+                   out.c_str());
+      failures++;
+    }
+    if (out.find("abc\033[6n\r\033[3C\033[KP$ ") == std::string::npos) {
+      std::fprintf(stderr, "FAIL expected the prompt painted at column 3 after `abc'\n%s\n",
+                   out.c_str());
+      failures++;
+    }
+    if (out.find("abc\r\033[K") != std::string::npos) {
+      std::fprintf(stderr, "FAIL the partial line `abc' was erased\n%s\n", out.c_str());
+      failures++;
+    }
+    // Typing on that line keeps repainting from column 3, and the typed
+    // command still runs.
+    if (out.find("\033[3C\033[KP$ echo hi") == std::string::npos ||
+        out.find("\r\nhi\r\n") == std::string::npos) {
+      std::fprintf(stderr, "FAIL editing after a partial line did not repaint from column 3\n%s\n",
+                   out.c_str());
+      failures++;
+    }
+  }
+
+  // 2. No answer: the prompt falls back to column 0 (erasing the row as
+  //    before), and the query is sent only once per session.
+  {
+    std::string out = session(argv[1], /*answer=*/false);
+    size_t queries = count_of(out, "\033[6n");
+    if (queries != 1) {
+      std::fprintf(stderr, "FAIL expected exactly 1 unanswered query, got %zu\n%s\n", queries,
+                   out.c_str());
+      failures++;
+    }
+    if (out.find("abc\r\033[KP$ ") == std::string::npos) {
+      std::fprintf(stderr, "FAIL expected the column-0 fallback prompt after `abc'\n%s\n",
+                   out.c_str());
+      failures++;
+    }
+    if (out.find("\r\nhi\r\n") == std::string::npos) {
+      std::fprintf(stderr, "FAIL `echo hi' did not run in the fallback session\n%s\n",
+                   out.c_str());
+      failures++;
+    }
+  }
+
+  if (failures == 0) std::printf("prompt_column_test: all tests passed\n");
+  return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- `cat` of a file whose last line has no trailing newline lost that line in interactive gnash: the editor repaints the row from column 0 with `\r ESC[K` before the prompt, erasing it. bash/readline print the prompt right after the text (`line2$ `).
- Before the first paint of each line, readline() now asks the terminal for the cursor position (`CSI 6 n`) and records the column as the prompt's start. Every repaint moves to that column (`\r ESC[nC`) instead of bare `\r`, and the wrap/scroll math adds the offset, so editing and wrapped lines stay correct on such a row. clear-screen, clear-display and `rl_clear_current_line` reset the offset since they clear from column 0.
- The query is skipped for non-terminals and an unset/dumb `$TERM`. Typed-ahead bytes read while waiting are stuffed back onto the input queue (the terminal answers in input order). A terminal that does not reply within 500 ms costs that once: the prompt falls back to column 0 as before and no further queries are sent that session.

## Test plan
- [x] New `tests/prompt_column_test.cpp` (pty-driven, like `job_notify_test`): with a replying terminal the prompt is painted at column 3 after `printf abc` and `abc` is never erased; without a reply the old column-0 behavior is used and the query is sent exactly once
- [x] pty scenarios by hand: typeahead of two commands before the first prompt runs both with no stray bytes; a wrapped line on a 20-column terminal after a partial line erases and repaints rows correctly
- [x] ctest 24/24 (including the existing pty job-notify test, which never answers the query)

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173DebhGJ2mwo3JCKHihSpB