### PR TITLE
refactor: consolidate duplicated code across builtins, core, and tests

### DIFF
--- a/core/include/gnash/core/quote.hpp
+++ b/core/include/gnash/core/quote.hpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// quote.hpp -- word-quoting idioms shared by the builtins and the expander.
+//
+// A handful of ways of re-quoting a string for later re-parsing by the shell
+// recur through the code: the `alias'/'declare -p'/'set' listings, xtrace
+// word rendering, the ${var@Q}/@K parameter transformations, compspec
+// display.  These helpers are the single home for those idioms so the rules
+// (and any future fix to them) live in one place:
+//   - single_quote:         '...' with an embedded ' spelled '\''
+//                           (bash sh_single_quote)
+//   - double_quote:         "..." escaping " \ $ `
+//                           (bash sh_double_quote)
+//   - contains_shell_metas: a word holds a shell metacharacter forcing
+//                           quoting (bash sh_contains_shell_metas)
+//   - has_nonprint:         a byte string holds a non-printable byte
+//                           (bash ansic_shouldquote)
+//   - ansic_quote:          $'...' with common escapes spelled out and the
+//                           other non-printables as \NNN octal
+//
+// They are byte-oriented on purpose: the locale/UTF-8-aware pair of
+// non-printable test and ANSI-C quoting is q_needs_ansic/q_ansic in
+// builtins.cpp, which the `declare -p' and xtrace paths keep using.
+
+#ifndef GNASH_CORE_QUOTE_HPP
+#define GNASH_CORE_QUOTE_HPP
+
+#include <cstdio>
+#include <string>
+
+namespace gnash::core {
+
+// Wrap S in single quotes; an embedded single quote becomes '\''.  Always
+// quotes, even a word that needs no quoting; an empty S renders as ''.
+inline std::string single_quote(const std::string &s) {
+  std::string r = "'";
+  for (char c : s) {
+    if (c == '\'') r += "'\\''";
+    else r += c;
+  }
+  return r + "'";
+}
+
+// Wrap S in double quotes, backslash-escaping the characters special inside
+// "..." (" \ $ `) -- the form `declare -p' and `set' use for plain values.
+inline std::string double_quote(const std::string &s) {
+  std::string r = "\"";
+  for (char c : s) {
+    if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\';
+    r += c;
+  }
+  return r + "\"";
+}
+
+// True if S holds a shell metacharacter that forces quoting when the string
+// is re-read (bash's sh_contains_shell_metas): whitespace and the quote,
+// backslash, operator and glob characters anywhere, plus `~' (also right
+// after `=' or `:') and `#' at the start of the string.
+inline bool contains_shell_metas(const std::string &s) {
+  for (size_t i = 0; i < s.size(); i++) {
+    char c = s[i];
+    switch (c) {
+      case ' ': case '\t': case '\n': case '\'': case '"': case '\\':
+      case '|': case '&': case ';': case '(': case ')': case '<': case '>':
+      case '!': case '{': case '}': case '*': case '[': case '?': case ']':
+      case '^': case '$': case '`':
+        return true;
+      case '~':
+        if (i == 0 || s[i - 1] == '=' || s[i - 1] == ':') return true;
+        break;
+      case '#':
+        if (i == 0) return true;
+        break;
+    }
+  }
+  return false;
+}
+
+// True if S contains a non-printable byte (bash's ansic_shouldquote,
+// byte-oriented): any control byte or DEL.
+inline bool has_nonprint(const std::string &s) {
+  for (unsigned char c : s)
+    if (c < 32 || c == 127) return true;
+  return false;
+}
+
+// ANSI-C ($'...') quoting of S: the common escapes spelled \n \t \r \\ \' ,
+// every other non-printable byte as \NNN octal, printable bytes verbatim.
+inline std::string ansic_quote(const std::string &s) {
+  std::string r = "$'";
+  for (unsigned char c : s) {
+    switch (c) {
+      case '\n': r += "\\n"; break;
+      case '\t': r += "\\t"; break;
+      case '\r': r += "\\r"; break;
+      case '\\': r += "\\\\"; break;
+      case '\'': r += "\\'"; break;
+      default:
+        if (c < 32 || c == 127) {
+          char b[8];
+          std::snprintf(b, sizeof b, "\\%03o", c);
+          r += b;
+        } else r += static_cast<char>(c);
+    }
+  }
+  return r + "'";
+}
+
+}  // namespace gnash::core
+
+#endif  // GNASH_CORE_QUOTE_HPP

--- a/core/include/gnash/core/shell.hpp
+++ b/core/include/gnash/core/shell.hpp
@@ -7,6 +7,8 @@
 #define GNASH_CORE_SHELL_HPP
 
 #include <csignal>
+#include <cstdarg>
+#include <cstdio>
 #include <functional>
 #include <map>
 #include <optional>
@@ -426,6 +428,16 @@ class Shell {
   // "NAME: line N: " prefix that bash prints before runtime errors.
   std::string err_prefix() const {
     return shell_name + ": line " + std::to_string(cur_lineno > 0 ? cur_lineno : 1) + ": ";
+  }
+  // Print a runtime error to stderr with the err_prefix() prepended, in printf
+  // style: the caller supplies only the message body.  Keeps the prefix
+  // formatting in one place and the hundreds of call sites short.
+  void errorf(const char *fmt, ...) const {
+    std::va_list ap;
+    va_start(ap, fmt);
+    std::fputs(err_prefix().c_str(), stderr);
+    std::vfprintf(stderr, fmt, ap);
+    va_end(ap);
   }
 
   // --- directory stack (pushd/popd/dirs); entries below the current dir ---

--- a/core/src/arith.cpp
+++ b/core/src/arith.cpp
@@ -786,18 +786,17 @@ static bool resolve_sub(const Node *n, Ctx &ctx, std::string &out, bool writing 
       // `(( a[""]=24 ))' -- an assignment target: `a[]': not a valid
       // identifier (with the command prefix).
       // Unlike the read below, this one carries the command prefix (`((: ').
-      std::fprintf(stderr, "%s%s%s`%s[]': not a valid identifier\n",
-                   ctx.sh.err_prefix().c_str(),
-                   (ctx.cmd_name && *ctx.cmd_name) ? ctx.cmd_name : "",
-                   (ctx.cmd_name && *ctx.cmd_name) ? ": " : "", n->name.c_str());
+      ctx.sh.errorf("%s%s`%s[]': not a valid identifier\n",
+                    (ctx.cmd_name && *ctx.cmd_name) ? ctx.cmd_name : "",
+                    (ctx.cmd_name && *ctx.cmd_name) ? ": " : "", n->name.c_str());
     } else {
       // `(( y[$none] ))' -- a read: y[]: bad array subscript (bare).  bash
       // reports it TWICE: once while resolving the reference and again when
       // the arithmetic command reports the failed expression (array27.sub).
       std::string m = n->name + "[]: bad array subscript";
-      std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), m.c_str());
+      ctx.sh.errorf("%s\n", m.c_str());
       if (ctx.expand_subs == 1)
-        std::fprintf(stderr, "%s%s\n", ctx.sh.err_prefix().c_str(), m.c_str());
+        ctx.sh.errorf("%s\n", m.c_str());
     }
     return false;
   }
@@ -868,8 +867,7 @@ long long ref_get(const Node *n, Ctx &ctx, const std::string *rsub = nullptr) {
     // set -u: an unset variable in arithmetic aborts like any other expansion
     // (non-interactive bash exits with 127); the message is already printed,
     // so fail without queueing a second diagnostic.
-    std::fprintf(stderr, "%s%s: unbound variable\n", ctx.sh.err_prefix().c_str(),
-                 n->name.c_str());
+    ctx.sh.errorf("%s: unbound variable\n", n->name.c_str());
     ctx.sh.exiting = true;
     ctx.sh.exit_status = 127;
     ctx.ok = false;
@@ -1050,15 +1048,14 @@ long long eval_arith_msg(Shell &sh, const std::string &expr, const char *cmd_nam
     // A nested value-evaluation failure carries its own fully formatted
     // diagnostic naming the VALUE as the expression; a subscript failure
     // prints bare (no `((: ' prefix), as bash's array layer does.
-    std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(),
-                 ctx.full_msg_bare ? "" : prefix.c_str(), rendere(ctx.full_msg).c_str());
+    sh.errorf("%s%s\n", ctx.full_msg_bare ? "" : prefix.c_str(), rendere(ctx.full_msg).c_str());
     // A failure raised by the ARRAY layer while evaluating a subscript unwinds
     // the command list, even from `let', where a failure of the top-level
     // expression (`let "x+"') merely returns non-zero and execution continues.
     if (ctx.full_msg_bare) sh.arith_abort = true;
   } else if (!ctx.ok && ctx.err_pos != std::string::npos && ctx.err_pos <= expr.size()) {
-    std::fprintf(stderr, "%s%s%s\n", sh.err_prefix().c_str(), prefix.c_str(),
-                 rendere(format_arith_err(expr, ctx.err_msg, ctx.err_pos)).c_str());
+    sh.errorf("%s%s\n", prefix.c_str(),
+              rendere(format_arith_err(expr, ctx.err_msg, ctx.err_pos)).c_str());
   }
   return v;
 }

--- a/core/src/ast.cpp
+++ b/core/src/ast.cpp
@@ -9,6 +9,7 @@
 
 #include "gnash/core/ast.hpp"
 #include "gnash/core/parser.hpp"
+#include "gnash/core/quote.hpp"
 
 namespace gnash::core {
 
@@ -624,17 +625,6 @@ struct MPrinter {
 // displays as `v='^A'' and `v=$"msg"' as `v="msg"'.  gnash keeps the source
 // text in the AST, so the printer performs the same expansion.
 
-// bash's sh_single_quote: wrap S in single quotes, ' -> '\''.
-std::string ansi_single_quote(const std::string &s) {
-  std::string out = "'";
-  for (char c : s) {
-    if (c == '\'') out += "'\\''";
-    else out += c;
-  }
-  out += '\'';
-  return out;
-}
-
 void utf8_append(std::string &out, unsigned long cp) {
   if (cp < 0x80) out += static_cast<char>(cp);
   else if (cp < 0x800) {
@@ -779,7 +769,7 @@ std::string ansi_expand_word(const std::string &w) {
         size_t j = i + 2;  // find the closing ', honoring backslash escapes
         while (j < w.size() && w[j] != '\'') j += (w[j] == '\\' && j + 1 < w.size()) ? 2 : 1;
         if (j >= w.size()) { out += w.substr(i); break; }
-        out += ansi_single_quote(ansi_c_decode(w.substr(i + 2, j - (i + 2))));
+        out += single_quote(ansi_c_decode(w.substr(i + 2, j - (i + 2))));
         i = j + 1;
         continue;
       }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -99,8 +99,7 @@ std::string decode_b(const std::string &s, bool &stop, bool bare_octal = true,
         if (k == 0) {
           out += "\\x";
           if (warn_sh)
-            std::fprintf(stderr, "%sprintf: missing hex digit for \\x\n",
-                         warn_sh->err_prefix().c_str());
+            warn_sh->errorf("printf: missing hex digit for \\x\n");
           break;
         }
         out += static_cast<char>(v);
@@ -182,8 +181,7 @@ int bi_echo(Shell &sh, const std::vector<std::string> &argv) {
   // fails only HERE, because duplicating a read-only descriptor onto stdout
   // succeeds and only the write itself gets EBADF.
   if (std::fflush(stdout) != 0 || std::ferror(stdout)) {
-    std::fprintf(stderr, "%secho: write error: %s\n", sh.err_prefix().c_str(),
-                 std::strerror(errno));
+    sh.errorf("echo: write error: %s\n", std::strerror(errno));
     std::clearerr(stdout);
     return 1;
   }
@@ -494,15 +492,13 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
         vname_idx = ai + 1;
         ai += 2;
       } else {
-        std::fprintf(stderr, "%sprintf: -v: option requires an argument\n",
-                     sh.err_prefix().c_str());
+        sh.errorf("printf: -v: option requires an argument\n");
         std::fputs(kUsage, stderr);
         return 2;
       }
       continue;
     }
-    std::fprintf(stderr, "%sprintf: %s: invalid option\n",
-                 sh.err_prefix().c_str(), opt.substr(0, 2).c_str());
+    sh.errorf("printf: %s: invalid option\n", opt.substr(0, 2).c_str());
     std::fputs(kUsage, stderr);
     return 2;
   }
@@ -515,8 +511,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
               (lb != std::string::npos && lb > 0 && vname.size() >= lb + 3 &&
                vname.back() == ']' && valid_identifier(vname.substr(0, lb)));
     if (!ok) {
-      std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), vname.c_str());
+      sh.errorf("printf: `%s': not a valid identifier\n", vname.c_str());
       return 2;
     }
   }
@@ -581,8 +576,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
     }
     if (!ovf) return static_cast<long>(v);
     flush_out();
-    std::fprintf(stderr, "%sprintf: %s: %s\n", sh.err_prefix().c_str(),
-                 f.substr(d0, sp - d0).c_str(), std::strerror(ERANGE));
+    sh.errorf("printf: %s: %s\n", f.substr(d0, sp - d0).c_str(), std::strerror(ERANGE));
     conv_error = true;
     return overflow_return;
   };
@@ -595,8 +589,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
   // scan; clearing argi ends the argument-reuse loop.
   auto pf_fail = [&]() {
     flush_out();
-    std::fprintf(stderr, "%sprintf: %s\n", sh.err_prefix().c_str(),
-                 std::strerror(errno));
+    sh.errorf("printf: %s\n", std::strerror(errno));
     fatal = true;
     argi = argv.size();
   };
@@ -617,13 +610,11 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
     bool overflow = errno == ERANGE || v < INT_MIN || v > INT_MAX;
     if (*ep != '\0' || ep == a.c_str()) {
       flush_out();
-      std::fprintf(stderr, "%sprintf: %s: invalid number\n",
-                   sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("printf: %s: invalid number\n", a.c_str());
       conv_error = true;
     } else if (overflow) {
       flush_out();
-      std::fprintf(stderr, "%sprintf: %s: %s\n", sh.err_prefix().c_str(),
-                   a.c_str(), std::strerror(ERANGE));
+      sh.errorf("printf: %s: %s\n", a.c_str(), std::strerror(ERANGE));
       conv_error = true;
     }
     return overflow ? overflow_return : static_cast<long>(v);
@@ -636,13 +627,11 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
   auto chk_num = [&](const std::string &a, const char *ep, bool erange) {
     if ((ep && *ep != '\0') || ep == a.c_str()) {
       flush_out();
-      std::fprintf(stderr, "%sprintf: %s: invalid number\n",
-                   sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("printf: %s: invalid number\n", a.c_str());
       conv_error = true;
     } else if (erange) {
       flush_out();
-      std::fprintf(stderr, "%sprintf: %s: %s\n", sh.err_prefix().c_str(),
-                   a.c_str(), std::strerror(ERANGE));
+      sh.errorf("printf: %s: %s\n", a.c_str(), std::strerror(ERANGE));
       conv_error = true;
     }
   };
@@ -716,8 +705,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
         // whole spec, stop processing, still write what accumulated (bash).
         auto missing_fmt_char = [&]() {
           flush_out();
-          std::fprintf(stderr, "%sprintf: `%s': missing format character\n",
-                       sh.err_prefix().c_str(), fmt.substr(i).c_str());
+          sh.errorf("printf: `%s': missing format character\n", fmt.substr(i).c_str());
           fatal = true;
           argi = argv.size();
         };
@@ -745,9 +733,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
             // literally and rescans the rest of the spec as ordinary text.
             char bad = (p + 1 < fmt.size()) ? fmt[p + 1] : '\0';
             flush_out();
-            std::fprintf(stderr,
-                         "%sprintf: warning: `%c': invalid time format specification\n",
-                         sh.err_prefix().c_str(), bad);
+            sh.errorf("printf: warning: `%c': invalid time format specification\n", bad);
             out += '%';
             continue;  // the loop ++ resumes at the character after `%'
           }
@@ -994,8 +980,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
           if (!var.empty()) {
             if (!valid_identifier(var)) {
               flush_out();
-              std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
-                           sh.err_prefix().c_str(), var.c_str());
+              sh.errorf("printf: `%s': not a valid identifier\n", var.c_str());
               fatal = true;
               argi = argv.size();
               break;
@@ -1012,8 +997,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
           // Anything else is `C': invalid format character -- an error that
           // stops processing (bash); what accumulated is still written.
           flush_out();
-          std::fprintf(stderr, "%sprintf: `%c': invalid format character\n",
-                       sh.err_prefix().c_str(), conv);
+          sh.errorf("printf: `%c': invalid format character\n", conv);
           fatal = true;
           argi = argv.size();
           break;
@@ -1030,8 +1014,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
     if (lb != std::string::npos &&
         ((!lenient_element_target(sh, vname_idx) && !well_formed_element(vname)) ||
          !subscript_reexpands(sh, vname))) {
-      std::fprintf(stderr, "%sprintf: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), vname.c_str());
+      sh.errorf("printf: `%s': not a valid identifier\n", vname.c_str());
       return 1;
     }
     if (lb != std::string::npos && !vname.empty() && vname.back() == ']') {
@@ -1041,8 +1024,7 @@ int bi_printf(Shell &sh, const std::vector<std::string> &argv) {
       auto pvit = sh.vars.find(sh.deref(base));
       bool pv_assoc = pvit != sh.vars.end() && pvit->second.kind == VarKind::Assoc;
       if (!pv_assoc && (sub == "@" || sub == "*")) {
-        std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
-                     vname.c_str());
+        sh.errorf("%s: bad array subscript\n", vname.c_str());
         return 1;
       }
       if (!sh.array_expand_once_ok(base, sub)) return 1;
@@ -1193,7 +1175,7 @@ struct TestEval {
   const char *at(size_t p) const { return p < v.size() ? v[p].c_str() : nullptr; }
 
   [[noreturn]] void syntax_error(const std::string &msg) {
-    std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), cmd, msg.c_str());
+    sh.errorf("%s: %s\n", cmd, msg.c_str());
     throw TestSyntaxError{};
   }
   [[noreturn]] void integer_expected(const std::string &s) {
@@ -1541,8 +1523,7 @@ int change_dir(Shell &sh, const std::string &dir, bool physical, const char *cal
   logical = canon_logical(logical);
   const std::string &target = physical ? dir : logical;
   if (chdir(target.c_str()) != 0) {
-    std::fprintf(stderr, "%s%s: %s: %s\n", sh.err_prefix().c_str(), caller,
-                 printable_name(dir).c_str(), std::strerror(errno));
+    sh.errorf("%s: %s: %s\n", caller, printable_name(dir).c_str(), std::strerror(errno));
     return 1;
   }
   // Updating a readonly PWD/OLDPWD fails (bash reports it and cd returns 1),
@@ -1553,13 +1534,13 @@ int change_dir(Shell &sh, const std::string &dir, bool physical, const char *cal
   };
   if (!oldpwd.empty()) {
     if (is_ro("OLDPWD")) {
-      std::fprintf(stderr, "%sOLDPWD: readonly variable\n", sh.err_prefix().c_str());
+      sh.errorf("OLDPWD: readonly variable\n");
       return 1;
     }
     sh.set_exported("OLDPWD", oldpwd);
   }
   if (is_ro("PWD")) {
-    std::fprintf(stderr, "%sPWD: readonly variable\n", sh.err_prefix().c_str());
+    sh.errorf("PWD: readonly variable\n");
     return 1;
   }
   sh.set_exported("PWD", physical ? phys_cwd() : logical);
@@ -1569,7 +1550,7 @@ int change_dir(Shell &sh, const std::string &dir, bool physical, const char *cal
 int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
   bool print_target = false;  // `cd -' echoes where it went, on success only
   if (sh.opt_restricted) {
-    std::fprintf(stderr, "%scd: restricted\n", sh.err_prefix().c_str());
+    sh.errorf("cd: restricted\n");
     return 1;
   }
   bool physical = false;
@@ -1581,20 +1562,20 @@ int bi_cd(Shell &sh, const std::vector<std::string> &argv) {
     else break;
   }
   if (argv.size() - i > 1) {
-    std::fprintf(stderr, "%scd: too many arguments\n", sh.err_prefix().c_str());
+    sh.errorf("cd: too many arguments\n");
     return 1;
   }
   std::string dir;
   if (i >= argv.size()) {
     if (!sh.is_set("HOME")) {
-      std::fprintf(stderr, "%scd: HOME not set\n", sh.err_prefix().c_str());
+      sh.errorf("cd: HOME not set\n");
       return 1;
     }
     dir = sh.get("HOME");
   } else if (argv[i] == "-") {
     print_target = true;  // set below, once the destination is known to be good
     if (!sh.is_set("OLDPWD")) {
-      std::fprintf(stderr, "%scd: OLDPWD not set\n", sh.err_prefix().c_str());
+      sh.errorf("cd: OLDPWD not set\n");
       return 1;
     }
     dir = sh.get("OLDPWD");
@@ -1724,7 +1705,7 @@ int bi_dirs(Shell &sh, const std::vector<std::string> &argv) {
     // A `-<non-digit>' is read as a bad `-N' index (invalid number); a bare
     // argument with no leading dash is an invalid option.
     if (a.empty() || a[0] != '-') {
-      std::fprintf(stderr, "%sdirs: %s: invalid option\n", sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("dirs: %s: invalid option\n", a.c_str());
       std::fprintf(stderr, "dirs: usage: dirs [-clpv] [+N] [-N]\n");
       return 2;
     }
@@ -1737,7 +1718,7 @@ int bi_dirs(Shell &sh, const std::vector<std::string> &argv) {
       else bad = true;
     }
     if (bad) {
-      std::fprintf(stderr, "%sdirs: %s: invalid number\n", sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("dirs: %s: invalid number\n", a.c_str());
       std::fprintf(stderr, "dirs: usage: dirs [-clpv] [+N] [-N]\n");
       return 2;
     }
@@ -1747,8 +1728,7 @@ int bi_dirs(Shell &sh, const std::vector<std::string> &argv) {
     int idx = rot_index(select, v.size());
     if (idx < 0) {
       // dirs reports the bare number (bash strips the +/- here, unlike pushd/popd).
-      std::fprintf(stderr, "%sdirs: %s: directory stack index out of range\n",
-                   sh.err_prefix().c_str(), select.substr(1).c_str());
+      sh.errorf("dirs: %s: directory stack index out of range\n", select.substr(1).c_str());
       return 1;
     }
     std::string s = tilde_abbrev(sh, v[static_cast<size_t>(idx)], longform);
@@ -1794,7 +1774,7 @@ int bi_pushd(Shell &sh, const std::vector<std::string> &argv) {
     // Rotate so the Nth entry becomes the top.
     std::vector<std::string> v = full_dirstack(sh);
     int idx = rot_index(a[1], v.size());
-    if (idx < 0) { std::fprintf(stderr, "%spushd: %s: directory stack index out of range\n", sh.err_prefix().c_str(), a[1].c_str()); return 1; }
+    if (idx < 0) { sh.errorf("pushd: %s: directory stack index out of range\n", a[1].c_str()); return 1; }
     std::rotate(v.begin(), v.begin() + idx, v.end());
     if (!no_cd && change_dir(sh, v[0], false, "pushd") != 0) return 1;
     sh.dir_stack.assign(v.begin() + 1, v.end());
@@ -1804,8 +1784,7 @@ int bi_pushd(Shell &sh, const std::vector<std::string> &argv) {
   }
   // A `+'/`-' argument that isn't a numeric index is a malformed rotation count.
   if (!opts_end && a.size() > 1 && (a[1][0] == '+' || a[1][0] == '-')) {
-    std::fprintf(stderr, "%spushd: %s: invalid number\n", sh.err_prefix().c_str(),
-                 a[1].c_str());
+    sh.errorf("pushd: %s: invalid number\n", a[1].c_str());
     std::fprintf(stderr, "pushd: usage: pushd [-n] [+N | -N | dir]\n");
     return 2;
   }
@@ -1818,7 +1797,7 @@ int bi_pushd(Shell &sh, const std::vector<std::string> &argv) {
   }
   // No argument: swap the top two directories.
   if (sh.dir_stack.empty()) {
-    std::fprintf(stderr, "%spushd: no other directory\n", sh.err_prefix().c_str());
+    sh.errorf("pushd: no other directory\n");
     return 1;
   }
   std::string target = sh.dir_stack.front();
@@ -1844,9 +1823,9 @@ int bi_popd(Shell &sh, const std::vector<std::string> &argv) {
       std::isdigit(static_cast<unsigned char>(a[1][1]))) {
     std::vector<std::string> v = full_dirstack(sh);
     int idx = rot_index(a[1], v.size());
-    if (idx < 0) { std::fprintf(stderr, "%spopd: %s: directory stack index out of range\n", sh.err_prefix().c_str(), a[1].c_str()); return 1; }
+    if (idx < 0) { sh.errorf("popd: %s: directory stack index out of range\n", a[1].c_str()); return 1; }
     if (idx == 0) {  // removing the top: cd to the next entry (unless `-n')
-      if (sh.dir_stack.empty()) { std::fprintf(stderr, "%spopd: directory stack empty\n", sh.err_prefix().c_str()); return 1; }
+      if (sh.dir_stack.empty()) { sh.errorf("popd: directory stack empty\n"); return 1; }
       std::string target = sh.dir_stack.front();
       sh.dir_stack.erase(sh.dir_stack.begin());
       if (!no_cd && change_dir(sh, target, false, "popd") != 0) return 1;
@@ -1859,19 +1838,17 @@ int bi_popd(Shell &sh, const std::vector<std::string> &argv) {
   // any other argument (without `--') is invalid outright -- popd takes no
   // directory name.
   if (!opts_end && a.size() > 1 && (a[1][0] == '+' || a[1][0] == '-')) {
-    std::fprintf(stderr, "%spopd: %s: invalid number\n", sh.err_prefix().c_str(),
-                 a[1].c_str());
+    sh.errorf("popd: %s: invalid number\n", a[1].c_str());
     std::fprintf(stderr, "popd: usage: popd [-n] [+N | -N]\n");
     return 2;
   }
   if (!opts_end && a.size() > 1) {
-    std::fprintf(stderr, "%spopd: %s: invalid argument\n", sh.err_prefix().c_str(),
-                 a[1].c_str());
+    sh.errorf("popd: %s: invalid argument\n", a[1].c_str());
     std::fprintf(stderr, "popd: usage: popd [-n] [+N | -N]\n");
     return 2;
   }
   if (sh.dir_stack.empty()) {
-    std::fprintf(stderr, "%spopd: directory stack empty\n", sh.err_prefix().c_str());
+    sh.errorf("popd: directory stack empty\n");
     return 1;
   }
   // Remove the entry that would become the current directory; `popd' cd's to it,
@@ -1931,8 +1908,7 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
         char *end = nullptr;
         long f = std::strtol(val.c_str(), &end, 10);
         if (val.empty() || *end != '\0') {
-          std::fprintf(stderr, "%smapfile: %s: invalid file descriptor specification\n",
-                       sh.err_prefix().c_str(), val.c_str());
+          sh.errorf("mapfile: %s: invalid file descriptor specification\n", val.c_str());
           return 1;
         }
         fd = static_cast<int>(f);
@@ -1947,12 +1923,11 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
 
   // Validate the descriptor and the target array name before reading.
   if (have_u && fcntl(fd, F_GETFD) == -1) {
-    std::fprintf(stderr, "%smapfile: %d: invalid file descriptor: %s\n", sh.err_prefix().c_str(),
-                 fd, std::strerror(errno));
+    sh.errorf("mapfile: %d: invalid file descriptor: %s\n", fd, std::strerror(errno));
     return 1;
   }
   if (name.empty()) {
-    std::fprintf(stderr, "%smapfile: empty array variable name\n", sh.err_prefix().c_str());
+    sh.errorf("mapfile: empty array variable name\n");
     return 1;
   }
   {
@@ -1960,8 +1935,7 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
     for (char c : name)
       if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) ok = false;
     if (!ok) {
-      std::fprintf(stderr, "%smapfile: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                   name.c_str());
+      sh.errorf("mapfile: `%s': not a valid identifier\n", name.c_str());
       return 1;
     }
   }
@@ -1971,8 +1945,7 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
   {
     std::string resolved = sh.deref(name);
     if (resolved.find('[') != std::string::npos) {
-      std::fprintf(stderr, "%smapfile: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), resolved.c_str());
+      sh.errorf("mapfile: `%s': not a valid identifier\n", resolved.c_str());
       return 1;
     }
   }
@@ -2015,8 +1988,7 @@ int bi_mapfile(Shell &sh, const std::vector<std::string> &argv) {
   {
     auto mit = sh.vars.find(sh.deref(name));
     if (mit != sh.vars.end() && mit->second.kind == VarKind::Assoc) {
-      std::fprintf(stderr, "%smapfile: %s: not an indexed array\n",
-                   sh.err_prefix().c_str(), name.c_str());
+      sh.errorf("mapfile: %s: not an indexed array\n", name.c_str());
       return 1;
     }
   }
@@ -2055,7 +2027,7 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       else if (a[k] == 'n') nflag = true;
       else if (a[k] == 'p') { /* listing handled by the caller */ }
       else {
-        std::fprintf(stderr, "%sexport: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
+        sh.errorf("export: -%c: invalid option\n", a[k]);
         std::fprintf(stderr, "export: usage: export [-fn] [name[=value] ...] or export -p [-f]\n");
         return 2;
       }
@@ -2068,15 +2040,13 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       // name that cannot encode as BASH_FUNC_<name>%% (it contains `=' or `/')
       // cannot be exported, even though it is a valid function name.
       if (a.find('=') != std::string::npos || a.find('/') != std::string::npos) {
-        std::fprintf(stderr, "%sexport: %s: cannot export\n", sh.err_prefix().c_str(),
-                     a.c_str());
+        sh.errorf("export: %s: cannot export\n", a.c_str());
         st = 1;
       } else if (sh.functions.count(a)) {
         sh.exported_functions.insert(a);
       } else {
         // Not a function: bash refuses to create an `invisible function'.
-        std::fprintf(stderr, "%sexport: %s: not a function\n", sh.err_prefix().c_str(),
-                     a.c_str());
+        sh.errorf("export: %s: not a function\n", a.c_str());
         st = 1;
       }
       continue;
@@ -2087,8 +2057,7 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
     size_t br = a.find('[');
     if (br != std::string::npos && (eq == std::string::npos || br < eq) && !sh.is_zsh()) {
       std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
-      std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), tgt.c_str());
+      sh.errorf("export: `%s': not a valid identifier\n", tgt.c_str());
       st = 1;
       continue;
     }
@@ -2134,8 +2103,7 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       // A bare NAME must be a valid identifier: `export non-identifier' is an
       // error with status 1, each bad name reported (errors11.sub).  POSIX:
       // fatal at the first bad name (`command' shields).
-      std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("export: `%s': not a valid identifier\n", a.c_str());
       st = 1;
       sh.posix_special_builtin_error(1);
       if (sh.exiting) return 1;
@@ -2144,8 +2112,7 @@ int bi_export(Shell &sh, const std::vector<std::string> &argv) {
       // `export a[5]': the resolved `var[0]' is not a valid identifier (bash).
       std::string dn = sh.deref(a);
       if (dn.find('[') != std::string::npos && !sh.is_zsh()) {
-        std::fprintf(stderr, "%sexport: `%s': not a valid identifier\n",
-                     sh.err_prefix().c_str(), dn.c_str());
+        sh.errorf("export: `%s': not a valid identifier\n", dn.c_str());
         st = 1;
       } else if (nflag) {
         // `export -n NAME' clears the export attribute of the nameref's target
@@ -2176,7 +2143,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       else if (a[k] == 'v') vflag = true;
       else if (a[k] == 'n') noref = true;
       else {
-        std::fprintf(stderr, "%sunset: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
+        sh.errorf("unset: -%c: invalid option\n", a[k]);
         std::fprintf(stderr, "unset: usage: unset [-f] [-v] [-n] [name ...]\n");
         sh.posix_special_builtin_error(2);
         return 2;
@@ -2184,8 +2151,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     }
   }
   if (fflag && vflag) {
-    std::fprintf(stderr, "%sunset: cannot simultaneously unset a function and a variable\n",
-                 sh.err_prefix().c_str());
+    sh.errorf("unset: cannot simultaneously unset a function and a variable\n");
     sh.posix_special_builtin_error(2);
     return 2;
   }
@@ -2196,8 +2162,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
   for (; i < argv.size(); i++) {
     if (funcs) {
       if (sh.readonly_functions.count(argv[i])) {
-        std::fprintf(stderr, "%sunset: %s: cannot unset: readonly function\n",
-                     sh.err_prefix().c_str(), argv[i].c_str());
+        sh.errorf("unset: %s: cannot unset: readonly function\n", argv[i].c_str());
         ret = 1;
       } else {
         sh.functions.erase(argv[i]);
@@ -2205,8 +2170,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       continue;
     }
     if (kNoUnset.count(argv[i])) {
-      std::fprintf(stderr, "%sunset: %s: cannot unset\n", sh.err_prefix().c_str(),
-                   argv[i].c_str());
+      sh.errorf("unset: %s: cannot unset\n", argv[i].c_str());
       ret = 1;
       continue;
     }
@@ -2229,8 +2193,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       // through to its function-unset attempt and stays silent
       // (quotearray5.sub line 27 vs quotearray3.sub line 55).
       if (vflag && !expand_once_on(sh)) {
-        std::fprintf(stderr, "%sunset: `%s': not a valid identifier\n",
-                     sh.err_prefix().c_str(), argv[i].c_str());
+        sh.errorf("unset: `%s': not a valid identifier\n", argv[i].c_str());
         ret = 1;
       }
       continue;
@@ -2300,16 +2263,14 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
         Expander uex(sh);
         std::string esub = uex.expand_no_split(sub);
         if (esub.empty() && sub.find('$') != std::string::npos) {
-          std::fprintf(stderr, "%sunset: [%s]: bad array subscript\n",
-                       sh.err_prefix().c_str(), sub.c_str());
+          sh.errorf("unset: [%s]: bad array subscript\n", sub.c_str());
           ret = 1;
           continue;
         }
         if (!esub.empty()) sub = esub;
       }
       if (bit != sh.vars.end() && bit->second.readonly) {
-        std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",
-                     sh.err_prefix().c_str(), bd.c_str());
+        sh.errorf("unset: %s: cannot unset: readonly variable\n", bd.c_str());
         ret = 1;
         continue;
       }
@@ -2324,8 +2285,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
           sh.unset(bd);
           continue;
         }
-        std::fprintf(stderr, "%sunset: %s: not an array variable\n",
-                     sh.err_prefix().c_str(), bd.c_str());
+        sh.errorf("unset: %s: not an array variable\n", bd.c_str());
         ret = 1;
         continue;
       }
@@ -2333,8 +2293,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       // (`unset a[-2]' on an empty or too-short indexed array); bash names just
       // the bracketed subscript, not the array.
       if (!sh.array_unset(base, sub)) {
-        std::fprintf(stderr, "%sunset: [%s]: bad array subscript\n",
-                     sh.err_prefix().c_str(), sub.c_str());
+        sh.errorf("unset: [%s]: bad array subscript\n", sub.c_str());
         ret = 1;
       }
       continue;
@@ -2346,8 +2305,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
       // through to its function-unset attempt and stays silent with status 0
       // (`unset /bin/sh' -- errors.tests), like the malformed-element case.
       if (vflag) {
-        std::fprintf(stderr, "%sunset: `%s': not a valid identifier\n",
-                     sh.err_prefix().c_str(), argv[i].c_str());
+        sh.errorf("unset: `%s': not a valid identifier\n", argv[i].c_str());
         ret = 1;
       }
       continue;
@@ -2357,8 +2315,7 @@ int bi_unset(Shell &sh, const std::vector<std::string> &argv) {
     std::string tgt = noref ? argv[i] : sh.deref(argv[i]);
     auto it = sh.vars.find(tgt);
     if (it != sh.vars.end() && it->second.readonly) {
-      std::fprintf(stderr, "%sunset: %s: cannot unset: readonly variable\n",
-                   sh.err_prefix().c_str(), tgt.c_str());
+      sh.errorf("unset: %s: cannot unset: readonly variable\n", tgt.c_str());
       ret = 1;
       continue;
     }
@@ -2669,7 +2626,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'r':  // restricted: can be turned on, never off
             if (on) sh.opt_restricted = true;
             else {
-              std::fprintf(stderr, "%sset: +r: invalid option\n", sh.err_prefix().c_str());
+              sh.errorf("set: +r: invalid option\n");
               std::fprintf(stderr, "set: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] "
                                    "[--] [-] [arg ...]\n");
               return 2;
@@ -2689,8 +2646,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
             } else {
               std::string oname = argv[++i];
               if (!set_o_option(sh, oname, on)) {
-                std::fprintf(stderr, "%sset: %s: invalid option name\n",
-                             sh.err_prefix().c_str(), oname.c_str());
+                sh.errorf("set: %s: invalid option name\n", oname.c_str());
                 return 2;
               }
             }
@@ -2704,8 +2660,7 @@ int bi_set(Shell &sh, const std::vector<std::string> &argv) {
           case 'a': sh.opt_allexport = on; break;  // allexport: assignments export
           case 'b': case 't': break;
           default:
-            std::fprintf(stderr, "%sset: %c%c: invalid option\n", sh.err_prefix().c_str(),
-                         a[0], a[k]);
+            sh.errorf("set: %c%c: invalid option\n", a[0], a[k]);
             std::fprintf(stderr, "set: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] "
                                  "[--] [-] [arg ...]\n");
             return 2;
@@ -2760,8 +2715,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
             char *end = nullptr;
             long f = std::strtol(v.c_str(), &end, 10);
             if (v.empty() || *end != '\0') {
-              std::fprintf(stderr, "%sread: %s: invalid file descriptor specification\n",
-                           sh.err_prefix().c_str(), v.c_str());
+              sh.errorf("read: %s: invalid file descriptor specification\n", v.c_str());
               return 1;
             }
             fd = static_cast<int>(f);
@@ -2774,8 +2728,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
             char *end = nullptr;
             long nv = std::strtol(v.c_str(), &end, 10);
             if (v.empty() || (end && *end) || nv < 0) {
-              std::fprintf(stderr, "%sread: %s: invalid number\n", sh.err_prefix().c_str(),
-                           v.c_str());
+              sh.errorf("read: %s: invalid number\n", v.c_str());
               return 1;
             }
             have_n = true;
@@ -2788,8 +2741,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
             char *end = nullptr;
             double tv = std::strtod(v.c_str(), &end);
             if (v.empty() || (end && *end) || tv < 0) {
-              std::fprintf(stderr, "%sread: %s: invalid timeout specification\n",
-                           sh.err_prefix().c_str(), v.c_str());
+              sh.errorf("read: %s: invalid timeout specification\n", v.c_str());
               return 1;
             }
             have_t = true;
@@ -2800,7 +2752,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
           case 'e': edit = true; break;              // readline editing
           case 's': case 'E': break;                 // silent: accepted
           default:
-            std::fprintf(stderr, "%sread: -%c: invalid option\n", sh.err_prefix().c_str(), o);
+            sh.errorf("read: -%c: invalid option\n", o);
             std::fprintf(stderr, "read: usage: read [-Eers] [-a array] [-d delim] [-i text] "
                                  "[-n nchars] [-N nchars] [-p prompt] [-t timeout] [-u fd] "
                                  "[name ...]\n");
@@ -2816,8 +2768,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   // Validate the -u descriptor and the target names before reading, as bash
   // does, so a bad fd or an invalid identifier is diagnosed even on EOF.
   if (have_u && fcntl(fd, F_GETFD) == -1) {
-    std::fprintf(stderr, "%sread: %d: invalid file descriptor: %s\n", sh.err_prefix().c_str(),
-                 fd, std::strerror(errno));
+    sh.errorf("read: %d: invalid file descriptor: %s\n", fd, std::strerror(errno));
     return 1;
   }
   auto valid_read_name = [](const std::string &s) {
@@ -2834,8 +2785,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     return well_formed_element(s2);  // `A[]]' is not a valid identifier
   };
   if (!arrayname.empty() && !valid_read_target(arrayname)) {
-    std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                 arrayname.c_str());
+    sh.errorf("read: `%s': not a valid identifier\n", arrayname.c_str());
     return 1;
   }
   // `read -a' fills a whole array, so a nameref target must resolve to a plain
@@ -2844,15 +2794,13 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   if (!arrayname.empty()) {
     std::string resolved = sh.deref(arrayname);
     if (resolved.find('[') != std::string::npos) {
-      std::fprintf(stderr, "%sread: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), resolved.c_str());
+      sh.errorf("read: `%s': not a valid identifier\n", resolved.c_str());
       return 1;
     }
     // `read -a' fills an indexed array; an existing associative array is rejected.
     auto av = sh.vars.find(resolved);
     if (av != sh.vars.end() && av->second.kind == VarKind::Assoc) {
-      std::fprintf(stderr, "%sread: %s: not an indexed array\n",
-                   sh.err_prefix().c_str(), arrayname.c_str());
+      sh.errorf("read: %s: not an indexed array\n", arrayname.c_str());
       return 1;
     }
   }
@@ -2860,8 +2808,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
     const std::string &nm = names[ni];
     if (lenient_element_target(sh, ni < name_idx.size() ? name_idx[ni] : SIZE_MAX)) continue;
     if (!valid_read_target(nm) || !subscript_reexpands(sh, nm)) {
-      std::fprintf(stderr, "%sread: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                   nm.c_str());
+      sh.errorf("read: `%s': not a valid identifier\n", nm.c_str());
       return 1;
     }
   }
@@ -3022,8 +2969,7 @@ int bi_read(Shell &sh, const std::vector<std::string> &argv) {
   // (read.def returns through its unwind frame before the assignment).
   if (read_errno != 0) {
     std::fflush(stdout);
-    std::fprintf(stderr, "%sread: %d: read error: %s\n", sh.err_prefix().c_str(),
-                 fd, std::strerror(read_errno));
+    sh.errorf("read: %d: read error: %s\n", fd, std::strerror(read_errno));
     return 1;
   }
 
@@ -3200,8 +3146,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       const char *allowed = force_ro ? kRoOpts : kDeclOpts;
       for (size_t k = 1; k < a.size(); k++) {
         if (!std::strchr(allowed, a[k])) {
-          std::fprintf(stderr, "%s%s: %c%c: invalid option\n", sh.err_prefix().c_str(),
-                       argv[0].c_str(), a[0], a[k]);
+          sh.errorf("%s: %c%c: invalid option\n", argv[0].c_str(), a[0], a[k]);
           if (force_ro)
             std::fprintf(stderr, "readonly: usage: readonly [-aAf] [name[=value] ...] "
                                  "or readonly -p\n");
@@ -3248,8 +3193,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
   // -n over -i over -A over -a.
   if ((funcs || funcnames) && (mk_array || mk_assoc || integer || nameref)) {
     const char *opt = nameref ? "-n" : integer ? "-i" : mk_assoc ? "-A" : "-a";
-    std::fprintf(stderr, "%s%s: %s: invalid option\n", sh.err_prefix().c_str(),
-                 argv[0].c_str(), opt);
+    sh.errorf("%s: %s: invalid option\n", argv[0].c_str(), opt);
     return 1;
   }
   // -p: display variables (named ones, or all) in reproducible form.
@@ -3322,8 +3266,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // under a pipe while stderr is not, so flush any already-printed
           // declarations first to keep the interleaving bash produces.
           std::fflush(stdout);
-          std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
-                       argv[0].c_str(), argv[i].c_str());
+          sh.errorf("%s: %s: not found\n", argv[0].c_str(), argv[i].c_str());
           st = 1;
         } else {
           declare_print_var(argv[i], it->second, argv[0], sh.opt_posix);
@@ -3340,13 +3283,11 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     for (; i < argv.size(); i++) {
       const std::string &fn = argv[i];
       if (!sh.functions.count(fn)) {
-        std::fprintf(stderr, "%s%s: %s: not a function\n", sh.err_prefix().c_str(),
-                     argv[0].c_str(), fn.c_str());
+        sh.errorf("%s: %s: not a function\n", argv[0].c_str(), fn.c_str());
         st = 1;
       } else if (rm_readonly) {
         if (sh.readonly_functions.count(fn)) {
-          std::fprintf(stderr, "%s%s: %s: readonly function\n", sh.err_prefix().c_str(),
-                       argv[0].c_str(), fn.c_str());
+          sh.errorf("%s: %s: readonly function\n", argv[0].c_str(), fn.c_str());
           st = 1;
         }
       } else {
@@ -3398,8 +3339,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       // (`declare -f name=value') is rejected outright and stops processing,
       // always naming `-f' in the diagnostic even under `-F' (declare.def).
       if (argv[i].find('=') != std::string::npos) {
-        std::fprintf(stderr, "%s%s: cannot use `-f' to make functions\n",
-                     sh.err_prefix().c_str(), argv[0].c_str());
+        sh.errorf("%s: cannot use `-f' to make functions\n", argv[0].c_str());
         return 1;
       }
       auto it = sh.functions.find(argv[i]);
@@ -3407,8 +3347,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // `declare -fp NAME' (the -p form) reports a missing function; the bare
         // `declare -f NAME' form fails silently.
         if (fp)
-          std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
-                       argv[0].c_str(), argv[i].c_str());
+          sh.errorf("%s: %s: not found\n", argv[0].c_str(), argv[i].c_str());
         st = 1;
         continue;
       }
@@ -3547,8 +3486,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             elb2 + 1 < elem.size() - 1) {
           std::string inner = elem.substr(elb2 + 1, elem.size() - elb2 - 2);
           if (inner.find(']') != std::string::npos) {
-            std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                         sh.err_prefix().c_str(), argv[0].c_str(), a_display.c_str());
+            sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), a_display.c_str());
             ret = 1;
             continue;
           }
@@ -3560,14 +3498,12 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       if (!assoc_literal &&
           (!valid_identifier(elem.substr(0, elem.find('['))) ||
            !well_formed_element(elem, /*allow_empty=*/true))) {
-        std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                     argv[0].c_str(), a_display.c_str());
+        sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), a_display.c_str());
         ret = 1;
         continue;
       }
       if (!assoc_literal && !well_formed_element(elem)) {  // balanced but empty: a[]
-        std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
-                     elem.c_str());
+        sh.errorf("%s: bad array subscript\n", elem.c_str());
         ret = 1;
         continue;
       }
@@ -3577,8 +3513,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // (zsh's array/readonly rules differ, so leave that personality alone.)
     if (subscript0 && !sh.is_zsh() && (argv[0] == "readonly" || argv[0] == "export")) {
       std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
-      std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                   argv[0].c_str(), tgt.c_str());
+      sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), tgt.c_str());
       ret = 1;
       // POSIX: fatal at the FIRST bad name -- later names are not reported
       // (errors11.sub); `command' shields via posix_builtin_shield.
@@ -3591,8 +3526,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // `declare -n r=a[2]', has `=' before `[' so subscript0 is false.)
     if (subscript0 && nameref) {
       std::string tgt = (eq == std::string::npos) ? a : a.substr(0, eq);
-      std::fprintf(stderr, "%s%s: %s: reference variable cannot be an array\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+      sh.errorf("%s: %s: reference variable cannot be an array\n", argv[0].c_str(), tgt.c_str());
       ret = 1;
       continue;
     }
@@ -3604,8 +3538,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // operand (bash), not an identifier, so it is not rejected here.
     if (!valid_identifier(name) && !(local && a == "-")) {
       // bash reports the whole offending word, including any `=value'.
-      std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), a.c_str());
+      sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), a.c_str());
       ret = 1;
       // POSIX readonly/export: fatal at the FIRST bad name (errors11.sub).
       if (argv[0] == "readonly" || argv[0] == "export") {
@@ -3660,10 +3593,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // reports the readonly violation bare before make_local's prefixed
           // one, so `local a=(...)' on a readonly global emits both.
           if (arraylit0)
-            std::fprintf(stderr, "%s%s: readonly variable\n",
-                         sh.err_prefix().c_str(), name.c_str());
-          std::fprintf(stderr, "%s%s: %s: readonly variable\n",
-                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+            sh.errorf("%s: readonly variable\n", name.c_str());
+          sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), name.c_str());
           ret = 1;
           continue;
         }
@@ -3726,10 +3657,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
                                   ? "associative to indexed"
                                   : nullptr;
         if (cvt_dir) {
-          const std::string &pfx = sh.err_prefix();
           if (funcname.empty()) {
-            std::fprintf(stderr, "%s%s: cannot convert %s array\n", pfx.c_str(),
-                         name.c_str(), cvt_dir);
+            sh.errorf("%s: cannot convert %s array\n", name.c_str(), cvt_dir);
           } else {
             // The function-name line also appears when a localvar_inherit'd
             // (or -I'd) local copied the mismatched enclosing array AND the
@@ -3737,10 +3666,9 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
             // failed make-local conversion first, a bare `declare -A var'
             // only the builtin's own line (varenv14.sub lines 31 vs 77).
             if (global || (inherited_local && eq != std::string::npos))
-              std::fprintf(stderr, "%s%s: %s: cannot convert %s array\n", pfx.c_str(),
-                           funcname.c_str(), name.c_str(), cvt_dir);
-            std::fprintf(stderr, "%s%s: %s: cannot convert %s array\n", pfx.c_str(),
-                         argv[0].c_str(), name.c_str(), cvt_dir);
+              sh.errorf("%s: %s: cannot convert %s array\n",
+                        funcname.c_str(), name.c_str(), cvt_dir);
+            sh.errorf("%s: %s: cannot convert %s array\n", argv[0].c_str(), name.c_str(), cvt_dir);
           }
           ret = 1;
           continue;
@@ -3755,8 +3683,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     if (subscript0 && (mk_array || mk_assoc) && !nameref && !rm_nameref) {
       auto nv = sh.vars.find(name);
       if (nv != sh.vars.end() && nv->second.nameref) {
-        std::fprintf(stderr, "%swarning: %s: removing nameref attribute\n",
-                     sh.err_prefix().c_str(), name.c_str());
+        sh.errorf("warning: %s: removing nameref attribute\n", name.c_str());
         nv->second.nameref = false;
         nv->second.value.clear();  // discard the old target; NAME becomes the array
       }
@@ -3841,9 +3768,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         Expander wex(sh);
         std::string ev = wex.expand_assignment(val);
             if (ev.size() >= 2 && ev.front() == '(' && ev.back() == ')' && !preexisting_target)
-          std::fprintf(stderr, "%swarning: %s%s=%s: quoted compound array assignment deprecated\n",
-                       sh.err_prefix().c_str(), name.c_str(),
-                       a.substr(nend, (append ? eq - 1 : eq) - nend).c_str(), ev.c_str());
+          sh.errorf("warning: %s%s=%s: quoted compound array assignment deprecated\n", name.c_str(),
+                    a.substr(nend, (append ? eq - 1 : eq) - nend).c_str(), ev.c_str());
       }
       if (exval_compound) {
         // A QUOTED compound reaches here rather than the assignment-word path
@@ -3852,8 +3778,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // called it and must stay bare for the command machinery's own path.
         auto rok = sh.vars.find(sh.deref(name));
         if (rok != sh.vars.end() && rok->second.readonly) {
-          std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
-                       argv[0].c_str(), name.c_str());
+          sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), name.c_str());
           ret = 1;
           continue;
         }
@@ -3940,13 +3865,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // reference after `+=' concatenation slips past that check and is
           // caught later while binding the value, which prints it bare.
           if (append)
-            std::fprintf(stderr,
-                         "%s%s: nameref variable self references not allowed\n",
-                         sh.err_prefix().c_str(), name.c_str());
+            sh.errorf("%s: nameref variable self references not allowed\n", name.c_str());
           else
-            std::fprintf(stderr,
-                         "%s%s: %s: nameref variable self references not allowed\n",
-                         sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+            sh.errorf("%s: %s: nameref variable self references not allowed\n", argv[0].c_str(),
+                      name.c_str());
           ret = 1;
           if (!preexist) sh.vars.erase(name);
           continue;
@@ -3954,18 +3876,15 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         if (selfref) {
           // Warn once with the builtin prefix and once without, matching bash's
           // declare.def (builtin_warning) plus bind_variable_value.
-          std::fprintf(stderr, "%s%s: warning: %s: circular name reference\n",
-                       sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
-          std::fprintf(stderr, "%swarning: %s: circular name reference\n",
-                       sh.err_prefix().c_str(), name.c_str());
+          sh.errorf("%s: warning: %s: circular name reference\n", argv[0].c_str(), name.c_str());
+          sh.errorf("warning: %s: circular name reference\n", name.c_str());
         }
         // An explicit empty target (`declare -n r=') is rejected as an invalid
         // identifier and does not create the nameref (bash reports the empty
         // name); at global scope no variable survives, in a function the local
         // that was just made stays as a plain variable.
         if (tgt.empty()) {
-          std::fprintf(stderr, "%s%s: `': not a valid identifier\n",
-                       sh.err_prefix().c_str(), argv[0].c_str());
+          sh.errorf("%s: `': not a valid identifier\n", argv[0].c_str());
           ret = 1;
           if (!preexist) sh.vars.erase(name);
           continue;
@@ -3973,9 +3892,8 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         // The target must be a valid nameref target (`foo' or `foo[2]').  bash
         // rejects anything else and does not create the variable.
         if (!tgt.empty() && !Shell::valid_nameref_target(tgt)) {
-          std::fprintf(stderr,
-                       "%s%s: `%s': invalid variable name for name reference\n",
-                       sh.err_prefix().c_str(), argv[0].c_str(), tgt.c_str());
+          sh.errorf("%s: `%s': invalid variable name for name reference\n", argv[0].c_str(),
+                    tgt.c_str());
           ret = 1;
           if (!preexist) sh.vars.erase(name);  // no half-created variable
           continue;
@@ -3993,8 +3911,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         }
         Variable &rv = sh.vars[name];
         if (rv.readonly) {
-          std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
-                       name.c_str());
+          sh.errorf("%s: readonly variable\n", name.c_str());
           return 1;
         }
         // A `declare -n' naming an existing array is rejected below ("reference
@@ -4064,12 +3981,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // ("invalid variable name for name reference"); at global scope it
           // reports it as a plain invalid identifier.
           if (sh.in_function())
-            std::fprintf(stderr,
-                         "%s%s: `%s': invalid variable name for name reference\n",
-                         sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
+            sh.errorf("%s: `%s': invalid variable name for name reference\n", argv[0].c_str(),
+                      val.c_str());
           else
-            std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                         sh.err_prefix().c_str(), argv[0].c_str(), val.c_str());
+            sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), val.c_str());
           ret = 1;
           // At global scope the still-invisible nameref is discarded (a later
           // `declare -p' reports it as not found); a function-local one made by
@@ -4086,8 +4001,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
         if (argv[0] == "declare" || argv[0] == "typeset" || argv[0] == "local") {
           auto rit = sh.vars.find(sh.deref(name));
           if (rit != sh.vars.end() && rit->second.readonly) {
-            std::fprintf(stderr, "%s%s: %s: readonly variable\n",
-                         sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+            sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), name.c_str());
             ret = 1;
             continue;
           }
@@ -4105,8 +4019,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
           // builtin prefix (the declare/typeset/local prefix case was handled
           // above, so this bare form is reached only by readonly/export).
           if (ait->second.readonly) {
-            std::fprintf(stderr, "%s%s: readonly variable\n", sh.err_prefix().c_str(),
-                         name.c_str());
+            sh.errorf("%s: readonly variable\n", name.c_str());
             ret = 1;
           } else {
             sh.array_set(atgt, "0", val);
@@ -4144,8 +4057,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // readonly/export (which reach bi_declare via force_ro / the -x path).
     if ((argv[0] == "readonly" || argv[0] == "export") && !sh.is_zsh() &&
         aname.find('[') != std::string::npos) {
-      std::fprintf(stderr, "%s%s: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+      sh.errorf("%s: `%s': not a valid identifier\n", argv[0].c_str(), aname.c_str());
       ret = 1;
       continue;
     }
@@ -4195,30 +4107,25 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       // Converting a pre-existing readonly plain variable to a nameref is
       // rejected (`declare -r RO=x; declare -n RO' -> `declare: RO: readonly
       // variable'); bash permits `-x' on a readonly var, but not `-n'.
-      std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
-                   argv[0].c_str(), name.c_str());
+      sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), name.c_str());
       ret = 1;
     } else if (nameref && (v.kind == VarKind::Indexed || v.kind == VarKind::Assoc)) {
       // An existing array/associative variable cannot be turned into a nameref;
       // bash rejects the `-n' and leaves the array (and any assignment made by
       // this same command) intact.
-      std::fprintf(stderr,
-                   "%s%s: %s: reference variable cannot be an array\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+      sh.errorf("%s: %s: reference variable cannot be an array\n", argv[0].c_str(), name.c_str());
       ret = 1;
     } else if (nameref && v.value == name && !sh.in_function()) {
-      std::fprintf(stderr,
-                   "%s%s: %s: nameref variable self references not allowed\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+      sh.errorf("%s: %s: nameref variable self references not allowed\n", argv[0].c_str(),
+                name.c_str());
       ret = 1;
     } else if (nameref && !v.invisible && v.value != name &&
                !Shell::valid_nameref_target(v.value)) {
       // An existing but EMPTY value is rejected too (`r=""; declare -n r'):
       // only a declared-but-unset variable becomes a targetless reference,
       // which is why this tests visibility rather than emptiness.
-      std::fprintf(stderr,
-                   "%s%s: `%s': invalid variable name for name reference\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), v.value.c_str());
+      sh.errorf("%s: `%s': invalid variable name for name reference\n", argv[0].c_str(),
+                v.value.c_str());
       ret = 1;
     } else if (nameref) {
       v.nameref = true;
@@ -4252,11 +4159,10 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       // A READONLY array reports the readonly violation instead (bash checks
       // the attribute change first): `declare +a c' on readonly c.
       if (v.readonly)
-        std::fprintf(stderr, "%s%s: %s: readonly variable\n", sh.err_prefix().c_str(),
-                     argv[0].c_str(), aname.c_str());
+        sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), aname.c_str());
       else
-        std::fprintf(stderr, "%s%s: %s: cannot destroy array variables in this way\n",
-                     sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+        sh.errorf("%s: %s: cannot destroy array variables in this way\n", argv[0].c_str(),
+                  aname.c_str());
       ret = 1;
       continue;
     }
@@ -4265,8 +4171,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
       // follows the reference to nothing, so it is a silent no-op rather than a
       // readonly-variable error -- there is no target variable to report.
       if (v.readonly && !(v.nameref && v.value.empty())) {
-        std::fprintf(stderr, "%s%s: %s: readonly variable\n",
-                     sh.err_prefix().c_str(), argv[0].c_str(), aname.c_str());
+        sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), aname.c_str());
         ret = 1;
       }
     }
@@ -4283,8 +4188,7 @@ int bi_declare(Shell &sh, const std::vector<std::string> &argv, bool force_local
     // the command was redirected to the reference's target above.
     Variable &nself = sh.vars[name];
     if (rm_nameref && nself.readonly && nself.nameref && !nself.value.empty()) {
-      std::fprintf(stderr, "%s%s: %s: readonly variable\n",
-                   sh.err_prefix().c_str(), argv[0].c_str(), name.c_str());
+      sh.errorf("%s: %s: readonly variable\n", argv[0].c_str(), name.c_str());
       ret = 1;
     } else if (rm_nameref) {
       nself.nameref = false;
@@ -4309,7 +4213,7 @@ int bi_let(Shell &sh, const std::vector<std::string> &argv) {
   // `--' as an expression.  Only the first `--' is consumed.
   size_t start = (argv.size() > 1 && argv[1] == "--") ? 2 : 1;
   if (start >= argv.size()) {  // `let' / `let --' with no expression
-    std::fprintf(stderr, "%slet: expression expected\n", sh.err_prefix().c_str());
+    sh.errorf("let: expression expected\n");
     return 1;
   }
   long long last = 0;
@@ -4394,7 +4298,7 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
         case 'a': fa = true; break;
         case 'f': ff = true; break;
         default:
-          std::fprintf(stderr, "%stype: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
+          sh.errorf("type: -%c: invalid option\n", a[k]);
           std::fprintf(stderr, "type: usage: type [-afptP] name [name ...]\n");
           return 2;
       }
@@ -4458,8 +4362,7 @@ int bi_type(Shell &sh, const std::vector<std::string> &argv) {
         std::fflush(stdout);  // keep interleaving with prior stdout lines
         // `command -V NAME' invokes this with argv[0] == "command", so the
         // diagnostic names the invoking builtin (bash: `command: NAME: not found').
-        std::fprintf(stderr, "%s%s: %s: not found\n", sh.err_prefix().c_str(),
-                     argv[0].c_str(), n.c_str());
+        sh.errorf("%s: %s: not found\n", argv[0].c_str(), n.c_str());
       }
       st = 1;
       continue;
@@ -4620,7 +4523,7 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
       else if (a[k] == 'P') opt_P = true;
       else if (a[k] == 'l') opt_l = true;
       else {
-        std::fprintf(stderr, "%strap: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
+        sh.errorf("trap: -%c: invalid option\n", a[k]);
         std::fprintf(stderr, "%s\n", kUsage);
         bad = true;
         break;
@@ -4630,7 +4533,7 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
   }
 
   if (opt_p && opt_P) {
-    std::fprintf(stderr, "%strap: cannot specify both -p and -P\n", sh.err_prefix().c_str());
+    sh.errorf("trap: cannot specify both -p and -P\n");
     return 1;
   }
 
@@ -4640,15 +4543,13 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
   // -P: print just the action(s) of the named signal(s); at least one required.
   if (opt_P) {
     if (i >= argv.size()) {
-      std::fprintf(stderr, "%strap: -P requires at least one signal name\n",
-                   sh.err_prefix().c_str());
+      sh.errorf("trap: -P requires at least one signal name\n");
       return 1;
     }
     int st = 0;
     for (; i < argv.size(); i++) {
       if (trap_pseudo(argv[i]).empty() && !valid_signal_spec(argv[i])) {
-        std::fprintf(stderr, "%strap: %s: invalid signal specification\n",
-                     sh.err_prefix().c_str(), argv[i].c_str());
+        sh.errorf("trap: %s: invalid signal specification\n", argv[i].c_str());
         st = 1;
         continue;
       }
@@ -4667,8 +4568,7 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
     } else {
       for (; i < argv.size(); i++) {
         if (trap_pseudo(argv[i]).empty() && !valid_signal_spec(argv[i])) {
-          std::fprintf(stderr, "%strap: %s: invalid signal specification\n",
-                       sh.err_prefix().c_str(), argv[i].c_str());
+          sh.errorf("trap: %s: invalid signal specification\n", argv[i].c_str());
           st = 1;
           continue;
         }
@@ -4725,8 +4625,7 @@ int bi_trap(Shell &sh, const std::vector<std::string> &argv) {
     }
     // A spec that names no real signal is an error, and that signal is skipped.
     if (!valid_signal_spec(spec)) {
-      std::fprintf(stderr, "%strap: %s: invalid signal specification\n",
-                   sh.err_prefix().c_str(), spec.c_str());
+      sh.errorf("trap: %s: invalid signal specification\n", spec.c_str());
       st = 1;
       continue;
     }
@@ -4823,8 +4722,7 @@ int bi_umask(Shell &sh, const std::vector<std::string> &argv) {
       if (argv[i][k] == 'S') sym = true;
       else if (argv[i][k] == 'p') print = true;
       else {
-        std::fprintf(stderr, "%sumask: -%c: invalid option\n", sh.err_prefix().c_str(),
-                     argv[i][k]);
+        sh.errorf("umask: -%c: invalid option\n", argv[i][k]);
         std::fprintf(stderr, "umask: usage: umask [-p] [-S] [mode]\n");
         return 2;
       }
@@ -4839,8 +4737,7 @@ int bi_umask(Shell &sh, const std::vector<std::string> &argv) {
       // A numeric mode must be all octal digits (bash reports a stray 8/9 as
       // out of range, but accepts values wider than 0777, e.g. setuid bits).
       if (mode.find_first_not_of("01234567") != std::string::npos) {
-        std::fprintf(stderr, "%sumask: %s: octal number out of range\n",
-                     sh.err_prefix().c_str(), mode.c_str());
+        sh.errorf("umask: %s: octal number out of range\n", mode.c_str());
         return 1;
       }
       cur = static_cast<mode_t>(std::strtol(mode.c_str(), nullptr, 8)) & 0777;
@@ -4849,8 +4746,8 @@ int bi_umask(Shell &sh, const std::vector<std::string> &argv) {
       char errch = 0;
       bool erropr = false;
       if (!umask_symbolic(mode, allowed, errch, erropr)) {
-        std::fprintf(stderr, "%sumask: `%c': invalid symbolic mode %s\n",
-                     sh.err_prefix().c_str(), errch, erropr ? "operator" : "character");
+        sh.errorf("umask: `%c': invalid symbolic mode %s\n", errch,
+                  erropr ? "operator" : "character");
         return 1;
       }
       cur = ~allowed & 0777;
@@ -4879,8 +4776,7 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
   std::string &s_curarg = sh.getopt_curarg;
 
   if (argv.size() >= 2 && argv[1].size() >= 2 && argv[1][0] == '-' && argv[1] != "--") {
-    std::fprintf(stderr, "%sgetopts: -%c: invalid option\n", sh.err_prefix().c_str(),
-                 argv[1][1]);
+    sh.errorf("getopts: -%c: invalid option\n", argv[1][1]);
     std::fprintf(stderr, "%s\n", kUsage);
     return 2;
   }
@@ -4896,8 +4792,7 @@ int bi_getopts(Shell &sh, const std::vector<std::string> &argv) {
     for (char c : name)
       if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) ok = false;
     if (!ok) {
-      std::fprintf(stderr, "%sgetopts: `%s': not a valid identifier\n",
-                   sh.err_prefix().c_str(), name.c_str());
+      sh.errorf("getopts: `%s': not a valid identifier\n", name.c_str());
       // bash has already consumed the current option-argument at this point,
       // so advance OPTIND past a leading option so `shift $((OPTIND-1))' works.
       int oi = 1;
@@ -5068,15 +4963,13 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
         if (n > 128) n -= 128;  // a 128+signum exit status names the signal
         if (const char *nm = trapname_from_num(n)) std::printf("%s\n", nm);
         else {
-          std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
-                       sh.err_prefix().c_str(), a.c_str());
+          sh.errorf("kill: %s: invalid signal specification\n", a.c_str());
           st = 1;
         }
       } else if (int n = resolve_sig(a); n > 0) {
         std::printf("%d\n", n);  // name -> number
       } else {
-        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
-                     sh.err_prefix().c_str(), a.c_str());
+        sh.errorf("kill: %s: invalid signal specification\n", a.c_str());
         st = 1;
       }
     }
@@ -5099,22 +4992,19 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
         arg = argv[2];
         i = 3;
       } else {
-        std::fprintf(stderr, "%skill: %s: option requires an argument\n",
-                     sh.err_prefix().c_str(), opt.c_str());
+        sh.errorf("kill: %s: option requires an argument\n", opt.c_str());
         return 1;
       }
       sig = resolve_sig(arg);
       if (sig < 0) {
-        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
-                     sh.err_prefix().c_str(), arg.c_str());
+        sh.errorf("kill: %s: invalid signal specification\n", arg.c_str());
         return 1;
       }
     } else {
       // `-INT' / `-9' / `-SIGHUP': the spec is the option itself.
       sig = resolve_sig(opt.substr(1));
       if (sig < 0) {
-        std::fprintf(stderr, "%skill: %s: invalid signal specification\n",
-                     sh.err_prefix().c_str(), opt.substr(1).c_str());
+        sh.errorf("kill: %s: invalid signal specification\n", opt.substr(1).c_str());
         return 1;
       }
       i = 2;
@@ -5132,7 +5022,7 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
     if (!t.empty() && t[0] == '%') {
       Shell::Job *j = sh.job_by_spec(t);
       if (!j) {
-        std::fprintf(stderr, "%skill: %s: no such job\n", sh.err_prefix().c_str(), t.c_str());
+        sh.errorf("kill: %s: no such job\n", t.c_str());
         st = 1;
         continue;
       }
@@ -5142,15 +5032,13 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
       // signal, so signal each member pid directly.
       if (sh.job_control && j->pgid > 0) {
         if (kill(static_cast<pid_t>(-j->pgid), sig) != 0) {
-          std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(),
-                       static_cast<long>(-j->pgid), std::strerror(errno));
+          sh.errorf("kill: (%ld) - %s\n", static_cast<long>(-j->pgid), std::strerror(errno));
           st = 1;
         }
       } else {
         for (long p : j->pids)
           if (kill(static_cast<pid_t>(p), sig) != 0) {
-            std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(), p,
-                         std::strerror(errno));
+            sh.errorf("kill: (%ld) - %s\n", p, std::strerror(errno));
             st = 1;
           }
       }
@@ -5164,16 +5052,14 @@ int bi_kill(Shell &sh, const std::vector<std::string> &argv) {
       for (; p < t.size(); p++)
         if (!std::isdigit(static_cast<unsigned char>(t[p]))) numeric = false;
       if (!numeric) {
-        std::fprintf(stderr, "%skill: `%s': not a pid or valid job spec\n",
-                     sh.err_prefix().c_str(), t.c_str());
+        sh.errorf("kill: `%s': not a pid or valid job spec\n", t.c_str());
         st = 1;
         continue;
       }
       target = static_cast<pid_t>(std::atol(t.c_str()));
     }
     if (kill(target, sig) != 0) {
-      std::fprintf(stderr, "%skill: (%ld) - %s\n", sh.err_prefix().c_str(),
-                   static_cast<long>(target), std::strerror(errno));
+      sh.errorf("kill: (%ld) - %s\n", static_cast<long>(target), std::strerror(errno));
       st = 1;
     }
   }
@@ -5504,7 +5390,7 @@ int bi_help(Shell &sh, const std::vector<std::string> &argv) {
       else if (a[k] == 'm') mflag = true;
       else {
         std::fflush(stdout);
-        std::fprintf(stderr, "%shelp: -%c: invalid option\n", sh.err_prefix().c_str(), a[k]);
+        sh.errorf("help: -%c: invalid option\n", a[k]);
         std::fprintf(stderr, "help: usage: help [-dms] [pattern ...]\n");
         return 2;
       }
@@ -5611,9 +5497,8 @@ int bi_help(Shell &sh, const std::vector<std::string> &argv) {
     });
     if (hits.empty()) {
       std::fflush(stdout);
-      std::fprintf(stderr,
-                   "%shelp: no help topics match `%s'.  Try `help help' or `man -k %s' or `info %s'.\n",
-                   sh.err_prefix().c_str(), pat.c_str(), pat.c_str(), pat.c_str());
+      sh.errorf("help: no help topics match `%s'.  Try `help help' or `man -k %s' or `info %s'.\n",
+                pat.c_str(), pat.c_str(), pat.c_str());
       st = 1;
       continue;
     }
@@ -5649,8 +5534,7 @@ int bi_builtin(Shell &sh, const std::vector<std::string> &argv) {
   size_t i = 1;
   if (argv[i] == "--") i++;  // `builtin' takes no options besides `--'
   else if (argv[i].size() >= 2 && argv[i][0] == '-') {
-    std::fprintf(stderr, "%sbuiltin: %s: invalid option\n", sh.err_prefix().c_str(),
-                 argv[i].c_str());
+    sh.errorf("builtin: %s: invalid option\n", argv[i].c_str());
     std::fprintf(stderr, "builtin: usage: builtin [shell-builtin [arg ...]]\n");
     return 2;
   }
@@ -5658,8 +5542,7 @@ int bi_builtin(Shell &sh, const std::vector<std::string> &argv) {
   std::vector<std::string> sub(argv.begin() + i, argv.end());
   if (!is_builtin_name(sub[0])) {
     std::fflush(stdout);
-    std::fprintf(stderr, "%sbuiltin: %s: not a shell builtin\n", sh.err_prefix().c_str(),
-                 sub[0].c_str());
+    sh.errorf("builtin: %s: not a shell builtin\n", sub[0].c_str());
     return 1;
   }
   int st = 0;
@@ -5670,7 +5553,7 @@ int bi_builtin(Shell &sh, const std::vector<std::string> &argv) {
 int bi_logout(Shell &sh, const std::vector<std::string> &argv) {
   if (!sh.login_shell) {
     std::fflush(stdout);
-    std::fprintf(stderr, "%slogout: not login shell: use `exit'\n", sh.err_prefix().c_str());
+    sh.errorf("logout: not login shell: use `exit'\n");
     return 1;
   }
   sh.exiting = true;
@@ -5683,7 +5566,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
   // of `hash' -- listing, adding, `-r', or an invalid option -- fails before
   // any processing (hash.def checks hashing_enabled first).
   if (!sh.opt_hashall) {
-    std::fprintf(stderr, "%shash: hashing disabled\n", sh.err_prefix().c_str());
+    sh.errorf("hash: hashing disabled\n");
     return 1;
   }
   bool list_l = false, del_d = false, print_t = false, expunge = false;
@@ -5706,7 +5589,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
         break;
       }
       else {
-        std::fprintf(stderr, "%shash: -%c: invalid option\n", sh.err_prefix().c_str(), o);
+        sh.errorf("hash: -%c: invalid option\n", o);
         std::fprintf(stderr, "hash: usage: hash [-lr] [-p pathname] [-dt] [name ...]\n");
         return 2;
       }
@@ -5715,8 +5598,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
   }
   // `-d'/`-t' each require at least one name operand (bash sh_needarg).
   if (i >= argv.size() && (del_d || print_t)) {
-    std::fprintf(stderr, "%shash: %s: option requires an argument\n", sh.err_prefix().c_str(),
-                 del_d ? "-d" : "-t");
+    sh.errorf("hash: %s: option requires an argument\n", del_d ? "-d" : "-t");
     return 1;
   }
   if (!ppath.empty() && i < argv.size()) {
@@ -5724,19 +5606,16 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
     // relative one cannot be resolved, so neither can be hashed.
     if (sh.opt_restricted) {
       if (ppath.find('/') != std::string::npos)
-        std::fprintf(stderr, "%shash: %s: restricted\n", sh.err_prefix().c_str(),
-                     ppath.c_str());
+        sh.errorf("hash: %s: restricted\n", ppath.c_str());
       else
-        std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(),
-                     ppath.c_str());
+        sh.errorf("hash: %s: not found\n", ppath.c_str());
       return 1;
     }
     // A pathname naming a directory is rejected; a nonexistent file is NOT --
     // `hash -p /nosuchfile cat' stores the bogus path silently (bash).
     struct stat pst;
     if (stat(ppath.c_str(), &pst) == 0 && S_ISDIR(pst.st_mode)) {
-      std::fprintf(stderr, "%shash: %s: Is a directory\n", sh.err_prefix().c_str(),
-                   ppath.c_str());
+      sh.errorf("hash: %s: Is a directory\n", ppath.c_str());
       return 1;
     }
     sh.hash_remember(argv[i], ppath);
@@ -5769,7 +5648,7 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
       sh.hashed_hits.erase(n);
       if (sh.hashed.erase(n) == 0) {
         std::fflush(stdout);
-        std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str());
+        sh.errorf("hash: %s: not found\n", n.c_str());
         st = 1;
       }
       continue;
@@ -5778,13 +5657,13 @@ int bi_hash(Shell &sh, const std::vector<std::string> &argv) {
       const std::string *hp = sh.hash_lookup(n);  // a -t lookup counts as a hit
       // With -l too, -t prints the reusable form (`hash -lt cat' ->
       // `builtin hash -p /path cat'), as bash does.
-      if (hp == nullptr) { std::fflush(stdout); std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str()); st = 1; }
+      if (hp == nullptr) { std::fflush(stdout); sh.errorf("hash: %s: not found\n", n.c_str()); st = 1; }
       else if (list_l) std::printf("builtin hash -p %s %s\n", hp->c_str(), n.c_str());
       else std::printf("%s\n", hp->c_str());
       continue;
     }
     std::string p = find_in_path(sh, n);
-    if (p.empty()) { std::fflush(stdout); std::fprintf(stderr, "%shash: %s: not found\n", sh.err_prefix().c_str(), n.c_str()); st = 1; }
+    if (p.empty()) { std::fflush(stdout); sh.errorf("hash: %s: not found\n", n.c_str()); st = 1; }
     else sh.hash_remember(n, p);
   }
   return st;
@@ -5836,16 +5715,14 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
         case 'p': print_p = true; break;
         case 'o': o_names = true; break;
         default:
-          std::fprintf(stderr, "%sshopt: -%c: invalid option\n",
-                       sh.err_prefix().c_str(), a[k]);
+          sh.errorf("shopt: -%c: invalid option\n", a[k]);
           std::fprintf(stderr, "shopt: usage: shopt [-pqsu] [-o] [optname ...]\n");
           return 2;
       }
     }
   }
   if (set_s && unset_u) {
-    std::fprintf(stderr, "%sshopt: cannot set and unset shell options simultaneously\n",
-                 sh.err_prefix().c_str());
+    sh.errorf("shopt: cannot set and unset shell options simultaneously\n");
     return 1;
   }
 
@@ -5873,8 +5750,7 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
         if (o.first == n) { found = true; cur = o.second; }
       if (!found) {
         if (!quiet_q)
-          std::fprintf(stderr, "%sshopt: %s: invalid option name\n",
-                       sh.err_prefix().c_str(), n.c_str());
+          sh.errorf("shopt: %s: invalid option name\n", n.c_str());
         st = 1;
         continue;
       }
@@ -5910,7 +5786,7 @@ int bi_shopt(Shell &sh, const std::vector<std::string> &argv) {
     if (it == sh.shopt_opts.end()) {
       if (!quiet_q) {
         std::fflush(stdout);
-        std::fprintf(stderr, "%sshopt: %s: invalid shell option name\n", sh.err_prefix().c_str(), n.c_str());
+        sh.errorf("shopt: %s: invalid shell option name\n", n.c_str());
       }
       st = 1;
       continue;
@@ -6000,7 +5876,7 @@ int bi_ulimit(Shell &sh, const std::vector<std::string> &argv) {
     const UlimitRes *r = nullptr;
     for (const auto &e : kUlimits) if (e.opt == o) { r = &e; break; }
     if (!r) {
-      std::fprintf(stderr, "%sulimit: -%c: invalid option\n", sh.err_prefix().c_str(), o);
+      sh.errorf("ulimit: -%c: invalid option\n", o);
       std::fprintf(stderr, "ulimit: usage: ulimit [-SHabcdefiklmnpqrstuvxPRT] [limit]\n");
       return 2;
     }
@@ -6018,8 +5894,7 @@ int bi_ulimit(Shell &sh, const std::vector<std::string> &argv) {
   if (value != "unlimited" && value != "hard" && value != "soft") {
     for (char c : value)
       if (c < '0' || c > '9') {
-        std::fprintf(stderr, "%sulimit: %s: invalid number\n", sh.err_prefix().c_str(),
-                     value.c_str());
+        sh.errorf("ulimit: %s: invalid number\n", value.c_str());
         return 1;
       }
   }
@@ -6038,8 +5913,7 @@ int bi_ulimit(Shell &sh, const std::vector<std::string> &argv) {
     if (setrlimit(r->res, &rl) != 0) {
       // bash names the resource: `ulimit: max user processes: cannot modify
       // limit: Operation not permitted'.
-      std::fprintf(stderr, "%sulimit: %s: cannot modify limit: %s\n",
-                   sh.err_prefix().c_str(), r->desc, std::strerror(errno));
+      sh.errorf("ulimit: %s: cannot modify limit: %s\n", r->desc, std::strerror(errno));
       return 1;
     }
   }
@@ -6081,7 +5955,7 @@ int bi_enable(Shell &sh, const std::vector<std::string> &argv) {
   for (; i < argv.size(); i++) {
     const std::string &n = argv[i];
     if (!is_builtin_name(n)) {
-      std::fprintf(stderr, "%senable: %s: not a shell builtin\n", sh.err_prefix().c_str(), n.c_str());
+      sh.errorf("enable: %s: not a shell builtin\n", n.c_str());
       st = 1;
       continue;
     }
@@ -6089,8 +5963,7 @@ int bi_enable(Shell &sh, const std::vector<std::string> &argv) {
     // builtin is static, so the request always fails as bash's does for a
     // compiled-in builtin.
     if (del) {
-      std::fprintf(stderr, "%senable: %s: not dynamically loaded\n", sh.err_prefix().c_str(),
-                   n.c_str());
+      sh.errorf("enable: %s: not dynamically loaded\n", n.c_str());
       st = 1;
       continue;
     }
@@ -6110,8 +5983,7 @@ int bi_caller(Shell &sh, const std::vector<std::string> &argv) {
   // no_options: a leading `-X' (anything but a bare `--') is an invalid option.
   if (ai < argv.size() && argv[ai].size() >= 1 && argv[ai][0] == '-' &&
       argv[ai] != "--") {
-    std::fprintf(stderr, "%scaller: %s: invalid option\n",
-                 sh.err_prefix().c_str(), argv[ai].c_str());
+    sh.errorf("caller: %s: invalid option\n", argv[ai].c_str());
     std::fprintf(stderr, "%s", kUsage);
     return 2;
   }
@@ -6140,8 +6012,7 @@ int bi_caller(Shell &sh, const std::vector<std::string> &argv) {
   for (size_t k = d; k < e; k++)
     if (!std::isdigit(static_cast<unsigned char>(w[k]))) { valid = false; break; }
   if (!valid) {
-    std::fprintf(stderr, "%scaller: %s: invalid number\n",
-                 sh.err_prefix().c_str(), w.c_str());
+    sh.errorf("caller: %s: invalid number\n", w.c_str());
     std::fprintf(stderr, "%s", kUsage);
     return 2;
   }
@@ -6171,8 +6042,7 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
     if (argv[i] == "-p") { i++; continue; }
     if (sh.is_zsh() && argv[i] == "-g") { kind = 'g'; i++; continue; }
     if (sh.is_zsh() && argv[i] == "-s") { kind = 's'; i++; continue; }
-    std::fprintf(stderr, "%salias: %s: invalid option\n", sh.err_prefix().c_str(),
-                 argv[i].c_str());
+    sh.errorf("alias: %s: invalid option\n", argv[i].c_str());
     std::fprintf(stderr, "alias: usage: alias [-p] [name[=value] ... ]\n");
     return 2;
   }
@@ -6200,7 +6070,7 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
         show(it->first, it->second);
       else {
         std::fflush(stdout);
-        std::fprintf(stderr, "%salias: %s: not found\n", sh.err_prefix().c_str(), a.c_str());
+        sh.errorf("alias: %s: not found\n", a.c_str());
         st = 1;
       }
     } else {
@@ -6208,8 +6078,7 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
       // bash refuses names containing metacharacters, blanks, quoting
       // characters, `$', or `/' (valid_alias_name); zsh has no such check.
       if (!sh.is_zsh() && !Shell::valid_alias_name(name)) {
-        std::fprintf(stderr, "%salias: `%s': invalid alias name\n", sh.err_prefix().c_str(),
-                     name.c_str());
+        sh.errorf("alias: `%s': invalid alias name\n", name.c_str());
         st = 1;
         continue;
       }
@@ -6229,8 +6098,7 @@ int bi_unalias(Shell &sh, const std::vector<std::string> &argv) {
   while (i < argv.size() && argv[i].size() >= 2 && argv[i][0] == '-' && argv[i] != "--") {
     if (argv[i] == "-a") { all = true; i++; continue; }
     if (sh.is_zsh() && argv[i] == "-s") { suffix = true; i++; continue; }
-    std::fprintf(stderr, "%sunalias: %s: invalid option\n", sh.err_prefix().c_str(),
-                 argv[i].c_str());
+    sh.errorf("unalias: %s: invalid option\n", argv[i].c_str());
     std::fprintf(stderr, "unalias: usage: unalias [-a] name [name ...]\n");
     return 2;
   }
@@ -6256,7 +6124,7 @@ int bi_unalias(Shell &sh, const std::vector<std::string> &argv) {
       removed = r || g;
     }
     if (!removed) {
-      std::fprintf(stderr, "%sunalias: %s: not found\n", sh.err_prefix().c_str(), argv[i].c_str());
+      sh.errorf("unalias: %s: not found\n", argv[i].c_str());
       st = 1;
     }
   }
@@ -6329,8 +6197,7 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
           case 's': stash = true; break;
           case 'p': expand = true; break;
           default:
-            std::fprintf(stderr, "%shistory: -%c: invalid option\n",
-                         sh.err_prefix().c_str(), a[k]);
+            sh.errorf("history: -%c: invalid option\n", a[k]);
             std::fprintf(stderr, "%s\n", kUsage);
             return 2;
         }
@@ -6342,8 +6209,7 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
   for (; i < argv.size(); i++) rest.push_back(argv[i]);
 
   if (app + wr + rd + nw > 1) {
-    std::fprintf(stderr, "%shistory: cannot use more than one of -anrw\n",
-                 sh.err_prefix().c_str());
+    sh.errorf("history: cannot use more than one of -anrw\n");
     return 2;
   }
 
@@ -6362,8 +6228,7 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
     int lo, hi;
     if (e1 != d.c_str() && *e1 == '\0') {           // single offset
       if (!resolve(v1, lo)) {
-        std::fprintf(stderr, "%shistory: %s: history position out of range\n",
-                     sh.err_prefix().c_str(), d.c_str());
+        sh.errorf("history: %s: history position out of range\n", d.c_str());
         return 2;
       }
       HIST_ENTRY *old = remove_history(lo);
@@ -6376,13 +6241,11 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
       long v2 = std::strtol(p2, &e2, 10);
       if (e2 != p2 && *e2 == '\0') {
         if (!resolve(v1, lo)) {
-          std::fprintf(stderr, "%shistory: %ld: history position out of range\n",
-                       sh.err_prefix().c_str(), v1);
+          sh.errorf("history: %ld: history position out of range\n", v1);
           return 2;
         }
         if (!resolve(v2, hi)) {
-          std::fprintf(stderr, "%shistory: %ld: history position out of range\n",
-                       sh.err_prefix().c_str(), v2);
+          sh.errorf("history: %ld: history position out of range\n", v2);
           return 2;
         }
         if (hi < lo) { int t = lo; lo = hi; hi = t; }
@@ -6393,12 +6256,10 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
         return 0;
       }
       // Range-shaped but the end does not parse: report the whole token.
-      std::fprintf(stderr, "%shistory: %s: history position out of range\n",
-                   sh.err_prefix().c_str(), d.c_str());
+      sh.errorf("history: %s: history position out of range\n", d.c_str());
       return 2;
     }
-    std::fprintf(stderr, "%shistory: %s: invalid number\n", sh.err_prefix().c_str(),
-                 d.c_str());
+    sh.errorf("history: %s: invalid number\n", d.c_str());
     return 2;
   }
   if (stash) {
@@ -6413,8 +6274,7 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
       char *e = nullptr;
       int hr = history_expand(const_cast<char *>(a.c_str()), &e);
       if (hr < 0) {
-        std::fprintf(stderr, "%shistory: %s: history expansion failed\n",
-                     sh.err_prefix().c_str(), a.c_str());
+        sh.errorf("history: %s: history expansion failed\n", a.c_str());
         st = 1;
       } else if (e) {
         std::printf("%s\n", e);
@@ -6435,15 +6295,14 @@ int bi_history(Shell &sh, const std::vector<std::string> &argv) {
 
   if (rest.size() > 1) {
     // The listing form takes at most one count (`history 10 42' errors).
-    std::fprintf(stderr, "%shistory: too many arguments\n", sh.err_prefix().c_str());
+    sh.errorf("history: too many arguments\n");
     return 2;
   }
   if (!rest.empty()) {
     char *e = nullptr;
     long v = std::strtol(rest[0].c_str(), &e, 10);
     if (e == rest[0].c_str() || *e != '\0' || v < 0) {
-      std::fprintf(stderr, "%shistory: %s: numeric argument required\n",
-                   sh.err_prefix().c_str(), rest[0].c_str());
+      sh.errorf("history: %s: numeric argument required\n", rest[0].c_str());
       return 2;
     }
     limit = static_cast<int>(v);
@@ -6487,8 +6346,7 @@ int bi_fc(Shell &sh, const std::vector<std::string> &argv) {
           else if (i + 1 < argv.size()) { ename = argv[i + 1]; consumed_next = true; }
           break;
         default:
-          std::fprintf(stderr, "%sfc: -%c: invalid option\n", sh.err_prefix().c_str(),
-                       a[k]);
+          sh.errorf("fc: -%c: invalid option\n", a[k]);
           std::fprintf(stderr, "%s\n", kUsage);
           return 2;
       }
@@ -6511,12 +6369,11 @@ int bi_fc(Shell &sh, const std::vector<std::string> &argv) {
   if (last_hist < 0) last_hist = 0;
 
   auto no_command = [&]() {
-    std::fprintf(stderr, "%sfc: no command found\n", sh.err_prefix().c_str());
+    sh.errorf("fc: no command found\n");
     return 1;
   };
   auto out_of_range = [&]() {
-    std::fprintf(stderr, "%sfc: history specification out of range\n",
-                 sh.err_prefix().c_str());
+    sh.errorf("fc: history specification out of range\n");
     return 1;
   };
 
@@ -6822,7 +6679,7 @@ int bi_compgen(Shell &sh, const std::vector<std::string> &argv) {
       std::string act = optarg(a);
       if (!compgen_valid_action(act)) {
         std::fflush(stdout);
-        std::fprintf(stderr, "%scompgen: %s: invalid action name\n", sh.err_prefix().c_str(), act.c_str());
+        sh.errorf("compgen: %s: invalid action name\n", act.c_str());
         return 1;
       }
       actions.push_back(act);
@@ -6830,7 +6687,7 @@ int bi_compgen(Shell &sh, const std::vector<std::string> &argv) {
       std::string opt = optarg(a);
       if (!compgen_valid_option(opt)) {
         std::fflush(stdout);
-        std::fprintf(stderr, "%scompgen: %s: invalid option name\n", sh.err_prefix().c_str(), opt.c_str());
+        sh.errorf("compgen: %s: invalid option name\n", opt.c_str());
         return 1;
       }
     } else if (o == 'G' || o == 'F' || o == 'C') {
@@ -6840,14 +6697,14 @@ int bi_compgen(Shell &sh, const std::vector<std::string> &argv) {
         if (const char *ac = compgen_short_action(a[j])) actions.push_back(ac);
     } else {
       std::fflush(stdout);
-      std::fprintf(stderr, "%scompgen: -%c: invalid option\n", sh.err_prefix().c_str(), o);
+      sh.errorf("compgen: -%c: invalid option\n", o);
       std::fprintf(stderr, "%s", kUsage);
       return 2;
     }
   }
   if (has_var && !valid_identifier(varname)) {
     std::fflush(stdout);
-    std::fprintf(stderr, "%scompgen: `%s': not a valid identifier\n", sh.err_prefix().c_str(), varname.c_str());
+    sh.errorf("compgen: `%s': not a valid identifier\n", varname.c_str());
     return 1;
   }
   if (i < argv.size()) word = argv[i];
@@ -6924,8 +6781,7 @@ int bi_complete(Shell &sh, const std::vector<std::string> &argv) {
           if (const char *act = short_action(o)) act_set.insert(act);
           else {
             std::fflush(stdout);
-            std::fprintf(stderr, "%scomplete: -%c: invalid option\n",
-                         sh.err_prefix().c_str(), o);
+            sh.errorf("complete: -%c: invalid option\n", o);
             std::fprintf(stderr, "%s", kUsage);
             return 2;
           }
@@ -6945,8 +6801,7 @@ int bi_complete(Shell &sh, const std::vector<std::string> &argv) {
           ord.erase(std::remove(ord.begin(), ord.end(), n), ord.end());
         } else {
           std::fflush(stdout);
-          std::fprintf(stderr, "%scomplete: %s: no completion specification\n",
-                       sh.err_prefix().c_str(), n.c_str());
+          sh.errorf("complete: %s: no completion specification\n", n.c_str());
           return 1;
         }
       }
@@ -7010,8 +6865,7 @@ int bi_complete(Shell &sh, const std::vector<std::string> &argv) {
       if (it != sh.completions.end()) emit(n, it->second);
       else {
         std::fflush(stdout);
-        std::fprintf(stderr, "%scomplete: %s: no completion specification\n",
-                     sh.err_prefix().c_str(), n.c_str());
+        sh.errorf("complete: %s: no completion specification\n", n.c_str());
         st = 1;
       }
     }
@@ -7032,27 +6886,24 @@ int bi_compopt(Shell &sh, const std::vector<std::string> &argv) {
     if ((a == "-o" || a == "+o") && i + 1 < argv.size()) {
       const std::string &opt = argv[++i];
       if (!compgen_valid_option(opt)) {
-        std::fprintf(stderr, "%scompopt: %s: invalid option name\n",
-                     sh.err_prefix().c_str(), opt.c_str());
+        sh.errorf("compopt: %s: invalid option name\n", opt.c_str());
         return 1;
       }
     } else if (a == "-D" || a == "-E" || a == "-I") {
       continue;
     } else if (!a.empty() && (a[0] == '-' || a[0] == '+') && a != "--") {
-      std::fprintf(stderr, "%scompopt: %c%c: invalid option\n",
-                   sh.err_prefix().c_str(), a[0], a.size() > 1 ? a[1] : ' ');
+      sh.errorf("compopt: %c%c: invalid option\n", a[0], a.size() > 1 ? a[1] : ' ');
       return 2;
     }
   }
-  std::fprintf(stderr, "%scompopt: not currently executing completion function\n",
-               sh.err_prefix().c_str());
+  sh.errorf("compopt: not currently executing completion function\n");
   return 1;  // gnash never runs a completion function, so this always applies
 }
 
 // ---- bind ----------------------------------------------------------------
 int bi_bind(Shell &sh, const std::vector<std::string> &argv) {
   if (!sh.interactive)
-    std::fprintf(stderr, "%sbind: warning: line editing not enabled\n", sh.err_prefix().c_str());
+    sh.errorf("bind: warning: line editing not enabled\n");
   for (size_t i = 1; i < argv.size(); i++) {
     const std::string &a = argv[i];
     if (a == "-l") {
@@ -7307,7 +7158,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     } else if (argv.size() - ai > 1) {
       // Extra arguments: status 2, and bash DISCARDS the rest of the command
       // list (the reader continues at the next line) in both modes.
-      std::fprintf(stderr, "%sshift: too many arguments\n", sh.err_prefix().c_str());
+      sh.errorf("shift: too many arguments\n");
       st = 2;
       sh.arith_abort = true;
     } else {
@@ -7321,8 +7172,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         numeric = !a.empty() && end != a.c_str() && *end == '\0';
       }
       if (!numeric) {
-        std::fprintf(stderr, "%sshift: %s: numeric argument required\n",
-                     sh.err_prefix().c_str(), a.c_str());
+        sh.errorf("shift: %s: numeric argument required\n", a.c_str());
         st = 2;
         sh.posix_special_builtin_error(st);  // posix: fatal (errors10.sub)
       } else if (n == 0) {
@@ -7330,15 +7180,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       } else if (n < 0) {
         // A negative count is always out of range (reported regardless of the
         // shift_verbose option), status 1.
-        std::fprintf(stderr, "%sshift: %s: shift count out of range\n",
-                     sh.err_prefix().c_str(), a.c_str());
+        sh.errorf("shift: %s: shift count out of range\n", a.c_str());
         st = 1;
       } else if (n > static_cast<long>(sh.positional.size())) {
         // Too large: silent failure unless `shopt -s shift_verbose' -- which
         // POSIX mode implies (`command shift 12' reports in errors8.sub).
         if (sh.shopt_opts["shift_verbose"] || sh.opt_posix)
-          std::fprintf(stderr, "%sshift: %s: shift count out of range\n",
-                       sh.err_prefix().c_str(), a.c_str());
+          sh.errorf("shift: %s: shift count out of range\n", a.c_str());
         st = 1;
       } else {
         for (long k = 0; k < n; k++) sh.positional.erase(sh.positional.begin());
@@ -7354,15 +7202,14 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     if (argv.size() - ci > 1) {
       // Extra arguments: the shell does NOT exit; status 2 and the rest of
       // the command list is discarded (both modes -- errors.tests).
-      std::fprintf(stderr, "%sexit: too many arguments\n", sh.err_prefix().c_str());
+      sh.errorf("exit: too many arguments\n");
       st = 2;
       sh.arith_abort = true;
     } else if (!a.empty() && (end == a.c_str() || *end != '\0')) {
       // A non-numeric argument is no longer a fatal error: bash reports it
       // and the shell CONTINUES with status 2 (posix mode still treats the
       // special-builtin error as fatal).
-      std::fprintf(stderr, "%sexit: %s: numeric argument required\n",
-                   sh.err_prefix().c_str(), a.c_str());
+      sh.errorf("exit: %s: numeric argument required\n", a.c_str());
       st = 2;
       sh.posix_special_builtin_error(st);
     } else {
@@ -7389,30 +7236,26 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     if (argv.size() - ri > 1) {
       // Extra arguments: status 2, rest of the command list discarded (the
       // function is NOT returned from -- errors.tests, both modes).
-      std::fprintf(stderr, "%sreturn: too many arguments\n", sh.err_prefix().c_str());
+      sh.errorf("return: too many arguments\n");
       st = 2;
       sh.arith_abort = true;
     } else if (badnum) {
       // Non-numeric: report, then RETURN with status 2 in default mode (the
       // function body after it never runs); at top level the can-only-return
       // report still follows.  POSIX: fatal (errors10.sub).
-      std::fprintf(stderr, "%sreturn: %s: numeric argument required\n",
-                   sh.err_prefix().c_str(), argv[ri].c_str());
+      sh.errorf("return: %s: numeric argument required\n", argv[ri].c_str());
       st = 2;
       sh.posix_special_builtin_error(st);
       if (sh.in_function() || sh.source_depth > 0) {
         sh.returning = true;
         sh.exit_status = 2;
       } else if (!sh.exiting) {
-        std::fprintf(stderr,
-                     "%sreturn: can only `return' from a function or sourced script\n",
-                     sh.err_prefix().c_str());
+        sh.errorf("return: can only `return' from a function or sourced script\n");
       }
     } else if (!sh.in_function() && sh.source_depth == 0) {
       // `return' is only meaningful in a function or a sourced script;
       // elsewhere it is an error and must not unwind the current input (bash).
-      std::fprintf(stderr, "%sreturn: can only `return' from a function or sourced script\n",
-                   sh.err_prefix().c_str());
+      sh.errorf("return: can only `return' from a function or sourced script\n");
       st = 1;
       sh.posix_special_builtin_error(st);  // special builtin: fatal in posix
     } else {
@@ -7441,13 +7284,11 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       bbad = argv[bi].empty() || bend == argv[bi].c_str() || *bend != '\0';
     }
     if (argv.size() - bi > 1) {
-      std::fprintf(stderr, "%s%s: too many arguments\n", sh.err_prefix().c_str(),
-                   cmd.c_str());
+      sh.errorf("%s: too many arguments\n", cmd.c_str());
       st = 2;
       sh.arith_abort = true;
     } else if (bbad) {
-      std::fprintf(stderr, "%s%s: %s: numeric argument required\n",
-                   sh.err_prefix().c_str(), cmd.c_str(), argv[bi].c_str());
+      sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), argv[bi].c_str());
       st = 2;
       if (!sh.interactive) {
         sh.exiting = true;
@@ -7459,8 +7300,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     // the rest of the input.  Mirrors builtins/break.def check_loop_level().
     else if (sh.loop_depth == 0) {
       if (!sh.opt_posix)
-        std::fprintf(stderr, "%s%s: only meaningful in a `for', `while', or `until' loop\n",
-                     sh.err_prefix().c_str(), cmd.c_str());
+        sh.errorf("%s: only meaningful in a `for', `while', or `until' loop\n", cmd.c_str());
       st = 0;
     } else {
       int n = 1;
@@ -7474,15 +7314,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // A non-numeric count: bash aborts the command (get_numeric_arg); we
         // report and terminate every enclosing loop, the closest observable
         // approximation without the top-level throw.
-        std::fprintf(stderr, "%s%s: %s: numeric argument required\n",
-                     sh.err_prefix().c_str(), cmd.c_str(), a.c_str());
+        sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), a.c_str());
         sh.break_count = sh.loop_depth;
         st = 1;
       } else if (v <= 0) {
         // A non-positive count breaks out of every enclosing loop (bash sets
         // `breaking = loop_level' for both break and continue), status 1.
-        std::fprintf(stderr, "%s%s: %s: loop count out of range\n",
-                     sh.err_prefix().c_str(), cmd.c_str(), a.c_str());
+        sh.errorf("%s: %s: loop count out of range\n", cmd.c_str(), a.c_str());
         sh.break_count = sh.loop_depth;
         st = 1;
       } else {
@@ -7499,8 +7337,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     // `eval' takes no options besides `--'; a leading `-X' is an error.
     size_t ai = 1;
     if (ai < argv.size() && argv[ai] != "--" && argv[ai].size() >= 2 && argv[ai][0] == '-') {
-      std::fprintf(stderr, "%seval: %s: invalid option\n", sh.err_prefix().c_str(),
-                   argv[ai].c_str());
+      sh.errorf("eval: %s: invalid option\n", argv[ai].c_str());
       std::fprintf(stderr, "eval: usage: eval [arg ...]\n");
       st = 2;
     } else {
@@ -7524,8 +7361,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       if (argv[ai] == "--") { ai++; break; }
       if (argv[ai] == "-p") { pflag = true; if (ai + 1 < argv.size()) ppath = argv[++ai]; continue; }
       if (argv[ai].size() >= 2 && argv[ai][0] == '-') {  // `. -i': unknown option
-        std::fprintf(stderr, "%s%s: %s: invalid option\n", sh.err_prefix().c_str(),
-                     cmd.c_str(), argv[ai].c_str());
+        sh.errorf("%s: %s: invalid option\n", cmd.c_str(), argv[ai].c_str());
         std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
                      cmd.c_str(), cmd.c_str());
         if (status) *status = 2;
@@ -7534,8 +7370,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       break;
     }
     if (ai >= argv.size()) {
-      std::fprintf(stderr, "%s%s: filename argument required\n", sh.err_prefix().c_str(),
-                   cmd.c_str());
+      sh.errorf("%s: filename argument required\n", cmd.c_str());
       std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
                    cmd.c_str(), cmd.c_str());
       if (status) *status = 2;
@@ -7543,8 +7378,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     }
     const std::string &fname = argv[ai];
     if (sh.opt_restricted && fname.find('/') != std::string::npos) {
-      std::fprintf(stderr, "%s%s: %s: restricted\n", sh.err_prefix().c_str(),
-                   cmd.c_str(), fname.c_str());
+      sh.errorf("%s: %s: restricted\n", cmd.c_str(), fname.c_str());
       if (status) *status = 1;
       return true;
     }
@@ -7571,8 +7405,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     } else if (pflag) {
       // `-p' searches only the given path; a miss is a hard failure.
       if (!search(ppath)) {
-        std::fprintf(stderr, "%s%s: %s: file not found\n", sh.err_prefix().c_str(),
-                     cmd.c_str(), fname.c_str());
+        sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
         st = 1;
         giveup = true;
         sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
@@ -7583,8 +7416,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       // and (unshielded) fatal for a non-interactive posix shell.
       const char *penv = std::getenv("PATH");
       if (!search(penv ? penv : "")) {
-        std::fprintf(stderr, "%s%s: %s: file not found\n", sh.err_prefix().c_str(),
-                     cmd.c_str(), fname.c_str());
+        sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
         st = 1;
         giveup = true;
         sh.posix_special_builtin_error(st);
@@ -7669,15 +7501,14 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
           sh.params_set_builtin = saved_params_flag;
         }
       } else {
-        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(),
-                     fname.c_str(), std::strerror(errno));
+        sh.errorf("%s: %s\n", fname.c_str(), std::strerror(errno));
         st = 1;
         sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
       }
     }
   } else if (cmd == "local") {
     if (!sh.in_function()) {
-      std::fprintf(stderr, "%slocal: can only be used in a function\n", sh.err_prefix().c_str());
+      sh.errorf("local: can only be used in a function\n");
       st = 1;
     } else {
       st = bi_declare(sh, argv, true, false);
@@ -7762,8 +7593,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       if (opt_err || consumed_p) { if (opt_err) break; else continue; }
     }
     if (opt_err) {
-      std::fprintf(stderr, "%swait: %s: invalid option\n", sh.err_prefix().c_str(),
-                   badopt.c_str());
+      sh.errorf("wait: %s: invalid option\n", badopt.c_str());
       std::fprintf(stderr, "wait: usage: wait [-fn] [-p var] [id ...]\n");
       st = 2;
     } else {
@@ -7778,8 +7608,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
           Shell::Job *j = sh.job_by_spec(argv[k]);
           if (j) ids.push_back(j->id);
           else {
-            std::fprintf(stderr, "%swait: %s: no such job\n", sh.err_prefix().c_str(),
-                         argv[k].c_str());
+            sh.errorf("wait: %s: no such job\n", argv[k].c_str());
             st = 127;
           }
         }
@@ -7795,8 +7624,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
             // A `%jobspec' that names no job: bash reports it and returns 127.
             Shell::Job *j = sh.job_by_spec(spec);
             if (!j) {
-              std::fprintf(stderr, "%swait: %s: no such job\n",
-                           sh.err_prefix().c_str(), spec.c_str());
+              sh.errorf("wait: %s: no such job\n", spec.c_str());
               st = 127;
               continue;
             }
@@ -7812,8 +7640,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
             for (char c : spec)
               if (!std::isdigit(static_cast<unsigned char>(c))) { numeric = false; break; }
             if (!numeric) {
-              std::fprintf(stderr, "%swait: `%s': not a pid or valid job spec\n",
-                           sh.err_prefix().c_str(), spec.c_str());
+              sh.errorf("wait: `%s': not a pid or valid job spec\n", spec.c_str());
               st = 1;
               continue;
             }
@@ -7839,8 +7666,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
                 sh.reaped_procsub_status.erase(rps);
                 continue;
               }
-              std::fprintf(stderr, "%swait: pid %ld is not a child of this shell\n",
-                           sh.err_prefix().c_str(), pp);
+              sh.errorf("wait: pid %ld is not a child of this shell\n", pp);
               st = 127;
               continue;
             }
@@ -7874,8 +7700,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
           psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
         }
         if (!valid_identifier(base)) {
-          std::fprintf(stderr, "%swait: `%s': not a valid identifier\n",
-                       sh.err_prefix().c_str(), pvar.c_str());
+          sh.errorf("wait: `%s': not a valid identifier\n", pvar.c_str());
           st = 1;
         } else if (found && finished_pid >= 0) {
           if (subscripted) {
@@ -7889,8 +7714,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
           // cannot be unset and is reported as such.
           auto it = sh.vars.find(sh.deref(base));
           if (it != sh.vars.end() && it->second.readonly) {
-            std::fprintf(stderr, "%swait: %s: cannot unset: readonly variable\n",
-                         sh.err_prefix().c_str(), base.c_str());
+            sh.errorf("wait: %s: cannot unset: readonly variable\n", base.c_str());
             st = 1;
           } else {
             sh.unset(pvar);
@@ -7933,19 +7757,18 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     std::string spec = argv.size() > 1 ? argv[1] : "";
     bool cur_spec = spec.empty() || spec == "%" || spec == "%%" || spec == "%+" || spec == "%-";
     if (!sh.job_control && !sh.opt_monitor) {
-      std::fprintf(stderr, "%sfg: no job control\n", sh.err_prefix().c_str());
+      sh.errorf("fg: no job control\n");
       st = 1;
     } else if (sh.no_current_job && cur_spec) {
       // A command-substitution subshell has no current job to bring forward.
-      std::fprintf(stderr, "%sfg: no current jobs\n", sh.err_prefix().c_str());
+      sh.errorf("fg: no current jobs\n");
       st = 1;
     } else if (Shell::Job *j = sh.job_by_spec(spec)) {
       if (!j->monitored) {
         // The job was started when job control was inactive (bash's
         // IS_JOBCONTROL(job) == 0), so it cannot be brought to the foreground
         // even though monitor mode is on now.
-        std::fprintf(stderr, "%sfg: job %d started without job control\n",
-                     sh.err_prefix().c_str(), j->id);
+        sh.errorf("fg: job %d started without job control\n", j->id);
         st = 1;
       } else {
         std::printf("%s\n", j->command.c_str());  // bash echoes the command
@@ -7953,14 +7776,13 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         st = sh.foreground_job(*j, true);
       }
     } else {
-      std::fprintf(stderr, "%sfg: %s: no such job\n", sh.err_prefix().c_str(),
-                   spec.empty() ? "current" : spec.c_str());
+      sh.errorf("fg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
       st = 1;
     }
   } else if (cmd == "bg") {
     std::string spec = argv.size() > 1 ? argv[1] : "";
     if (!sh.job_control) {
-      std::fprintf(stderr, "%sbg: no job control\n", sh.err_prefix().c_str());
+      sh.errorf("bg: no job control\n");
       st = 1;
     } else if (Shell::Job *j = sh.job_by_spec(spec)) {
       sh.background_job(*j, true);
@@ -7968,8 +7790,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       std::fflush(stdout);
       st = 0;
     } else {
-      std::fprintf(stderr, "%sbg: %s: no such job\n", sh.err_prefix().c_str(),
-                   spec.empty() ? "current" : spec.c_str());
+      sh.errorf("bg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
       st = 1;
     }
   } else if (cmd == "disown") {
@@ -8033,7 +7854,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         else if (o[k] == 'V') desc_V = true;
         else if (o[k] == 'p') {  // default PATH; disallowed under restricted
           if (sh.opt_restricted) {
-            std::fprintf(stderr, "%scommand: -p: restricted\n", sh.err_prefix().c_str());
+            sh.errorf("command: -p: restricted\n");
             if (status) *status = 2;
             return true;
           }
@@ -8043,8 +7864,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       if (bad) break;
     }
     if (bad) {
-      std::fprintf(stderr, "%scommand: %s: invalid option\n", sh.err_prefix().c_str(),
-                   badopt.c_str());
+      sh.errorf("command: %s: invalid option\n", badopt.c_str());
       std::fprintf(stderr, "command: usage: command [-pVv] command [arg ...]\n");
       st = 2;
     } else if (desc_V) {
@@ -8086,7 +7906,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     }
   } else if (cmd == "exec") {
     if (sh.opt_restricted) {
-      std::fprintf(stderr, "%sexec: restricted\n", sh.err_prefix().c_str());
+      sh.errorf("exec: restricted\n");
       if (status) *status = 2;
       return true;
     }
@@ -8114,8 +7934,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       if (consumed_next) i++;
     }
     if (bad_opt) {
-      std::fprintf(stderr, "%sexec: %s: invalid option\n", sh.err_prefix().c_str(),
-                   argv[i].c_str());
+      sh.errorf("exec: %s: invalid option\n", argv[i].c_str());
       std::fprintf(stderr, "exec: usage: exec [-cl] [-a name] [command "
                            "[argument ...]] [redirection ...]\n");
       st = 2;
@@ -8178,10 +7997,9 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
         // execve returned: it failed.  bash reports this as "<path>: <error>"
         // (no "exec:" prefix), using the resolved path.
         code = (errno == EACCES) ? 126 : 127;
-        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), full.c_str(),
-                     std::strerror(errno));
+        sh.errorf("%s: %s\n", full.c_str(), std::strerror(errno));
       } else {
-        std::fprintf(stderr, "%sexec: %s: not found\n", sh.err_prefix().c_str(), target.c_str());
+        sh.errorf("exec: %s: not found\n", target.c_str());
       }
       // bash: an interactive shell (or `shopt -s execfail') stays alive and
       // returns failure; a non-interactive shell exits.
@@ -8373,8 +8191,7 @@ struct CondEval {
         char *endp = nullptr;
         long fd = std::strtol(arg.c_str(), &endp, 10);
         if (arg.empty() || *endp != '\0') {
-          std::fprintf(stderr, "%s[[: %s: integer expected\n", sh.err_prefix().c_str(),
-                       arg.c_str());
+          sh.errorf("[[: %s: integer expected\n", arg.c_str());
           synerr = 2;
           return false;
         }
@@ -8435,8 +8252,7 @@ struct CondEval {
           std::string why;
           regex_t *rx = cached_regex(re, &why);
           if (!rx) {
-            std::fprintf(stderr, "%s[[: invalid regular expression `%s': %s\n",
-                         sh.err_prefix().c_str(), re.c_str(), why.c_str());
+            sh.errorf("[[: invalid regular expression `%s': %s\n", re.c_str(), why.c_str());
             synerr = 2;
             return false;
           }

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -4,6 +4,7 @@
 // builtins.cpp -- shell builtins, plus the test/[ and [[ ]] evaluators.
 
 #include "gnash/core/builtins.hpp"
+#include "gnash/core/quote.hpp"
 #include "gnash/core/subscript.hpp"
 
 #include <algorithm>
@@ -282,17 +283,9 @@ std::string shell_quote(const std::string &s, bool altform = false) {
   if (s.empty()) return "''";
   if (q_needs_ansic(s)) return q_ansic(s);
   // The alternate form (printf %#q -> bash sh_single_quote) ALWAYS
-  // single-quotes, even a string needing no quoting, with embedded single
-  // quotes spelled '\''.  ANSI-C quoting above still takes precedence.
-  if (altform) {
-    std::string r = "'";
-    for (char c : s) {
-      if (c == '\'') r += "'\\''";
-      else r += c;
-    }
-    r += '\'';
-    return r;
-  }
+  // single-quotes, even a string needing no quoting.  ANSI-C quoting above
+  // still takes precedence.
+  if (altform) return single_quote(s);
   // Characters bash leaves unescaped, plus alphanumerics; `~' and `#' are only
   // safe when they do not start the string.
   static const char *safe = "#%+-./:=@_~";
@@ -1658,9 +1651,7 @@ std::string xtrace_quote_word(const std::string &w) {
     }
   }
   if (!meta) return w;
-  std::string r = "'";
-  for (char c : w) { if (c == '\'') r += "'\\''"; else r += c; }
-  return r + "'";
+  return single_quote(w);
 }
 
 std::vector<std::string> Shell::dirstack() const {
@@ -2345,48 +2336,14 @@ std::string set_quote(const std::string &v) {
     break;
   }
   if (simple) return v;
-  std::string r = "'";
-  for (char c : v) { if (c == '\'') r += "'\\''"; else r += c; }
-  return r + "'";
-}
-
-std::string set_elem(const std::string &v) {  // array element form: "value"
-  std::string r = "\"";
-  for (char c : v) { if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\'; r += c; }
-  return r + "\"";
+  return single_quote(v);
 }
 
 // Quote a value for `declare -p': ANSI-C ($'...') for non-printable bytes,
 // double quotes otherwise (escaping " \\ $ `).
 std::string declare_quote(const std::string &v) {
   if (q_needs_ansic(v)) return q_ansic(v);
-  std::string r = "\"";
-  for (char c : v) { if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\'; r += c; }
-  return r + "\"";
-}
-
-// True if KEY contains a shell metacharacter (bash's sh_contains_shell_metas),
-// used to decide whether an associative-array subscript must be quoted.
-static bool sub_has_metas(const std::string &s) {
-  for (size_t i = 0; i < s.size(); i++) {
-    switch (s[i]) {
-      case ' ': case '\t': case '\n':
-      case '\'': case '"': case '\\':
-      case '|': case '&': case ';':
-      case '(': case ')': case '<': case '>':
-      case '!': case '{': case '}':
-      case '*': case '[': case '?': case ']':
-      case '^': case '$': case '`':
-        return true;
-      case '~':
-        if (i == 0 || s[i - 1] == '=' || s[i - 1] == ':') return true;
-        break;
-      case '#':
-        if (i == 0) return true;
-        break;
-    }
-  }
-  return false;
+  return double_quote(v);
 }
 
 // Quote an associative-array subscript for `declare -p' the way bash does:
@@ -2394,10 +2351,8 @@ static bool sub_has_metas(const std::string &s) {
 // metacharacter or is the lone `*'/`@' selector, otherwise bare.
 std::string declare_sub_quote(const std::string &k) {
   if (q_needs_ansic(k)) return q_ansic(k);
-  if (!sub_has_metas(k) && k != "*" && k != "@") return k;
-  std::string r = "\"";
-  for (char c : k) { if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\'; r += c; }
-  return r + "\"";
+  if (!contains_shell_metas(k) && k != "*" && k != "@") return k;
+  return double_quote(k);
 }
 
 // `declare -p NAME': the attribute flags plus the reproducible assignment.
@@ -2478,7 +2433,7 @@ void set_print_var(const std::string &name, const Variable &v) {
     for (const auto &kv : v.idx) {
       if (!first) s += ' ';
       first = false;
-      s += "[" + std::to_string(kv.first) + "]=" + set_elem(kv.second);
+      s += "[" + std::to_string(kv.first) + "]=" + double_quote(kv.second);
     }
     std::printf("%s)\n", s.c_str());
   } else if (v.kind == VarKind::Assoc) {
@@ -2487,7 +2442,7 @@ void set_print_var(const std::string &name, const Variable &v) {
     for (const auto &k : Shell::assoc_order(v)) {
       if (!first) s += ' ';
       first = false;
-      s += "[" + declare_sub_quote(k) + "]=" + set_elem(v.assoc.at(k));
+      s += "[" + declare_sub_quote(k) + "]=" + double_quote(v.assoc.at(k));
     }
     // bash prints a trailing space before `)' for a non-empty associative array.
     std::printf("%s%s)\n", s.c_str(), first ? "" : " ");
@@ -6029,12 +5984,6 @@ int bi_caller(Shell &sh, const std::vector<std::string> &argv) {
 }
 
 // ---- alias / unalias -----------------------------------------------------
-static std::string alias_quote(const std::string &v) {
-  std::string r = "'";
-  for (char c : v) { if (c == '\'') r += "'\\''"; else r += c; }
-  return r + "'";
-}
-
 int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
   size_t i = 1;
   char kind = 0;  // 0 = regular; 'g' = global, 's' = suffix (zsh `alias -g'/`-s')
@@ -6052,9 +6001,9 @@ int bi_alias(Shell &sh, const std::vector<std::string> &argv) {
   // list as `name=value'.
   auto show = [&](const std::string &n, const std::string &v) {
     if (kind == 0)
-      std::printf("alias %s=%s\n", n.c_str(), alias_quote(v).c_str());
+      std::printf("alias %s=%s\n", n.c_str(), single_quote(v).c_str());
     else
-      std::printf("%s=%s\n", n.c_str(), alias_quote(v).c_str());
+      std::printf("%s=%s\n", n.c_str(), single_quote(v).c_str());
   };
   if (i >= argv.size()) {
     for (const auto &kv : table) show(kv.first, kv.second);
@@ -6557,13 +6506,6 @@ static const CompActEnt kCompActs[] = {
     {"signal", 0},    {"stopped", 0},   {"user", 'u'},   {"variable", 'v'},
     {nullptr, 0}};
 
-// bash's sh_single_quote: wrap in single quotes, embedded ' becomes '\''.
-static std::string comp_squote(const std::string &s) {
-  std::string r = "'";
-  for (char c : s) { if (c == '\'') r += "'\\''"; else r += c; }
-  return r + "'";
-}
-
 // FNV variant matching bash's hash_string / gnash's assoc_hash_string, so the
 // compspec listing walks the same 512-bucket table order bash does.
 static unsigned comp_hash(const std::string &s) {
@@ -6817,13 +6759,13 @@ int bi_complete(Shell &sh, const std::vector<std::string> &argv) {
     if (e->opt && act_set.count(e->name)) add(std::string("-") + e->opt);
   for (const CompActEnt *e = kCompActs; e->name; e++)  // then long-only -A actions
     if (e->opt == 0 && act_set.count(e->name)) add(std::string("-A ") + e->name);
-  if (has_g) add("-G " + comp_squote(g_arg));
-  if (has_w) add("-W " + comp_squote(w_arg));
-  if (has_p) add("-P " + comp_squote(p_arg));
-  if (has_s) add("-S " + comp_squote(s_arg));
-  if (has_x) add("-X " + comp_squote(x_arg));
-  if (has_c) add("-C " + comp_squote(c_arg));
-  if (has_f) add("-F " + (sub_has_metas(f_arg) ? comp_squote(f_arg) : f_arg));
+  if (has_g) add("-G " + single_quote(g_arg));
+  if (has_w) add("-W " + single_quote(w_arg));
+  if (has_p) add("-P " + single_quote(p_arg));
+  if (has_s) add("-S " + single_quote(s_arg));
+  if (has_x) add("-X " + single_quote(x_arg));
+  if (has_c) add("-C " + single_quote(c_arg));
+  if (has_f) add("-F " + (contains_shell_metas(f_arg) ? single_quote(f_arg) : f_arg));
 
   auto emit = [&](const std::string &name, const std::string &sp) {
     if (sp.empty()) std::printf("complete %s\n", name.c_str());
@@ -7886,7 +7828,7 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
       for (size_t j = i; j < argv.size(); j++) {
         const std::string &n = argv[j];
         if (aliases_on && sh.aliases.count(n)) {
-          std::printf("alias %s=%s\n", n.c_str(), alias_quote(sh.aliases.at(n)).c_str());
+          std::printf("alias %s=%s\n", n.c_str(), single_quote(sh.aliases.at(n)).c_str());
         } else if (sh.functions.count(n) || is_builtin_name(n) || is_reserved_word(n)) {
           std::printf("%s\n", n.c_str());
         } else if (const std::string *hp = sh.hash_lookup(n)) {

--- a/core/src/builtins.cpp
+++ b/core/src/builtins.cpp
@@ -7035,6 +7035,915 @@ int bi_personality(Shell &sh, const std::vector<std::string> &argv) {
   return 0;
 }
 
+namespace {  // builtins formerly inlined in run_builtin's dispatch
+
+int bi_shift(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  size_t ai = 1;
+  if (ai < argv.size() && argv[ai] == "--") ai++;  // end-of-options marker
+  if (ai < argv.size() && argv[ai] == "--help") {
+    // Help form: the full per-builtin help text is not yet implemented, so
+    // treat it as a no-op success rather than a numeric-argument error.
+    st = 0;
+  } else if (argv.size() - ai > 1) {
+    // Extra arguments: status 2, and bash DISCARDS the rest of the command
+    // list (the reader continues at the next line) in both modes.
+    sh.errorf("shift: too many arguments\n");
+    st = 2;
+    sh.arith_abort = true;
+  } else {
+    long n = 1;
+    std::string a;
+    bool numeric = true;
+    if (ai < argv.size()) {
+      a = argv[ai];
+      char *end = nullptr;
+      n = std::strtol(a.c_str(), &end, 10);
+      numeric = !a.empty() && end != a.c_str() && *end == '\0';
+    }
+    if (!numeric) {
+      sh.errorf("shift: %s: numeric argument required\n", a.c_str());
+      st = 2;
+      sh.posix_special_builtin_error(st);  // posix: fatal (errors10.sub)
+    } else if (n == 0) {
+      st = 0;
+    } else if (n < 0) {
+      // A negative count is always out of range (reported regardless of the
+      // shift_verbose option), status 1.
+      sh.errorf("shift: %s: shift count out of range\n", a.c_str());
+      st = 1;
+    } else if (n > static_cast<long>(sh.positional.size())) {
+      // Too large: silent failure unless `shopt -s shift_verbose' -- which
+      // POSIX mode implies (`command shift 12' reports in errors8.sub).
+      if (sh.shopt_opts["shift_verbose"] || sh.opt_posix)
+        sh.errorf("shift: %s: shift count out of range\n", a.c_str());
+      st = 1;
+    } else {
+      for (long k = 0; k < n; k++) sh.positional.erase(sh.positional.begin());
+      st = 0;
+    }
+  }
+  return st;
+}
+
+int bi_exit(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  size_t ci = 1;
+  if (ci < argv.size() && argv[ci] == "--") ci++;
+  const std::string a = ci < argv.size() ? argv[ci] : std::string();
+  char *end = nullptr;
+  long v = a.empty() ? sh.last_status : std::strtol(a.c_str(), &end, 10);
+  if (argv.size() - ci > 1) {
+    // Extra arguments: the shell does NOT exit; status 2 and the rest of
+    // the command list is discarded (both modes -- errors.tests).
+    sh.errorf("exit: too many arguments\n");
+    st = 2;
+    sh.arith_abort = true;
+  } else if (!a.empty() && (end == a.c_str() || *end != '\0')) {
+    // A non-numeric argument is no longer a fatal error: bash reports it
+    // and the shell CONTINUES with status 2 (posix mode still treats the
+    // special-builtin error as fatal).
+    sh.errorf("exit: %s: numeric argument required\n", a.c_str());
+    st = 2;
+    sh.posix_special_builtin_error(st);
+  } else {
+    sh.exiting = true;
+    sh.exit_status = static_cast<int>(v) & 0xff;
+    st = sh.exit_status;
+    // `exit' inside a function runs the EXIT trap with that function's frame
+    // still active ($FUNCNAME), so snapshot the call stack before it unwinds.
+    if (sh.in_function()) { sh.exit_src_frames = sh.src_frames; sh.have_exit_frames = true; }
+  }
+  return st;
+}
+
+int bi_return(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // Argument validation runs FIRST (bash's get_exitstat): extra arguments
+  // and a non-numeric status are reported even at top level, before the
+  // can-only-return check.
+  size_t ri = 1;
+  if (ri < argv.size() && argv[ri] == "--") ri++;
+  char *rend = nullptr;
+  long rv = 0;
+  bool badnum = false;
+  if (ri < argv.size()) {
+    rv = std::strtol(argv[ri].c_str(), &rend, 10);
+    badnum = argv[ri].empty() || rend == argv[ri].c_str() || *rend != '\0';
+  }
+  if (argv.size() - ri > 1) {
+    // Extra arguments: status 2, rest of the command list discarded (the
+    // function is NOT returned from -- errors.tests, both modes).
+    sh.errorf("return: too many arguments\n");
+    st = 2;
+    sh.arith_abort = true;
+  } else if (badnum) {
+    // Non-numeric: report, then RETURN with status 2 in default mode (the
+    // function body after it never runs); at top level the can-only-return
+    // report still follows.  POSIX: fatal (errors10.sub).
+    sh.errorf("return: %s: numeric argument required\n", argv[ri].c_str());
+    st = 2;
+    sh.posix_special_builtin_error(st);
+    if (sh.in_function() || sh.source_depth > 0) {
+      sh.returning = true;
+      sh.exit_status = 2;
+    } else if (!sh.exiting) {
+      sh.errorf("return: can only `return' from a function or sourced script\n");
+    }
+  } else if (!sh.in_function() && sh.source_depth == 0) {
+    // `return' is only meaningful in a function or a sourced script;
+    // elsewhere it is an error and must not unwind the current input (bash).
+    sh.errorf("return: can only `return' from a function or sourced script\n");
+    st = 1;
+    sh.posix_special_builtin_error(st);  // special builtin: fatal in posix
+  } else {
+    sh.returning = true;
+    // A BARE `return' inside a signal trap action reports $? from before the
+    // trap ran -- the action cannot change it (posix interp 1602) -- unless
+    // the action called a function we are still inside.  An explicit
+    // argument always wins.
+    int bare = (sh.trap_ret_depth >= 0 && sh.nest_depth() == sh.trap_ret_depth)
+                   ? sh.trap_saved_status
+                   : sh.last_status;
+    sh.exit_status = ri < argv.size() ? (static_cast<int>(rv) & 0xff) : bare;
+    st = sh.exit_status;
+  }
+  return st;
+}
+
+int bi_break_continue(Shell &sh, const std::vector<std::string> &argv) {
+  const std::string &cmd = argv[0];
+  int st = 0;
+  // Argument validation runs before the loop-level check (bash): extra
+  // arguments discard the rest of the list with status 2, and a
+  // non-numeric count is FATAL to any non-interactive shell in BOTH modes
+  // (`break x' ends the script -- errors4.sub, errors10.sub).
+  size_t bi = 1;
+  if (bi < argv.size() && argv[bi] == "--") bi++;
+  char *bend = nullptr;
+  bool bbad = false;
+  if (bi < argv.size()) {
+    std::strtol(argv[bi].c_str(), &bend, 10);
+    bbad = argv[bi].empty() || bend == argv[bi].c_str() || *bend != '\0';
+  }
+  if (argv.size() - bi > 1) {
+    sh.errorf("%s: too many arguments\n", cmd.c_str());
+    st = 2;
+    sh.arith_abort = true;
+  } else if (bbad) {
+    sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), argv[bi].c_str());
+    st = 2;
+    if (!sh.interactive) {
+      sh.exiting = true;
+      sh.exit_status = 2;
+    }
+  }
+  // Outside any loop bash prints a diagnostic (suppressed under `set -o
+  // posix') and succeeds without unwinding, rather than silently swallowing
+  // the rest of the input.  Mirrors builtins/break.def check_loop_level().
+  else if (sh.loop_depth == 0) {
+    if (!sh.opt_posix)
+      sh.errorf("%s: only meaningful in a `for', `while', or `until' loop\n", cmd.c_str());
+    st = 0;
+  } else {
+    int n = 1;
+    // Skip a leading `--' end-of-options marker (`break -- 5').
+    size_t ci = 1;
+    if (ci < argv.size() && argv[ci] == "--") ci++;
+    const std::string a = ci < argv.size() ? argv[ci] : std::string();
+    char *end = nullptr;
+    long v = a.empty() ? 1 : std::strtol(a.c_str(), &end, 10);
+    if (!a.empty() && (end == a.c_str() || *end != '\0')) {
+      // A non-numeric count: bash aborts the command (get_numeric_arg); we
+      // report and terminate every enclosing loop, the closest observable
+      // approximation without the top-level throw.
+      sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), a.c_str());
+      sh.break_count = sh.loop_depth;
+      st = 1;
+    } else if (v <= 0) {
+      // A non-positive count breaks out of every enclosing loop (bash sets
+      // `breaking = loop_level' for both break and continue), status 1.
+      sh.errorf("%s: %s: loop count out of range\n", cmd.c_str(), a.c_str());
+      sh.break_count = sh.loop_depth;
+      st = 1;
+    } else {
+      // Requesting more levels than are active caps at the outermost loop, so
+      // the remaining count never unwinds past the loop nest.
+      n = static_cast<int>(v);
+      if (n > sh.loop_depth) n = sh.loop_depth;
+      if (cmd == "break") sh.break_count = n;
+      else sh.continue_count = n;
+      st = 0;
+    }
+  }
+  return st;
+}
+
+int bi_eval(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // `eval' takes no options besides `--'; a leading `-X' is an error.
+  size_t ai = 1;
+  if (ai < argv.size() && argv[ai] != "--" && argv[ai].size() >= 2 && argv[ai][0] == '-') {
+    sh.errorf("eval: %s: invalid option\n", argv[ai].c_str());
+    std::fprintf(stderr, "eval: usage: eval [arg ...]\n");
+    st = 2;
+  } else {
+    if (ai < argv.size() && argv[ai] == "--") ai++;
+    std::string saved_ctx = sh.error_context;
+    sh.error_context = "eval";  // parse errors report `NAME: eval: line N: ...'
+    // $LINENO inside eval continues from the eval command's line (bash), so an
+    // eval on line 42 whose body is `echo $LINENO' prints 42.
+    int saved_base = sh.lineno_base;
+    if (sh.cur_lineno > 0) sh.lineno_base = sh.cur_lineno - 1;
+    st = sh.run_string(join(argv, ai));
+    sh.lineno_base = saved_base;
+    sh.error_context = saved_ctx;
+  }
+  return st;
+}
+
+int bi_source(Shell &sh, const std::vector<std::string> &argv) {
+  const std::string &cmd = argv[0];
+  int st = 0;
+  // `-p PATH' gives an explicit colon-separated search path (bash 5.2+).
+  size_t ai = 1;
+  bool pflag = false;
+  std::string ppath;
+  for (; ai < argv.size(); ai++) {
+    if (argv[ai] == "--") { ai++; break; }
+    if (argv[ai] == "-p") { pflag = true; if (ai + 1 < argv.size()) ppath = argv[++ai]; continue; }
+    if (argv[ai].size() >= 2 && argv[ai][0] == '-') {  // `. -i': unknown option
+      sh.errorf("%s: %s: invalid option\n", cmd.c_str(), argv[ai].c_str());
+      std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
+                   cmd.c_str(), cmd.c_str());
+      return 2;
+    }
+    break;
+  }
+  if (ai >= argv.size()) {
+    sh.errorf("%s: filename argument required\n", cmd.c_str());
+    std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
+                 cmd.c_str(), cmd.c_str());
+    return 2;
+  }
+  const std::string &fname = argv[ai];
+  if (sh.opt_restricted && fname.find('/') != std::string::npos) {
+    sh.errorf("%s: %s: restricted\n", cmd.c_str(), fname.c_str());
+    return 1;
+  }
+  // Resolve the file: a name with a slash is used as-is; otherwise search the
+  // `-p' path, or $PATH when the `sourcepath' shopt is on, falling back to the
+  // current directory.
+  std::string path = fname;
+  auto search = [&](const std::string &plist) -> bool {
+    size_t start = 0;
+    while (start <= plist.size()) {
+      size_t e = plist.find(':', start);
+      std::string dir = plist.substr(start, e == std::string::npos ? std::string::npos : e - start);
+      if (dir.empty()) dir = ".";
+      std::string cand = dir + "/" + fname;
+      if (access(cand.c_str(), R_OK) == 0) { path = cand; return true; }
+      if (e == std::string::npos) break;
+      start = e + 1;
+    }
+    return false;
+  };
+  bool giveup = false;
+  if (fname.find('/') != std::string::npos) {
+    // used directly
+  } else if (pflag) {
+    // `-p' searches only the given path; a miss is a hard failure.
+    if (!search(ppath)) {
+      sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
+      st = 1;
+      giveup = true;
+      sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
+    }
+  } else if (sh.opt_posix) {
+    // POSIX `.'/source: search $PATH only -- NO current-directory fallback
+    // even when the file exists there.  A miss is `.: NAME: file not found'
+    // and (unshielded) fatal for a non-interactive posix shell.
+    const char *penv = std::getenv("PATH");
+    if (!search(penv ? penv : "")) {
+      sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
+      st = 1;
+      giveup = true;
+      sh.posix_special_builtin_error(st);
+    }
+  } else if (sh.shopt_opts["sourcepath"] && access(fname.c_str(), R_OK) != 0) {
+    const char *penv = std::getenv("PATH");
+    search(penv ? penv : "");  // on a miss, path stays fname (current directory)
+  }
+  if (!giveup) {
+    std::ifstream f(path);
+    if (f) {
+      std::ostringstream ss; ss << f.rdbuf();
+      // Extra arguments become the sourced file's positional parameters
+      // (`. file a b'); with none, it inherits the caller's positionals.
+      std::vector<std::string> saved_pos;
+      bool set_pos = argv.size() > ai + 1;
+      bool saved_params_flag = sh.params_set_builtin;
+      if (set_pos) {
+        saved_pos = sh.positional;
+        sh.positional.assign(argv.begin() + ai + 1, argv.end());
+        sh.params_set_builtin = false;
+      }
+      // A sourced file becomes the innermost BASH_SOURCE frame; use the
+      // resolved path (bash records the PATH-found path, not the bare name),
+      // so ${BASH_SOURCE[0]} lets a script locate itself.  The call line is
+      // where `source' appears in the current file.
+      int src_call_line = sh.cur_lineno;  // where `source' appears; see below
+      sh.push_src_frame("source", path, sh.cur_lineno, false);
+      // A sourced file has its own line numbering starting at 1 ($LINENO, the
+      // DEBUG trap, and functions it defines all use the file's own lines).
+      int saved_src_base = sh.lineno_base;
+      sh.lineno_base = 0;
+      // A sourced file does not inherit the DEBUG trap unless functrace is
+      // set (source.def restores the default for the duration).  bash lifts
+      // the suppression in an unwind frame that runs AFTER `source_file',
+      // and `source_file' is what fires the RETURN trap -- so the RETURN
+      // trap's own body produces no DEBUG line either.  Hence the window
+      // below closes past the RETURN trap, not at the end of the file.
+      std::string hidden_debug;
+      bool hid_debug = false;
+      if (!sh.opt_functrace) {
+        auto dit = sh.traps.find("DEBUG");
+        if (dit != sh.traps.end()) {
+          hidden_debug = dit->second;
+          hid_debug = true;
+          sh.traps.erase(dit);
+        }
+      }
+      sh.source_depth++;  // `return' is legal while sourcing
+      st = sh.run_string(ss.str());
+      sh.source_depth--;
+      sh.lineno_base = saved_src_base;
+      // `return' inside a sourced file ends the file (and sets its status),
+      // like reaching EOF -- it must not unwind past `source' or exit the
+      // shell (bash semantics; e.g. /etc/bashrc does `[ -z "$PS1" ] && return').
+      if (sh.returning) { sh.returning = false; st = sh.exit_status; }
+      sh.pop_src_frame();
+      // A sourced file is a FUNCTION FRAME to bash: leaving it fires the
+      // DEBUG and RETURN traps, reporting the line `source' was called on --
+      // exactly as leaving a function body re-reports its definition line.
+      // The frame is already popped, so $FUNCNAME names the caller.
+      {
+        sh.cur_lineno = src_call_line;
+        // Only the RETURN trap is fired here: the DEBUG line that precedes it
+        // is the one its own body produces under functrace, exactly as when a
+        // function body returns.
+        //
+        // Unlike a function, a sourced file does NOT gate this on functrace:
+        // `source_file' runs the trap unconditionally, so a `source' at top
+        // level fires it either way.  Inside a function it follows the
+        // function's own rule, because that is where bash restored the
+        // default trap.  See Shell::return_trap_fires().
+        if (sh.return_trap_fires()) sh.run_return_trap(st);
+      }
+      // Restore the DEBUG trap -- but only if the sourced file did not set
+      // one of its own, which is what bash's trap_if_untrapped() amounts to.
+      if (hid_debug && !sh.traps.count("DEBUG")) sh.traps["DEBUG"] = hidden_debug;
+      // Restore the caller's parameters UNLESS the sourced script ran the
+      // `set' builtin at top level -- then its parameters stick (bash).
+      if (set_pos) {
+        if (!(!sh.in_function() && sh.params_set_builtin)) sh.positional = saved_pos;
+        sh.params_set_builtin = saved_params_flag;
+      }
+    } else {
+      sh.errorf("%s: %s\n", fname.c_str(), std::strerror(errno));
+      st = 1;
+      sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
+    }
+  }
+  return st;
+}
+
+int bi_wait(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // Options: -f (wait for termination, not just a status change), -n (return
+  // after the next job finishes) and -p VAR (store the finished job's pid in
+  // VAR).  A leading `-<digit>' is a (negative) id, not an option.
+  bool nflag = false, have_p = false, opt_err = false;
+  std::string pvar, badopt;
+  size_t ai = 1;
+  for (; ai < argv.size(); ai++) {
+    const std::string &o = argv[ai];
+    if (o == "--") { ai++; break; }
+    if (o.size() < 2 || o[0] != '-' ||
+        std::isdigit(static_cast<unsigned char>(o[1])))
+      break;
+    bool consumed_p = false;
+    for (size_t k = 1; k < o.size() && !opt_err; k++) {
+      char c = o[k];
+      if (c == 'n') nflag = true;
+      else if (c == 'f') { /* no async status tracking: -f is a no-op here */ }
+      else if (c == 'p') {
+        have_p = true;
+        if (k + 1 < o.size()) pvar = o.substr(k + 1);
+        else if (ai + 1 < argv.size()) pvar = argv[++ai];
+        consumed_p = true;
+        break;
+      } else { opt_err = true; badopt = std::string("-") + c; }
+    }
+    if (opt_err || consumed_p) { if (opt_err) break; else continue; }
+  }
+  if (opt_err) {
+    sh.errorf("wait: %s: invalid option\n", badopt.c_str());
+    std::fprintf(stderr, "wait: usage: wait [-fn] [-p var] [id ...]\n");
+    st = 2;
+  } else {
+    long finished_pid = -1;
+    bool found = false;
+    if (nflag) {
+      // `-n': return after the NEXT of the named jobs finishes (or any job
+      // when none are named).  Resolve each id to a job; an unknown `%spec'
+      // reports "no such job" but the wait proceeds with the rest.
+      std::vector<int> ids;
+      for (size_t k = ai; k < argv.size(); k++) {
+        Shell::Job *j = sh.job_by_spec(argv[k]);
+        if (j) ids.push_back(j->id);
+        else {
+          sh.errorf("wait: %s: no such job\n", argv[k].c_str());
+          st = 127;
+        }
+      }
+      // With ids named but none resolvable, there is nothing to wait for.
+      if (ai < argv.size() && ids.empty()) st = 127;
+      else st = sh.wait_next(ids, &finished_pid, &found);
+    } else if (ai < argv.size()) {
+      // Wait for every named id (bash waits for all of them).  The last one's
+      // pid is the -p result.
+      for (size_t k = ai; k < argv.size(); k++) {
+        const std::string &spec = argv[k];
+        if (!spec.empty() && spec[0] == '%') {
+          // A `%jobspec' that names no job: bash reports it and returns 127.
+          Shell::Job *j = sh.job_by_spec(spec);
+          if (!j) {
+            sh.errorf("wait: %s: no such job\n", spec.c_str());
+            st = 127;
+            continue;
+          }
+          int wid = j->id;
+          if (!j->pids.empty()) { finished_pid = j->pids.front(); found = true; }
+          for (long p : j->pids) st = sh.wait_for_pid(p);
+          // A waited-for job is consumed: bash removes it so its number frees
+          // up for reuse by the next async job.
+          sh.remove_jobs_if([wid](const Shell::Job &x) { return x.id == wid; });
+        } else {
+          // Anything not a `%jobspec' must be a decimal pid.
+          bool numeric = !spec.empty();
+          for (char c : spec)
+            if (!std::isdigit(static_cast<unsigned char>(c))) { numeric = false; break; }
+          if (!numeric) {
+            sh.errorf("wait: `%s': not a pid or valid job spec\n", spec.c_str());
+            st = 1;
+            continue;
+          }
+          long pp = std::atol(spec.c_str());
+          Shell::Job *pj = sh.job_by_spec(spec);
+          if (!pj) {
+            // A process-substitution child is waitable too, though it is not
+            // a job: `cat <(exit 123); wait "$!"' reports 123 (procsub1.sub).
+            bool is_procsub = false;
+            for (const auto &ps : sh.procsubs)
+              if (ps.pid == pp) { is_procsub = true; break; }
+            if (is_procsub) {
+              st = sh.wait_for_pid(pp);
+              finished_pid = pp;
+              found = true;
+              continue;
+            }
+            auto rps = sh.reaped_procsub_status.find(pp);
+            if (rps != sh.reaped_procsub_status.end()) {
+              st = rps->second;
+              finished_pid = pp;
+              found = true;
+              sh.reaped_procsub_status.erase(rps);
+              continue;
+            }
+            sh.errorf("wait: pid %ld is not a child of this shell\n", pp);
+            st = 127;
+            continue;
+          }
+          int wid = pj->id;
+          st = sh.wait_for_pid(pp);
+          finished_pid = pp;
+          found = true;
+          // The waited-for job is consumed once it is fully done, so its
+          // number frees up for reuse (bash removes it after `wait pid').
+          sh.remove_jobs_if(
+              [wid](const Shell::Job &x) { return x.id == wid && x.done; });
+        }
+      }
+    } else if (!have_p) {
+      st = sh.wait_all();
+    } else {
+      // `-p var' with no ids and no `-n': reap without blocking; the var is
+      // left unset (bash) when no job supplied a pid.
+      sh.reap_jobs(false);
+      st = 0;
+    }
+    // -p VAR: store the finished pid, or unset VAR when no job was waited for.
+    // The name is validated like other builtins, and an array-element
+    // subscript is arithmetic (a bad one raises bash's arithmetic diagnostic).
+    if (have_p) {
+      auto lb = pvar.find('[');
+      std::string base = pvar, psub;
+      bool subscripted = lb != std::string::npos && !pvar.empty() && pvar.back() == ']';
+      if (subscripted) {
+        base = pvar.substr(0, lb);
+        psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
+      }
+      if (!valid_identifier(base)) {
+        sh.errorf("wait: `%s': not a valid identifier\n", pvar.c_str());
+        st = 1;
+      } else if (found && finished_pid >= 0) {
+        if (subscripted) {
+          if (!sh.array_expand_once_ok(base, psub)) st = 1;  // arith error printed
+          else sh.array_set(base, psub, std::to_string(finished_pid));
+        } else {
+          sh.set(pvar, std::to_string(finished_pid));
+        }
+      } else if (!subscripted) {
+        // No job finished: bash unsets the -p variable.  A readonly target
+        // cannot be unset and is reported as such.
+        auto it = sh.vars.find(sh.deref(base));
+        if (it != sh.vars.end() && it->second.readonly) {
+          sh.errorf("wait: %s: cannot unset: readonly variable\n", base.c_str());
+          st = 1;
+        } else {
+          sh.unset(pvar);
+        }
+      }
+    }
+  }
+  return st;
+}
+
+int bi_jobs(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // jobs [-lnprs] [jobspec]: -l long (with pgid), -p pids only, -r running
+  // only, -s stopped only, -n changed-only (we have no async change tracking).
+  bool jl = false, jp = false, jr = false, js = false;
+  std::string jspec;
+  bool jbad = false;
+  for (size_t k = 1; k < argv.size(); k++) {
+    const std::string &o = argv[k];
+    if (o == "--") continue;
+    if (o.size() >= 2 && o[0] == '-' && o[1] != '%') {
+      for (size_t c = 1; c < o.size(); c++) {
+        switch (o[c]) {
+          case 'l': jl = true; break;
+          case 'p': jp = true; break;
+          case 'r': jr = true; break;
+          case 's': js = true; break;
+          case 'n': break;  // no async change tracking: nothing extra to show
+          default: jbad = true; break;
+        }
+      }
+    } else {
+      jspec = o;
+    }
+  }
+  if (jbad) {
+    std::fprintf(stderr, "jobs: usage: jobs [-lnprs] [jobspec ...] or jobs -x command [args]\n");
+    st = 1;
+  } else {
+    sh.print_jobs(jspec, jl, jp, jr, js);
+    st = 0;
+  }
+  return st;
+}
+
+int bi_fg(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  std::string spec = argv.size() > 1 ? argv[1] : "";
+  bool cur_spec = spec.empty() || spec == "%" || spec == "%%" || spec == "%+" || spec == "%-";
+  if (!sh.job_control && !sh.opt_monitor) {
+    sh.errorf("fg: no job control\n");
+    st = 1;
+  } else if (sh.no_current_job && cur_spec) {
+    // A command-substitution subshell has no current job to bring forward.
+    sh.errorf("fg: no current jobs\n");
+    st = 1;
+  } else if (Shell::Job *j = sh.job_by_spec(spec)) {
+    if (!j->monitored) {
+      // The job was started when job control was inactive (bash's
+      // IS_JOBCONTROL(job) == 0), so it cannot be brought to the foreground
+      // even though monitor mode is on now.
+      sh.errorf("fg: job %d started without job control\n", j->id);
+      st = 1;
+    } else {
+      std::printf("%s\n", j->command.c_str());  // bash echoes the command
+      std::fflush(stdout);
+      st = sh.foreground_job(*j, true);
+    }
+  } else {
+    sh.errorf("fg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
+    st = 1;
+  }
+  return st;
+}
+
+int bi_bg(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  std::string spec = argv.size() > 1 ? argv[1] : "";
+  if (!sh.job_control) {
+    sh.errorf("bg: no job control\n");
+    st = 1;
+  } else if (Shell::Job *j = sh.job_by_spec(spec)) {
+    sh.background_job(*j, true);
+    std::printf("[%d]+ %s &\n", j->id, j->command.c_str());  // bash echoes it
+    std::fflush(stdout);
+    st = 0;
+  } else {
+    sh.errorf("bg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
+    st = 1;
+  }
+  return st;
+}
+
+int bi_disown(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // disown [-h] [-ar] [jobspec ... | pid ...]: -a all jobs, -r running jobs
+  // only, -h keep the job but mark it to skip SIGHUP.  With no jobspec (and no
+  // -a/-r) it acts on the current job.  We drop disowned jobs from the table
+  // (the -h "keep but no HUP" nuance is not modelled -- we have no HUP-on-exit).
+  bool all = false, running_only = false, hold = false;
+  std::vector<std::string> specs;
+  for (size_t k = 1; k < argv.size(); k++) {
+    const std::string &o = argv[k];
+    if (o.size() >= 2 && o[0] == '-' && o != "--") {
+      for (size_t c = 1; c < o.size(); c++) {
+        if (o[c] == 'a') all = true;
+        else if (o[c] == 'r') running_only = true;
+        else if (o[c] == 'h') hold = true;
+      }
+    } else if (o == "--") {
+      continue;
+    } else {
+      specs.push_back(o);
+    }
+  }
+  std::vector<int> drop;
+  if (all || running_only) {
+    for (const auto &x : sh.jobs)
+      if (!running_only || (x.running && !x.done)) drop.push_back(x.id);
+  } else if (!specs.empty()) {
+    for (const auto &s : specs)
+      if (Shell::Job *j = sh.job_by_spec(s)) drop.push_back(j->id);
+  } else if (Shell::Job *j = sh.job_by_spec("")) {
+    drop.push_back(j->id);
+  }
+  if (!hold) {
+    sh.jobs.erase(std::remove_if(sh.jobs.begin(), sh.jobs.end(),
+                                 [&](const Shell::Job &x) {
+                                   return std::find(drop.begin(), drop.end(), x.id) !=
+                                          drop.end();
+                                 }),
+                  sh.jobs.end());
+  }
+  st = 0;
+  return st;
+}
+
+int bi_command(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  // Execution of `command NAME args' is handled in the executor (run_simple),
+  // which runs NAME through the normal builtin/external path with shell
+  // functions bypassed.  Only the describe forms (-v/-V) and option errors
+  // reach here; the name-lookup helpers this needs live in this file.
+  size_t i = 1;
+  bool desc_v = false, desc_V = false, bad = false;
+  std::string badopt;
+  for (; i < argv.size(); i++) {
+    const std::string &o = argv[i];
+    if (o == "--") { i++; break; }
+    if (o.size() < 2 || o[0] != '-') break;
+    for (size_t k = 1; k < o.size(); k++) {
+      if (o[k] == 'v') desc_v = true;
+      else if (o[k] == 'V') desc_V = true;
+      else if (o[k] == 'p') {  // default PATH; disallowed under restricted
+        if (sh.opt_restricted) {
+          sh.errorf("command: -p: restricted\n");
+          return 2;
+        }
+      }
+      else { bad = true; badopt = std::string("-") + o[k]; break; }
+    }
+    if (bad) break;
+  }
+  if (bad) {
+    sh.errorf("command: %s: invalid option\n", badopt.c_str());
+    std::fprintf(stderr, "command: usage: command [-pVv] command [arg ...]\n");
+    st = 2;
+  } else if (desc_V) {
+    // `command -V NAME...' == `type NAME...', but a not-found name is reported
+    // against `command' (bi_type uses argv[0] for that diagnostic).
+    std::vector<std::string> t = {"command"};
+    t.insert(t.end(), argv.begin() + i, argv.end());
+    st = bi_type(sh, t);
+  } else if (desc_v) {
+    // For each name print the alias definition (reusable form), the name
+    // (function/builtin/keyword), or the full path (hashed, then $PATH);
+    // 0 if all resolved, 1 otherwise.  Like `type', an alias is reported
+    // only when aliases would actually expand, and a hashed path is
+    // reported (and counted as a hit) before any $PATH search.
+    bool aliases_on = sh.interactive;
+    auto eit = sh.shopt_opts.find("expand_aliases");
+    if (eit != sh.shopt_opts.end() && eit->second) aliases_on = true;
+    st = (i < argv.size()) ? 0 : 1;
+    for (size_t j = i; j < argv.size(); j++) {
+      const std::string &n = argv[j];
+      if (aliases_on && sh.aliases.count(n)) {
+        std::printf("alias %s=%s\n", n.c_str(), single_quote(sh.aliases.at(n)).c_str());
+      } else if (sh.functions.count(n) || is_builtin_name(n) || is_reserved_word(n)) {
+        std::printf("%s\n", n.c_str());
+      } else if (const std::string *hp = sh.hash_lookup(n)) {
+        std::printf("%s\n", hp->c_str());
+      } else {
+        std::string p = find_in_path(sh, n);
+        if (!p.empty()) std::printf("%s\n", p.c_str());
+        else st = 1;
+      }
+    }
+  } else {
+    // No -v/-V: execution is handled in run_simple; reached only defensively
+    // (e.g. run_builtin called directly).  Run the target if it is a builtin.
+    std::vector<std::string> rest(argv.begin() + i, argv.end());
+    if (!rest.empty()) run_builtin(sh, rest, &st);
+    else st = 0;
+  }
+  return st;
+}
+
+int bi_exec(Shell &sh, const std::vector<std::string> &argv) {
+  int st = 0;
+  if (sh.opt_restricted) {
+    sh.errorf("exec: restricted\n");
+    return 2;
+  }
+  // Options: -a NAME (argv[0] for the command), -c (empty environment),
+  // -l (login: prefix argv[0] with '-').
+  size_t i = 1;
+  std::string a_name;
+  bool have_a = false, clear_env = false, login = false, bad_opt = false;
+  for (; i < argv.size(); i++) {
+    const std::string &o = argv[i];
+    if (o == "--") { i++; break; }
+    if (o.size() < 2 || o[0] != '-') break;
+    bool consumed_next = false;
+    for (size_t k = 1; k < o.size(); k++) {
+      if (o[k] == 'c') clear_env = true;
+      else if (o[k] == 'l') login = true;
+      else if (o[k] == 'a') {
+        have_a = true;
+        if (k + 1 < o.size()) { a_name = o.substr(k + 1); }
+        else if (i + 1 < argv.size()) { a_name = argv[i + 1]; consumed_next = true; }
+        k = o.size();
+      } else { bad_opt = true; break; }
+    }
+    if (bad_opt) break;
+    if (consumed_next) i++;
+  }
+  if (bad_opt) {
+    sh.errorf("exec: %s: invalid option\n", argv[i].c_str());
+    std::fprintf(stderr, "exec: usage: exec [-cl] [-a name] [command "
+                         "[argument ...]] [redirection ...]\n");
+    st = 2;
+  } else if (i >= argv.size()) {
+    // No command word: `exec' with only options/redirections is a no-op here
+    // (redirections are applied by the caller and made permanent).
+    st = 0;
+  } else {
+    const std::string &target = argv[i];
+    // Resolve through the shell's $PATH (what `type'/normal execution use), so
+    // exec finds exactly what the rest of the shell would run.
+    std::string full;
+    bool found = false;
+    if (target.find('/') != std::string::npos) {
+      full = target;
+      found = true;  // let execve report ENOENT/EACCES for an explicit path
+    } else {
+      std::vector<std::string> m = find_all_in_path(sh, target);
+      if (!m.empty()) { full = m[0]; found = true; }
+      else {
+        // No executable match: if a file by that name merely exists on $PATH,
+        // use it so execve reports the real error (e.g. EACCES), as bash does.
+        std::string path = sh.get("PATH");
+        size_t p = 0;
+        while (p <= path.size()) {
+          size_t q = path.find(':', p);
+          std::string dir = path.substr(p, q == std::string::npos ? std::string::npos : q - p);
+          if (dir.empty()) dir = ".";
+          std::string cand = dir + "/" + target;
+          if (access(cand.c_str(), F_OK) == 0) { full = cand; found = true; break; }
+          if (q == std::string::npos) break;
+          p = q + 1;
+        }
+      }
+    }
+    // argv[0] for the command: -a NAME, else the name as typed; -l adds '-'.
+    std::string a0 = have_a ? a_name : target;
+    if (login) a0 = "-" + a0;
+    std::vector<char *> cargv;
+    cargv.push_back(const_cast<char *>(a0.c_str()));
+    for (size_t j = i + 1; j < argv.size(); j++)
+      cargv.push_back(const_cast<char *>(argv[j].c_str()));
+    cargv.push_back(nullptr);
+    // Pass the shell's current environment (empty under -c) explicitly via
+    // execve, so the live shell's `environ' is never disturbed on failure.
+    std::vector<std::string> envs;
+    if (!clear_env) envs = sh.environ_block();
+    std::vector<char *> envp;
+    for (auto &e : envs) envp.push_back(const_cast<char *>(e.c_str()));
+    envp.push_back(nullptr);
+
+    int code = 127;
+    if (found) {
+      // The process image is about to be replaced, so an interactive
+      // session's history has to reach $HISTFILE now or be lost.  Not from a
+      // subshell: that history belongs to the parent, which will write it.
+      if (sh.interactive && sh.subshell_level == 0) save_shell_history(sh);
+      std::fflush(nullptr);
+      execve(full.c_str(), cargv.data(), envp.data());
+      // execve returned: it failed.  bash reports this as "<path>: <error>"
+      // (no "exec:" prefix), using the resolved path.
+      code = (errno == EACCES) ? 126 : 127;
+      sh.errorf("%s: %s\n", full.c_str(), std::strerror(errno));
+    } else {
+      sh.errorf("exec: %s: not found\n", target.c_str());
+    }
+    // bash: an interactive shell (or `shopt -s execfail') stays alive and
+    // returns failure; a non-interactive shell exits.
+    auto ef = sh.shopt_opts.find("execfail");
+    bool execfail = ef != sh.shopt_opts.end() && ef->second;
+    if (sh.interactive || execfail)
+      st = code;
+    else
+      _exit(code);
+  }
+  return st;
+}
+
+// The builtin table: name -> handler, for every builtin whose whole dispatch
+// is the plain `st = fn(sh, argv)' call.  The builtins that do not fit that
+// shape -- the no-ops, the multiple-name aliases, and the declare family with
+// its extra parameters -- are handled in run_builtin itself; this table is
+// the one place to look when adding a builtin.
+using BiFn = int (*)(Shell &, const std::vector<std::string> &);
+struct BuiltinEntry {
+  const char *name;
+  BiFn fn;
+};
+static const BuiltinEntry kBuiltinTable[] = {
+    {"echo", bi_echo},
+    {"printf", bi_printf},
+    {"pwd", bi_pwd},
+    {"cd", bi_cd},
+    {"dirs", bi_dirs},
+    {"pushd", bi_pushd},
+    {"popd", bi_popd},
+    {"unset", bi_unset},
+    {"set", bi_set},
+    {"read", bi_read},
+    {"shift", bi_shift},
+    {"exit", bi_exit},
+    {"return", bi_return},
+    {"eval", bi_eval},
+    {"let", bi_let},
+    {"type", bi_type},
+    {"help", bi_help},
+    {"builtin", bi_builtin},
+    {"logout", bi_logout},
+    {"hash", bi_hash},
+    {"shopt", bi_shopt},
+    {"ulimit", bi_ulimit},
+    {"enable", bi_enable},
+    {"caller", bi_caller},
+    {"alias", bi_alias},
+    {"unalias", bi_unalias},
+    {"history", bi_history},
+    {"fc", bi_fc},
+    {"compgen", bi_compgen},
+    {"complete", bi_complete},
+    {"compopt", bi_compopt},
+    {"bind", bi_bind},
+    {"trap", bi_trap},
+    {"umask", bi_umask},
+    {"getopts", bi_getopts},
+    {"wait", bi_wait},
+    {"jobs", bi_jobs},
+    {"fg", bi_fg},
+    {"bg", bi_bg},
+    {"disown", bi_disown},
+    {"kill", bi_kill},
+    {"command", bi_command},
+    {"exec", bi_exec},
+};
+
+}  // namespace
+
 bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
   if (argv.empty()) return false;
   const std::string &cmd = argv[0];
@@ -7065,390 +7974,27 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     if (kZshNoops.count(cmd)) { if (status) *status = 0; return true; }
   }
 
-  if (cmd == ":" || cmd == "true") st = 0;
-  else if (cmd == "false") st = 1;
-  else if (cmd == "echo") st = bi_echo(sh, argv);
-  else if (cmd == "printf") st = bi_printf(sh, argv);
-  else if (cmd == "pwd") st = bi_pwd(sh, argv);
-  else if (cmd == "cd") st = bi_cd(sh, argv);
-  else if (cmd == "dirs") st = bi_dirs(sh, argv);
-  else if (cmd == "pushd") st = bi_pushd(sh, argv);
-  else if (cmd == "popd") st = bi_popd(sh, argv);
-  else if (cmd == "mapfile" || cmd == "readarray") st = bi_mapfile(sh, argv);
-  else if (cmd == "export") {
-    st = bi_export(sh, argv);
-    // POSIX: a failing export (invalid identifier, assignment error) is a
-    // special-builtin error, fatal to a non-interactive shell unless run via
-    // `command' (errors11.sub).
-    if (st != 0) sh.posix_special_builtin_error(st);
-  }
-  else if (cmd == "unset") st = bi_unset(sh, argv);
-  else if (cmd == "set") st = bi_set(sh, argv);
-  // `personality' is always available; `emulate' is its zsh-mode alias.
-  else if (cmd == "personality" || (cmd == "emulate" && sh.is_zsh()))
+  // The builtins that do not fit the plain table below: the no-ops, the
+  // multiple-name aliases, and the declare family with its extra parameters.
+  if (cmd == ":" || cmd == "true" || cmd == "times" || cmd == "suspend")
+    st = 0;
+  else if (cmd == "false")
+    st = 1;
+  else if (cmd == "mapfile" || cmd == "readarray")
+    st = bi_mapfile(sh, argv);
+  else if (cmd == "test")
+    st = bi_test(sh, argv, false);
+  else if (cmd == "[")
+    st = bi_test(sh, argv, true);
+  else if (cmd == "break" || cmd == "continue")
+    st = bi_break_continue(sh, argv);
+  else if (cmd == "source" || cmd == ".")
+    st = bi_source(sh, argv);
+  else if (cmd == "personality" || (cmd == "emulate" && sh.is_zsh())) {
+    // `personality' is always available; `emulate' is its zsh-mode alias.
     st = bi_personality(sh, argv);
-  else if (cmd == "read") st = bi_read(sh, argv);
-  else if (cmd == "test") st = bi_test(sh, argv, false);
-  else if (cmd == "[") st = bi_test(sh, argv, true);
-  else if (cmd == "shift") {
-    size_t ai = 1;
-    if (ai < argv.size() && argv[ai] == "--") ai++;  // end-of-options marker
-    if (ai < argv.size() && argv[ai] == "--help") {
-      // Help form: the full per-builtin help text is not yet implemented, so
-      // treat it as a no-op success rather than a numeric-argument error.
-      st = 0;
-    } else if (argv.size() - ai > 1) {
-      // Extra arguments: status 2, and bash DISCARDS the rest of the command
-      // list (the reader continues at the next line) in both modes.
-      sh.errorf("shift: too many arguments\n");
-      st = 2;
-      sh.arith_abort = true;
-    } else {
-      long n = 1;
-      std::string a;
-      bool numeric = true;
-      if (ai < argv.size()) {
-        a = argv[ai];
-        char *end = nullptr;
-        n = std::strtol(a.c_str(), &end, 10);
-        numeric = !a.empty() && end != a.c_str() && *end == '\0';
-      }
-      if (!numeric) {
-        sh.errorf("shift: %s: numeric argument required\n", a.c_str());
-        st = 2;
-        sh.posix_special_builtin_error(st);  // posix: fatal (errors10.sub)
-      } else if (n == 0) {
-        st = 0;
-      } else if (n < 0) {
-        // A negative count is always out of range (reported regardless of the
-        // shift_verbose option), status 1.
-        sh.errorf("shift: %s: shift count out of range\n", a.c_str());
-        st = 1;
-      } else if (n > static_cast<long>(sh.positional.size())) {
-        // Too large: silent failure unless `shopt -s shift_verbose' -- which
-        // POSIX mode implies (`command shift 12' reports in errors8.sub).
-        if (sh.shopt_opts["shift_verbose"] || sh.opt_posix)
-          sh.errorf("shift: %s: shift count out of range\n", a.c_str());
-        st = 1;
-      } else {
-        for (long k = 0; k < n; k++) sh.positional.erase(sh.positional.begin());
-        st = 0;
-      }
-    }
-  } else if (cmd == "exit") {
-    size_t ci = 1;
-    if (ci < argv.size() && argv[ci] == "--") ci++;
-    const std::string a = ci < argv.size() ? argv[ci] : std::string();
-    char *end = nullptr;
-    long v = a.empty() ? sh.last_status : std::strtol(a.c_str(), &end, 10);
-    if (argv.size() - ci > 1) {
-      // Extra arguments: the shell does NOT exit; status 2 and the rest of
-      // the command list is discarded (both modes -- errors.tests).
-      sh.errorf("exit: too many arguments\n");
-      st = 2;
-      sh.arith_abort = true;
-    } else if (!a.empty() && (end == a.c_str() || *end != '\0')) {
-      // A non-numeric argument is no longer a fatal error: bash reports it
-      // and the shell CONTINUES with status 2 (posix mode still treats the
-      // special-builtin error as fatal).
-      sh.errorf("exit: %s: numeric argument required\n", a.c_str());
-      st = 2;
-      sh.posix_special_builtin_error(st);
-    } else {
-      sh.exiting = true;
-      sh.exit_status = static_cast<int>(v) & 0xff;
-      st = sh.exit_status;
-      // `exit' inside a function runs the EXIT trap with that function's frame
-      // still active ($FUNCNAME), so snapshot the call stack before it unwinds.
-      if (sh.in_function()) { sh.exit_src_frames = sh.src_frames; sh.have_exit_frames = true; }
-    }
-  } else if (cmd == "return") {
-    // Argument validation runs FIRST (bash's get_exitstat): extra arguments
-    // and a non-numeric status are reported even at top level, before the
-    // can-only-return check.
-    size_t ri = 1;
-    if (ri < argv.size() && argv[ri] == "--") ri++;
-    char *rend = nullptr;
-    long rv = 0;
-    bool badnum = false;
-    if (ri < argv.size()) {
-      rv = std::strtol(argv[ri].c_str(), &rend, 10);
-      badnum = argv[ri].empty() || rend == argv[ri].c_str() || *rend != '\0';
-    }
-    if (argv.size() - ri > 1) {
-      // Extra arguments: status 2, rest of the command list discarded (the
-      // function is NOT returned from -- errors.tests, both modes).
-      sh.errorf("return: too many arguments\n");
-      st = 2;
-      sh.arith_abort = true;
-    } else if (badnum) {
-      // Non-numeric: report, then RETURN with status 2 in default mode (the
-      // function body after it never runs); at top level the can-only-return
-      // report still follows.  POSIX: fatal (errors10.sub).
-      sh.errorf("return: %s: numeric argument required\n", argv[ri].c_str());
-      st = 2;
-      sh.posix_special_builtin_error(st);
-      if (sh.in_function() || sh.source_depth > 0) {
-        sh.returning = true;
-        sh.exit_status = 2;
-      } else if (!sh.exiting) {
-        sh.errorf("return: can only `return' from a function or sourced script\n");
-      }
-    } else if (!sh.in_function() && sh.source_depth == 0) {
-      // `return' is only meaningful in a function or a sourced script;
-      // elsewhere it is an error and must not unwind the current input (bash).
-      sh.errorf("return: can only `return' from a function or sourced script\n");
-      st = 1;
-      sh.posix_special_builtin_error(st);  // special builtin: fatal in posix
-    } else {
-      sh.returning = true;
-      // A BARE `return' inside a signal trap action reports $? from before the
-      // trap ran -- the action cannot change it (posix interp 1602) -- unless
-      // the action called a function we are still inside.  An explicit
-      // argument always wins.
-      int bare = (sh.trap_ret_depth >= 0 && sh.nest_depth() == sh.trap_ret_depth)
-                     ? sh.trap_saved_status
-                     : sh.last_status;
-      sh.exit_status = ri < argv.size() ? (static_cast<int>(rv) & 0xff) : bare;
-      st = sh.exit_status;
-    }
-  } else if (cmd == "break" || cmd == "continue") {
-    // Argument validation runs before the loop-level check (bash): extra
-    // arguments discard the rest of the list with status 2, and a
-    // non-numeric count is FATAL to any non-interactive shell in BOTH modes
-    // (`break x' ends the script -- errors4.sub, errors10.sub).
-    size_t bi = 1;
-    if (bi < argv.size() && argv[bi] == "--") bi++;
-    char *bend = nullptr;
-    bool bbad = false;
-    if (bi < argv.size()) {
-      std::strtol(argv[bi].c_str(), &bend, 10);
-      bbad = argv[bi].empty() || bend == argv[bi].c_str() || *bend != '\0';
-    }
-    if (argv.size() - bi > 1) {
-      sh.errorf("%s: too many arguments\n", cmd.c_str());
-      st = 2;
-      sh.arith_abort = true;
-    } else if (bbad) {
-      sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), argv[bi].c_str());
-      st = 2;
-      if (!sh.interactive) {
-        sh.exiting = true;
-        sh.exit_status = 2;
-      }
-    }
-    // Outside any loop bash prints a diagnostic (suppressed under `set -o
-    // posix') and succeeds without unwinding, rather than silently swallowing
-    // the rest of the input.  Mirrors builtins/break.def check_loop_level().
-    else if (sh.loop_depth == 0) {
-      if (!sh.opt_posix)
-        sh.errorf("%s: only meaningful in a `for', `while', or `until' loop\n", cmd.c_str());
-      st = 0;
-    } else {
-      int n = 1;
-      // Skip a leading `--' end-of-options marker (`break -- 5').
-      size_t ci = 1;
-      if (ci < argv.size() && argv[ci] == "--") ci++;
-      const std::string a = ci < argv.size() ? argv[ci] : std::string();
-      char *end = nullptr;
-      long v = a.empty() ? 1 : std::strtol(a.c_str(), &end, 10);
-      if (!a.empty() && (end == a.c_str() || *end != '\0')) {
-        // A non-numeric count: bash aborts the command (get_numeric_arg); we
-        // report and terminate every enclosing loop, the closest observable
-        // approximation without the top-level throw.
-        sh.errorf("%s: %s: numeric argument required\n", cmd.c_str(), a.c_str());
-        sh.break_count = sh.loop_depth;
-        st = 1;
-      } else if (v <= 0) {
-        // A non-positive count breaks out of every enclosing loop (bash sets
-        // `breaking = loop_level' for both break and continue), status 1.
-        sh.errorf("%s: %s: loop count out of range\n", cmd.c_str(), a.c_str());
-        sh.break_count = sh.loop_depth;
-        st = 1;
-      } else {
-        // Requesting more levels than are active caps at the outermost loop, so
-        // the remaining count never unwinds past the loop nest.
-        n = static_cast<int>(v);
-        if (n > sh.loop_depth) n = sh.loop_depth;
-        if (cmd == "break") sh.break_count = n;
-        else sh.continue_count = n;
-        st = 0;
-      }
-    }
-  } else if (cmd == "eval") {
-    // `eval' takes no options besides `--'; a leading `-X' is an error.
-    size_t ai = 1;
-    if (ai < argv.size() && argv[ai] != "--" && argv[ai].size() >= 2 && argv[ai][0] == '-') {
-      sh.errorf("eval: %s: invalid option\n", argv[ai].c_str());
-      std::fprintf(stderr, "eval: usage: eval [arg ...]\n");
-      st = 2;
-    } else {
-      if (ai < argv.size() && argv[ai] == "--") ai++;
-      std::string saved_ctx = sh.error_context;
-      sh.error_context = "eval";  // parse errors report `NAME: eval: line N: ...'
-      // $LINENO inside eval continues from the eval command's line (bash), so an
-      // eval on line 42 whose body is `echo $LINENO' prints 42.
-      int saved_base = sh.lineno_base;
-      if (sh.cur_lineno > 0) sh.lineno_base = sh.cur_lineno - 1;
-      st = sh.run_string(join(argv, ai));
-      sh.lineno_base = saved_base;
-      sh.error_context = saved_ctx;
-    }
-  } else if (cmd == "source" || cmd == ".") {
-    // `-p PATH' gives an explicit colon-separated search path (bash 5.2+).
-    size_t ai = 1;
-    bool pflag = false;
-    std::string ppath;
-    for (; ai < argv.size(); ai++) {
-      if (argv[ai] == "--") { ai++; break; }
-      if (argv[ai] == "-p") { pflag = true; if (ai + 1 < argv.size()) ppath = argv[++ai]; continue; }
-      if (argv[ai].size() >= 2 && argv[ai][0] == '-') {  // `. -i': unknown option
-        sh.errorf("%s: %s: invalid option\n", cmd.c_str(), argv[ai].c_str());
-        std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
-                     cmd.c_str(), cmd.c_str());
-        if (status) *status = 2;
-        return true;
-      }
-      break;
-    }
-    if (ai >= argv.size()) {
-      sh.errorf("%s: filename argument required\n", cmd.c_str());
-      std::fprintf(stderr, "%s: usage: %s [-p path] filename [arguments]\n",
-                   cmd.c_str(), cmd.c_str());
-      if (status) *status = 2;
-      return true;
-    }
-    const std::string &fname = argv[ai];
-    if (sh.opt_restricted && fname.find('/') != std::string::npos) {
-      sh.errorf("%s: %s: restricted\n", cmd.c_str(), fname.c_str());
-      if (status) *status = 1;
-      return true;
-    }
-    // Resolve the file: a name with a slash is used as-is; otherwise search the
-    // `-p' path, or $PATH when the `sourcepath' shopt is on, falling back to the
-    // current directory.
-    std::string path = fname;
-    auto search = [&](const std::string &plist) -> bool {
-      size_t start = 0;
-      while (start <= plist.size()) {
-        size_t e = plist.find(':', start);
-        std::string dir = plist.substr(start, e == std::string::npos ? std::string::npos : e - start);
-        if (dir.empty()) dir = ".";
-        std::string cand = dir + "/" + fname;
-        if (access(cand.c_str(), R_OK) == 0) { path = cand; return true; }
-        if (e == std::string::npos) break;
-        start = e + 1;
-      }
-      return false;
-    };
-    bool giveup = false;
-    if (fname.find('/') != std::string::npos) {
-      // used directly
-    } else if (pflag) {
-      // `-p' searches only the given path; a miss is a hard failure.
-      if (!search(ppath)) {
-        sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
-        st = 1;
-        giveup = true;
-        sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
-      }
-    } else if (sh.opt_posix) {
-      // POSIX `.'/source: search $PATH only -- NO current-directory fallback
-      // even when the file exists there.  A miss is `.: NAME: file not found'
-      // and (unshielded) fatal for a non-interactive posix shell.
-      const char *penv = std::getenv("PATH");
-      if (!search(penv ? penv : "")) {
-        sh.errorf("%s: %s: file not found\n", cmd.c_str(), fname.c_str());
-        st = 1;
-        giveup = true;
-        sh.posix_special_builtin_error(st);
-      }
-    } else if (sh.shopt_opts["sourcepath"] && access(fname.c_str(), R_OK) != 0) {
-      const char *penv = std::getenv("PATH");
-      search(penv ? penv : "");  // on a miss, path stays fname (current directory)
-    }
-    if (!giveup) {
-      std::ifstream f(path);
-      if (f) {
-        std::ostringstream ss; ss << f.rdbuf();
-        // Extra arguments become the sourced file's positional parameters
-        // (`. file a b'); with none, it inherits the caller's positionals.
-        std::vector<std::string> saved_pos;
-        bool set_pos = argv.size() > ai + 1;
-        bool saved_params_flag = sh.params_set_builtin;
-        if (set_pos) {
-          saved_pos = sh.positional;
-          sh.positional.assign(argv.begin() + ai + 1, argv.end());
-          sh.params_set_builtin = false;
-        }
-        // A sourced file becomes the innermost BASH_SOURCE frame; use the
-        // resolved path (bash records the PATH-found path, not the bare name),
-        // so ${BASH_SOURCE[0]} lets a script locate itself.  The call line is
-        // where `source' appears in the current file.
-        int src_call_line = sh.cur_lineno;  // where `source' appears; see below
-        sh.push_src_frame("source", path, sh.cur_lineno, false);
-        // A sourced file has its own line numbering starting at 1 ($LINENO, the
-        // DEBUG trap, and functions it defines all use the file's own lines).
-        int saved_src_base = sh.lineno_base;
-        sh.lineno_base = 0;
-        // A sourced file does not inherit the DEBUG trap unless functrace is
-        // set (source.def restores the default for the duration).  bash lifts
-        // the suppression in an unwind frame that runs AFTER `source_file',
-        // and `source_file' is what fires the RETURN trap -- so the RETURN
-        // trap's own body produces no DEBUG line either.  Hence the window
-        // below closes past the RETURN trap, not at the end of the file.
-        std::string hidden_debug;
-        bool hid_debug = false;
-        if (!sh.opt_functrace) {
-          auto dit = sh.traps.find("DEBUG");
-          if (dit != sh.traps.end()) {
-            hidden_debug = dit->second;
-            hid_debug = true;
-            sh.traps.erase(dit);
-          }
-        }
-        sh.source_depth++;  // `return' is legal while sourcing
-        st = sh.run_string(ss.str());
-        sh.source_depth--;
-        sh.lineno_base = saved_src_base;
-        // `return' inside a sourced file ends the file (and sets its status),
-        // like reaching EOF -- it must not unwind past `source' or exit the
-        // shell (bash semantics; e.g. /etc/bashrc does `[ -z "$PS1" ] && return').
-        if (sh.returning) { sh.returning = false; st = sh.exit_status; }
-        sh.pop_src_frame();
-        // A sourced file is a FUNCTION FRAME to bash: leaving it fires the
-        // DEBUG and RETURN traps, reporting the line `source' was called on --
-        // exactly as leaving a function body re-reports its definition line.
-        // The frame is already popped, so $FUNCNAME names the caller.
-        {
-          sh.cur_lineno = src_call_line;
-          // Only the RETURN trap is fired here: the DEBUG line that precedes it
-          // is the one its own body produces under functrace, exactly as when a
-          // function body returns.
-          //
-          // Unlike a function, a sourced file does NOT gate this on functrace:
-          // `source_file' runs the trap unconditionally, so a `source' at top
-          // level fires it either way.  Inside a function it follows the
-          // function's own rule, because that is where bash restored the
-          // default trap.  See Shell::return_trap_fires().
-          if (sh.return_trap_fires()) sh.run_return_trap(st);
-        }
-        // Restore the DEBUG trap -- but only if the sourced file did not set
-        // one of its own, which is what bash's trap_if_untrapped() amounts to.
-        if (hid_debug && !sh.traps.count("DEBUG")) sh.traps["DEBUG"] = hidden_debug;
-        // Restore the caller's parameters UNLESS the sourced script ran the
-        // `set' builtin at top level -- then its parameters stick (bash).
-        if (set_pos) {
-          if (!(!sh.in_function() && sh.params_set_builtin)) sh.positional = saved_pos;
-          sh.params_set_builtin = saved_params_flag;
-        }
-      } else {
-        sh.errorf("%s: %s\n", fname.c_str(), std::strerror(errno));
-        st = 1;
-        sh.posix_special_builtin_error(st);  // `.'/source: fatal in posix
-      }
-    }
-  } else if (cmd == "local") {
+  }
+  else if (cmd == "local") {
     if (!sh.in_function()) {
       sh.errorf("local: can only be used in a function\n");
       st = 1;
@@ -7462,498 +8008,19 @@ bool run_builtin(Shell &sh, const std::vector<std::string> &argv, int *status) {
     st = bi_declare(sh, argv, false, true);
     // POSIX: like export, a failing readonly is fatal unless `command'-run.
     if (st != 0) sh.posix_special_builtin_error(st);
-  } else if (cmd == "let") {
-    st = bi_let(sh, argv);
-  } else if (cmd == "type") {
-    st = bi_type(sh, argv);
-  } else if (cmd == "help") {
-    st = bi_help(sh, argv);
-  } else if (cmd == "builtin") {
-    st = bi_builtin(sh, argv);
-  } else if (cmd == "logout") {
-    st = bi_logout(sh, argv);
-  } else if (cmd == "hash") {
-    st = bi_hash(sh, argv);
-  } else if (cmd == "shopt") {
-    st = bi_shopt(sh, argv);
-  } else if (cmd == "ulimit") {
-    st = bi_ulimit(sh, argv);
-  } else if (cmd == "enable") {
-    st = bi_enable(sh, argv);
-  } else if (cmd == "caller") {
-    st = bi_caller(sh, argv);
-  } else if (cmd == "alias") {
-    st = bi_alias(sh, argv);
-  } else if (cmd == "unalias") {
-    st = bi_unalias(sh, argv);
-  } else if (cmd == "history") {
-    st = bi_history(sh, argv);
-  } else if (cmd == "fc") {
-    st = bi_fc(sh, argv);
-  } else if (cmd == "compgen") {
-    st = bi_compgen(sh, argv);
-  } else if (cmd == "complete") {
-    st = bi_complete(sh, argv);
-  } else if (cmd == "compopt") {
-    st = bi_compopt(sh, argv);
-  } else if (cmd == "bind") {
-    st = bi_bind(sh, argv);
-  } else if (cmd == "trap") {
-    st = bi_trap(sh, argv);
-  } else if (cmd == "umask") {
-    st = bi_umask(sh, argv);
-  } else if (cmd == "getopts") {
-    st = bi_getopts(sh, argv);
-  } else if (cmd == "times") {
-    st = 0;
-  } else if (cmd == "wait") {
-    // Options: -f (wait for termination, not just a status change), -n (return
-    // after the next job finishes) and -p VAR (store the finished job's pid in
-    // VAR).  A leading `-<digit>' is a (negative) id, not an option.
-    bool nflag = false, have_p = false, opt_err = false;
-    std::string pvar, badopt;
-    size_t ai = 1;
-    for (; ai < argv.size(); ai++) {
-      const std::string &o = argv[ai];
-      if (o == "--") { ai++; break; }
-      if (o.size() < 2 || o[0] != '-' ||
-          std::isdigit(static_cast<unsigned char>(o[1])))
-        break;
-      bool consumed_p = false;
-      for (size_t k = 1; k < o.size() && !opt_err; k++) {
-        char c = o[k];
-        if (c == 'n') nflag = true;
-        else if (c == 'f') { /* no async status tracking: -f is a no-op here */ }
-        else if (c == 'p') {
-          have_p = true;
-          if (k + 1 < o.size()) pvar = o.substr(k + 1);
-          else if (ai + 1 < argv.size()) pvar = argv[++ai];
-          consumed_p = true;
-          break;
-        } else { opt_err = true; badopt = std::string("-") + c; }
-      }
-      if (opt_err || consumed_p) { if (opt_err) break; else continue; }
-    }
-    if (opt_err) {
-      sh.errorf("wait: %s: invalid option\n", badopt.c_str());
-      std::fprintf(stderr, "wait: usage: wait [-fn] [-p var] [id ...]\n");
-      st = 2;
-    } else {
-      long finished_pid = -1;
-      bool found = false;
-      if (nflag) {
-        // `-n': return after the NEXT of the named jobs finishes (or any job
-        // when none are named).  Resolve each id to a job; an unknown `%spec'
-        // reports "no such job" but the wait proceeds with the rest.
-        std::vector<int> ids;
-        for (size_t k = ai; k < argv.size(); k++) {
-          Shell::Job *j = sh.job_by_spec(argv[k]);
-          if (j) ids.push_back(j->id);
-          else {
-            sh.errorf("wait: %s: no such job\n", argv[k].c_str());
-            st = 127;
-          }
-        }
-        // With ids named but none resolvable, there is nothing to wait for.
-        if (ai < argv.size() && ids.empty()) st = 127;
-        else st = sh.wait_next(ids, &finished_pid, &found);
-      } else if (ai < argv.size()) {
-        // Wait for every named id (bash waits for all of them).  The last one's
-        // pid is the -p result.
-        for (size_t k = ai; k < argv.size(); k++) {
-          const std::string &spec = argv[k];
-          if (!spec.empty() && spec[0] == '%') {
-            // A `%jobspec' that names no job: bash reports it and returns 127.
-            Shell::Job *j = sh.job_by_spec(spec);
-            if (!j) {
-              sh.errorf("wait: %s: no such job\n", spec.c_str());
-              st = 127;
-              continue;
-            }
-            int wid = j->id;
-            if (!j->pids.empty()) { finished_pid = j->pids.front(); found = true; }
-            for (long p : j->pids) st = sh.wait_for_pid(p);
-            // A waited-for job is consumed: bash removes it so its number frees
-            // up for reuse by the next async job.
-            sh.remove_jobs_if([wid](const Shell::Job &x) { return x.id == wid; });
-          } else {
-            // Anything not a `%jobspec' must be a decimal pid.
-            bool numeric = !spec.empty();
-            for (char c : spec)
-              if (!std::isdigit(static_cast<unsigned char>(c))) { numeric = false; break; }
-            if (!numeric) {
-              sh.errorf("wait: `%s': not a pid or valid job spec\n", spec.c_str());
-              st = 1;
-              continue;
-            }
-            long pp = std::atol(spec.c_str());
-            Shell::Job *pj = sh.job_by_spec(spec);
-            if (!pj) {
-              // A process-substitution child is waitable too, though it is not
-              // a job: `cat <(exit 123); wait "$!"' reports 123 (procsub1.sub).
-              bool is_procsub = false;
-              for (const auto &ps : sh.procsubs)
-                if (ps.pid == pp) { is_procsub = true; break; }
-              if (is_procsub) {
-                st = sh.wait_for_pid(pp);
-                finished_pid = pp;
-                found = true;
-                continue;
-              }
-              auto rps = sh.reaped_procsub_status.find(pp);
-              if (rps != sh.reaped_procsub_status.end()) {
-                st = rps->second;
-                finished_pid = pp;
-                found = true;
-                sh.reaped_procsub_status.erase(rps);
-                continue;
-              }
-              sh.errorf("wait: pid %ld is not a child of this shell\n", pp);
-              st = 127;
-              continue;
-            }
-            int wid = pj->id;
-            st = sh.wait_for_pid(pp);
-            finished_pid = pp;
-            found = true;
-            // The waited-for job is consumed once it is fully done, so its
-            // number frees up for reuse (bash removes it after `wait pid').
-            sh.remove_jobs_if(
-                [wid](const Shell::Job &x) { return x.id == wid && x.done; });
-          }
-        }
-      } else if (!have_p) {
-        st = sh.wait_all();
-      } else {
-        // `-p var' with no ids and no `-n': reap without blocking; the var is
-        // left unset (bash) when no job supplied a pid.
-        sh.reap_jobs(false);
-        st = 0;
-      }
-      // -p VAR: store the finished pid, or unset VAR when no job was waited for.
-      // The name is validated like other builtins, and an array-element
-      // subscript is arithmetic (a bad one raises bash's arithmetic diagnostic).
-      if (have_p) {
-        auto lb = pvar.find('[');
-        std::string base = pvar, psub;
-        bool subscripted = lb != std::string::npos && !pvar.empty() && pvar.back() == ']';
-        if (subscripted) {
-          base = pvar.substr(0, lb);
-          psub = pvar.substr(lb + 1, pvar.size() - lb - 2);
-        }
-        if (!valid_identifier(base)) {
-          sh.errorf("wait: `%s': not a valid identifier\n", pvar.c_str());
-          st = 1;
-        } else if (found && finished_pid >= 0) {
-          if (subscripted) {
-            if (!sh.array_expand_once_ok(base, psub)) st = 1;  // arith error printed
-            else sh.array_set(base, psub, std::to_string(finished_pid));
-          } else {
-            sh.set(pvar, std::to_string(finished_pid));
-          }
-        } else if (!subscripted) {
-          // No job finished: bash unsets the -p variable.  A readonly target
-          // cannot be unset and is reported as such.
-          auto it = sh.vars.find(sh.deref(base));
-          if (it != sh.vars.end() && it->second.readonly) {
-            sh.errorf("wait: %s: cannot unset: readonly variable\n", base.c_str());
-            st = 1;
-          } else {
-            sh.unset(pvar);
-          }
-        }
-      }
-    }
-  } else if (cmd == "jobs") {
-    // jobs [-lnprs] [jobspec]: -l long (with pgid), -p pids only, -r running
-    // only, -s stopped only, -n changed-only (we have no async change tracking).
-    bool jl = false, jp = false, jr = false, js = false;
-    std::string jspec;
-    bool jbad = false;
-    for (size_t k = 1; k < argv.size(); k++) {
-      const std::string &o = argv[k];
-      if (o == "--") continue;
-      if (o.size() >= 2 && o[0] == '-' && o[1] != '%') {
-        for (size_t c = 1; c < o.size(); c++) {
-          switch (o[c]) {
-            case 'l': jl = true; break;
-            case 'p': jp = true; break;
-            case 'r': jr = true; break;
-            case 's': js = true; break;
-            case 'n': break;  // no async change tracking: nothing extra to show
-            default: jbad = true; break;
-          }
-        }
-      } else {
-        jspec = o;
-      }
-    }
-    if (jbad) {
-      std::fprintf(stderr, "jobs: usage: jobs [-lnprs] [jobspec ...] or jobs -x command [args]\n");
-      st = 1;
-    } else {
-      sh.print_jobs(jspec, jl, jp, jr, js);
-      st = 0;
-    }
-  } else if (cmd == "fg") {
-    std::string spec = argv.size() > 1 ? argv[1] : "";
-    bool cur_spec = spec.empty() || spec == "%" || spec == "%%" || spec == "%+" || spec == "%-";
-    if (!sh.job_control && !sh.opt_monitor) {
-      sh.errorf("fg: no job control\n");
-      st = 1;
-    } else if (sh.no_current_job && cur_spec) {
-      // A command-substitution subshell has no current job to bring forward.
-      sh.errorf("fg: no current jobs\n");
-      st = 1;
-    } else if (Shell::Job *j = sh.job_by_spec(spec)) {
-      if (!j->monitored) {
-        // The job was started when job control was inactive (bash's
-        // IS_JOBCONTROL(job) == 0), so it cannot be brought to the foreground
-        // even though monitor mode is on now.
-        sh.errorf("fg: job %d started without job control\n", j->id);
-        st = 1;
-      } else {
-        std::printf("%s\n", j->command.c_str());  // bash echoes the command
-        std::fflush(stdout);
-        st = sh.foreground_job(*j, true);
-      }
-    } else {
-      sh.errorf("fg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
-      st = 1;
-    }
-  } else if (cmd == "bg") {
-    std::string spec = argv.size() > 1 ? argv[1] : "";
-    if (!sh.job_control) {
-      sh.errorf("bg: no job control\n");
-      st = 1;
-    } else if (Shell::Job *j = sh.job_by_spec(spec)) {
-      sh.background_job(*j, true);
-      std::printf("[%d]+ %s &\n", j->id, j->command.c_str());  // bash echoes it
-      std::fflush(stdout);
-      st = 0;
-    } else {
-      sh.errorf("bg: %s: no such job\n", spec.empty() ? "current" : spec.c_str());
-      st = 1;
-    }
-  } else if (cmd == "disown") {
-    // disown [-h] [-ar] [jobspec ... | pid ...]: -a all jobs, -r running jobs
-    // only, -h keep the job but mark it to skip SIGHUP.  With no jobspec (and no
-    // -a/-r) it acts on the current job.  We drop disowned jobs from the table
-    // (the -h "keep but no HUP" nuance is not modelled -- we have no HUP-on-exit).
-    bool all = false, running_only = false, hold = false;
-    std::vector<std::string> specs;
-    for (size_t k = 1; k < argv.size(); k++) {
-      const std::string &o = argv[k];
-      if (o.size() >= 2 && o[0] == '-' && o != "--") {
-        for (size_t c = 1; c < o.size(); c++) {
-          if (o[c] == 'a') all = true;
-          else if (o[c] == 'r') running_only = true;
-          else if (o[c] == 'h') hold = true;
-        }
-      } else if (o == "--") {
-        continue;
-      } else {
-        specs.push_back(o);
-      }
-    }
-    std::vector<int> drop;
-    if (all || running_only) {
-      for (const auto &x : sh.jobs)
-        if (!running_only || (x.running && !x.done)) drop.push_back(x.id);
-    } else if (!specs.empty()) {
-      for (const auto &s : specs)
-        if (Shell::Job *j = sh.job_by_spec(s)) drop.push_back(j->id);
-    } else if (Shell::Job *j = sh.job_by_spec("")) {
-      drop.push_back(j->id);
-    }
-    if (!hold) {
-      sh.jobs.erase(std::remove_if(sh.jobs.begin(), sh.jobs.end(),
-                                   [&](const Shell::Job &x) {
-                                     return std::find(drop.begin(), drop.end(), x.id) !=
-                                            drop.end();
-                                   }),
-                    sh.jobs.end());
-    }
-    st = 0;
-  } else if (cmd == "kill") {
-    st = bi_kill(sh, argv);
-  } else if (cmd == "suspend") {
-    st = 0;
-  } else if (cmd == "command") {
-    // Execution of `command NAME args' is handled in the executor (run_simple),
-    // which runs NAME through the normal builtin/external path with shell
-    // functions bypassed.  Only the describe forms (-v/-V) and option errors
-    // reach here; the name-lookup helpers this needs live in this file.
-    size_t i = 1;
-    bool desc_v = false, desc_V = false, bad = false;
-    std::string badopt;
-    for (; i < argv.size(); i++) {
-      const std::string &o = argv[i];
-      if (o == "--") { i++; break; }
-      if (o.size() < 2 || o[0] != '-') break;
-      for (size_t k = 1; k < o.size(); k++) {
-        if (o[k] == 'v') desc_v = true;
-        else if (o[k] == 'V') desc_V = true;
-        else if (o[k] == 'p') {  // default PATH; disallowed under restricted
-          if (sh.opt_restricted) {
-            sh.errorf("command: -p: restricted\n");
-            if (status) *status = 2;
-            return true;
-          }
-        }
-        else { bad = true; badopt = std::string("-") + o[k]; break; }
-      }
-      if (bad) break;
-    }
-    if (bad) {
-      sh.errorf("command: %s: invalid option\n", badopt.c_str());
-      std::fprintf(stderr, "command: usage: command [-pVv] command [arg ...]\n");
-      st = 2;
-    } else if (desc_V) {
-      // `command -V NAME...' == `type NAME...', but a not-found name is reported
-      // against `command' (bi_type uses argv[0] for that diagnostic).
-      std::vector<std::string> t = {"command"};
-      t.insert(t.end(), argv.begin() + i, argv.end());
-      st = bi_type(sh, t);
-    } else if (desc_v) {
-      // For each name print the alias definition (reusable form), the name
-      // (function/builtin/keyword), or the full path (hashed, then $PATH);
-      // 0 if all resolved, 1 otherwise.  Like `type', an alias is reported
-      // only when aliases would actually expand, and a hashed path is
-      // reported (and counted as a hit) before any $PATH search.
-      bool aliases_on = sh.interactive;
-      auto eit = sh.shopt_opts.find("expand_aliases");
-      if (eit != sh.shopt_opts.end() && eit->second) aliases_on = true;
-      st = (i < argv.size()) ? 0 : 1;
-      for (size_t j = i; j < argv.size(); j++) {
-        const std::string &n = argv[j];
-        if (aliases_on && sh.aliases.count(n)) {
-          std::printf("alias %s=%s\n", n.c_str(), single_quote(sh.aliases.at(n)).c_str());
-        } else if (sh.functions.count(n) || is_builtin_name(n) || is_reserved_word(n)) {
-          std::printf("%s\n", n.c_str());
-        } else if (const std::string *hp = sh.hash_lookup(n)) {
-          std::printf("%s\n", hp->c_str());
-        } else {
-          std::string p = find_in_path(sh, n);
-          if (!p.empty()) std::printf("%s\n", p.c_str());
-          else st = 1;
-        }
-      }
-    } else {
-      // No -v/-V: execution is handled in run_simple; reached only defensively
-      // (e.g. run_builtin called directly).  Run the target if it is a builtin.
-      std::vector<std::string> rest(argv.begin() + i, argv.end());
-      if (!rest.empty()) run_builtin(sh, rest, &st);
-      else st = 0;
-    }
-  } else if (cmd == "exec") {
-    if (sh.opt_restricted) {
-      sh.errorf("exec: restricted\n");
-      if (status) *status = 2;
-      return true;
-    }
-    // Options: -a NAME (argv[0] for the command), -c (empty environment),
-    // -l (login: prefix argv[0] with '-').
-    size_t i = 1;
-    std::string a_name;
-    bool have_a = false, clear_env = false, login = false, bad_opt = false;
-    for (; i < argv.size(); i++) {
-      const std::string &o = argv[i];
-      if (o == "--") { i++; break; }
-      if (o.size() < 2 || o[0] != '-') break;
-      bool consumed_next = false;
-      for (size_t k = 1; k < o.size(); k++) {
-        if (o[k] == 'c') clear_env = true;
-        else if (o[k] == 'l') login = true;
-        else if (o[k] == 'a') {
-          have_a = true;
-          if (k + 1 < o.size()) { a_name = o.substr(k + 1); }
-          else if (i + 1 < argv.size()) { a_name = argv[i + 1]; consumed_next = true; }
-          k = o.size();
-        } else { bad_opt = true; break; }
-      }
-      if (bad_opt) break;
-      if (consumed_next) i++;
-    }
-    if (bad_opt) {
-      sh.errorf("exec: %s: invalid option\n", argv[i].c_str());
-      std::fprintf(stderr, "exec: usage: exec [-cl] [-a name] [command "
-                           "[argument ...]] [redirection ...]\n");
-      st = 2;
-    } else if (i >= argv.size()) {
-      // No command word: `exec' with only options/redirections is a no-op here
-      // (redirections are applied by the caller and made permanent).
-      st = 0;
-    } else {
-      const std::string &target = argv[i];
-      // Resolve through the shell's $PATH (what `type'/normal execution use), so
-      // exec finds exactly what the rest of the shell would run.
-      std::string full;
-      bool found = false;
-      if (target.find('/') != std::string::npos) {
-        full = target;
-        found = true;  // let execve report ENOENT/EACCES for an explicit path
-      } else {
-        std::vector<std::string> m = find_all_in_path(sh, target);
-        if (!m.empty()) { full = m[0]; found = true; }
-        else {
-          // No executable match: if a file by that name merely exists on $PATH,
-          // use it so execve reports the real error (e.g. EACCES), as bash does.
-          std::string path = sh.get("PATH");
-          size_t p = 0;
-          while (p <= path.size()) {
-            size_t q = path.find(':', p);
-            std::string dir = path.substr(p, q == std::string::npos ? std::string::npos : q - p);
-            if (dir.empty()) dir = ".";
-            std::string cand = dir + "/" + target;
-            if (access(cand.c_str(), F_OK) == 0) { full = cand; found = true; break; }
-            if (q == std::string::npos) break;
-            p = q + 1;
-          }
-        }
-      }
-      // argv[0] for the command: -a NAME, else the name as typed; -l adds '-'.
-      std::string a0 = have_a ? a_name : target;
-      if (login) a0 = "-" + a0;
-      std::vector<char *> cargv;
-      cargv.push_back(const_cast<char *>(a0.c_str()));
-      for (size_t j = i + 1; j < argv.size(); j++)
-        cargv.push_back(const_cast<char *>(argv[j].c_str()));
-      cargv.push_back(nullptr);
-      // Pass the shell's current environment (empty under -c) explicitly via
-      // execve, so the live shell's `environ' is never disturbed on failure.
-      std::vector<std::string> envs;
-      if (!clear_env) envs = sh.environ_block();
-      std::vector<char *> envp;
-      for (auto &e : envs) envp.push_back(const_cast<char *>(e.c_str()));
-      envp.push_back(nullptr);
-
-      int code = 127;
-      if (found) {
-        // The process image is about to be replaced, so an interactive
-        // session's history has to reach $HISTFILE now or be lost.  Not from a
-        // subshell: that history belongs to the parent, which will write it.
-        if (sh.interactive && sh.subshell_level == 0) save_shell_history(sh);
-        std::fflush(nullptr);
-        execve(full.c_str(), cargv.data(), envp.data());
-        // execve returned: it failed.  bash reports this as "<path>: <error>"
-        // (no "exec:" prefix), using the resolved path.
-        code = (errno == EACCES) ? 126 : 127;
-        sh.errorf("%s: %s\n", full.c_str(), std::strerror(errno));
-      } else {
-        sh.errorf("exec: %s: not found\n", target.c_str());
-      }
-      // bash: an interactive shell (or `shopt -s execfail') stays alive and
-      // returns failure; a non-interactive shell exits.
-      auto ef = sh.shopt_opts.find("execfail");
-      bool execfail = ef != sh.shopt_opts.end() && ef->second;
-      if (sh.interactive || execfail)
-        st = code;
-      else
-        _exit(code);
-    }
+  } else if (cmd == "export") {
+    st = bi_export(sh, argv);
+    // POSIX: a failing export (invalid identifier, assignment error) is a
+    // special-builtin error, fatal to a non-interactive shell unless run via
+    // `command' (errors11.sub).
+    if (st != 0) sh.posix_special_builtin_error(st);
   } else {
-    return false;
+    // Every other builtin is a plain `int (Shell &, argv)' function in the
+    // table above.
+    bool handled = false;
+    for (const auto &e : kBuiltinTable)
+      if (cmd == e.name) { st = e.fn(sh, argv); handled = true; break; }
+    if (!handled) return false;
   }
   if (status) *status = st;
   return true;

--- a/core/src/executor.cpp
+++ b/core/src/executor.cpp
@@ -110,8 +110,7 @@ static bool expand_redir_target(Shell &sh, const Word &w, std::string &out) {
   sh.arith_error = saved_ae;
   if (expfail) return false;
   if (words.size() != 1) {
-    std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
-                 w.text.c_str());
+    sh.errorf("%s: ambiguous redirect\n", w.text.c_str());
     return false;
   }
   out = std::move(words[0]);
@@ -190,8 +189,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       case RedirOp::AndAppend: {
         Expander rex(sh);
         std::string fn = rex.expand_no_split(r.target.text, true);
-        std::fprintf(stderr, "%s%s: restricted: cannot redirect output\n",
-                     sh.err_prefix().c_str(), fn.c_str());
+        sh.errorf("%s: restricted: cannot redirect output\n", fn.c_str());
         return false;
       }
       default: break;
@@ -220,8 +218,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
         ok = sh.set(r.fd_var, std::to_string(f), fdvar_ctx);
       }
       if (!ok) {
-        std::fprintf(stderr, "%s%s: cannot assign fd to variable\n", sh.err_prefix().c_str(),
-                     r.fd_var.c_str());
+        sh.errorf("%s: cannot assign fd to variable\n", r.fd_var.c_str());
         close(f);
         return false;
       }
@@ -250,8 +247,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
         std::fprintf(stderr, "%s: redirection error: cannot duplicate fd: %s\n",
                      sh.shell_name.c_str(), std::strerror(e));
         if (!fn.empty())
-          std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(),
-                       std::strerror(e));
+          sh.errorf("%s: %s\n", fn.c_str(), std::strerror(e));
         close(f);
         return false;
       }
@@ -263,8 +259,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), flags, 0666);
       if (f < 0) {
-        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(),
-                     std::strerror(errno));
+        sh.errorf("%s: %s\n", fn.c_str(), std::strerror(errno));
         return false;
       }
       return assign_fd(f, fn);
@@ -283,8 +278,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
           if (cur.empty()) {
             // `exec {v}>&-' with no fd number in the variable: bash reports
             // the bare variable name as an ambiguous redirect.
-            std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
-                         r.fd_var.c_str());
+            sh.errorf("%s: ambiguous redirect\n", r.fd_var.c_str());
             return false;
           }
           int n = std::atoi(cur.c_str());
@@ -301,8 +295,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
         // report prints an uninitialized number; the ambiguous/converted
         // reports here cover those deterministically.)
         if (w.empty() || w.find_first_not_of("0123456789") != std::string::npos) {
-          std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
-                       r.fd_var.c_str());
+          sh.errorf("%s: ambiguous redirect\n", r.fd_var.c_str());
           return false;
         }
         errno = 0;
@@ -320,8 +313,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
           std::string shown = inrange ? std::to_string(src) : w;
           std::fprintf(stderr, "%s: redirection error: cannot duplicate fd: %s\n",
                        sh.shell_name.c_str(), std::strerror(e));
-          std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), shown.c_str(),
-                       std::strerror(e));
+          sh.errorf("%s: %s\n", shown.c_str(), std::strerror(e));
           return false;
         }
         if (move) close(static_cast<int>(src));
@@ -364,7 +356,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       std::string fn;
       if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), O_RDONLY);
-      if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
+      if (f < 0) { sh.errorf("%s: %s\n", fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 0 : target_fd);
       return true;
     }
@@ -375,11 +367,10 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       // `>' honors noclobber; `>|' (Clobber) always overrides it.
       int f = open_redir_output(sh, fn, r.op == RedirOp::OutputRedir);
       if (f == kNoclobberRefused) {
-        std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
-                     sh.err_prefix().c_str(), fn.c_str());
+        sh.errorf("%s: cannot overwrite existing file\n", fn.c_str());
         return false;
       }
-      if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
+      if (f < 0) { sh.errorf("%s: %s\n", fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 1 : target_fd);
       return true;
     }
@@ -387,7 +378,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       std::string fn;
       if (!expand_redir_target(sh, r.target, fn)) return false;
       int f = open(fn.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0666);
-      if (f < 0) { std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), fn.c_str(), std::strerror(errno)); return false; }
+      if (f < 0) { sh.errorf("%s: %s\n", fn.c_str(), std::strerror(errno)); return false; }
       redir_to(f, target_fd < 0 ? 1 : target_fd);
       return true;
     }
@@ -409,8 +400,7 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
       } else {  // `&>' truncates, so it honors noclobber
         f = open_redir_output(sh, fn, true);
         if (f == kNoclobberRefused) {
-          std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
-                       sh.err_prefix().c_str(), fn.c_str());
+          sh.errorf("%s: cannot overwrite existing file\n", fn.c_str());
           return false;
         }
       }
@@ -444,28 +434,24 @@ bool apply_redirect(Shell &sh, const Redirect &r, std::vector<SavedFd> &saved,
         if (r.op == RedirOp::DupOutput && target_fd < 0 && !w.empty()) {
           int f = open_redir_output(sh, w, true);  // `>&file' honors noclobber
           if (f == kNoclobberRefused) {
-            std::fprintf(stderr, "%s%s: cannot overwrite existing file\n",
-                         sh.err_prefix().c_str(), w.c_str());
+            sh.errorf("%s: cannot overwrite existing file\n", w.c_str());
             return false;
           }
           if (f < 0) {
-            std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), w.c_str(),
-                         std::strerror(errno));
+            sh.errorf("%s: %s\n", w.c_str(), std::strerror(errno));
             return false;
           }
           install_both(f);
           return true;
         }
-        std::fprintf(stderr, "%s%s: ambiguous redirect\n", sh.err_prefix().c_str(),
-                     w.c_str());
+        sh.errorf("%s: ambiguous redirect\n", w.c_str());
         return false;
       }
       int src = std::atoi(w.c_str());
       // A source fd that is not open is an error, reported with the
       // UNEXPANDED word (`echo foo >&$fd' -> `$fd: Bad file descriptor').
       if (fcntl(src, F_GETFD) < 0) {
-        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), r.target.text.c_str(),
-                     std::strerror(EBADF));
+        sh.errorf("%s: %s\n", r.target.text.c_str(), std::strerror(EBADF));
         return false;
       }
       save_fd(fd, saved);
@@ -625,13 +611,11 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
           // bash stops the whole compound assignment at the first bad subscript
           // (the array has already been cleared, so the partial result stands).
           if (sub.empty()) {
-            std::fprintf(stderr, "%s%s: bad array subscript\n",
-                         sh.err_prefix().c_str(), e.c_str());
+            sh.errorf("%s: bad array subscript\n", e.c_str());
             break;
           }
           if (sub == "*" || sub == "@") {
-            std::fprintf(stderr, "%s%s: cannot assign to non-numeric index\n",
-                         sh.err_prefix().c_str(), e.c_str());
+            sh.errorf("%s: cannot assign to non-numeric index\n", e.c_str());
             break;
           }
           // `shopt -s array_expand_once': a compound assignment must not perform
@@ -649,8 +633,7 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
           ok = true;
           if (ok && k < 0) k += maxidx + 1;  // resolve negative against running max
           if (ok && k < 0) {
-            std::fprintf(stderr, "%s%s: bad array subscript\n",
-                         sh.err_prefix().c_str(), e.c_str());
+            sh.errorf("%s: bad array subscript\n", e.c_str());
             break;
           }
           if (ok) { sub = std::to_string(k); if (k > maxidx) maxidx = k; }
@@ -673,9 +656,8 @@ parse_array_elems(Shell &sh, Expander &ex, const std::string &name, bool integer
     // An associative array in subscript mode cannot take a bare value: bash
     // reports the offending word and stops the assignment.
     if (assoc && saw_sub) {
-      std::fprintf(stderr,
-                   "%s%s: %s: must use subscript when assigning associative array\n",
-                   sh.err_prefix().c_str(), name.c_str(), e.c_str());
+      sh.errorf("%s: %s: must use subscript when assigning associative array\n", name.c_str(),
+                e.c_str());
       break;
     }
     if (assoc) {
@@ -708,8 +690,7 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a,
       const std::string &fn =
           sh.call_stack.empty() ? std::string() : sh.call_stack.back().func;
       std::string who = ctx ? std::string(ctx) : fn;
-      std::fprintf(stderr, "%s%s%s%s: readonly variable\n", sh.err_prefix().c_str(),
-                   who.c_str(), who.empty() ? "" : ": ", a.name.c_str());
+      sh.errorf("%s%s%s: readonly variable\n", who.c_str(), who.empty() ? "" : ": ", a.name.c_str());
       sh.last_status = 1;
       return;
     }
@@ -724,14 +705,13 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a,
     // identifier' and leaves ref an unset reference.
     auto nit = sh.vars.find(a.name);
     if (nit != sh.vars.end() && nit->second.nameref && nit->second.value.empty()) {
-      std::fprintf(stderr, "%s`': not a valid identifier\n", sh.err_prefix().c_str());
+      sh.errorf("`': not a valid identifier\n");
       sh.last_status = 1;
       return;
     }
     std::string dn = sh.deref(a.name);
     if (dn.find('[') != std::string::npos) {
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh.err_prefix().c_str(),
-                   dn.c_str());
+      sh.errorf("`%s': not a valid identifier\n", dn.c_str());
       sh.last_status = 1;
       return;
     }
@@ -743,8 +723,7 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a,
     auto sit = sh.vars.find(sh.deref(a.name));
     bool assoc = sit != sh.vars.end() && sit->second.kind == VarKind::Assoc;
     if (a.sub->empty() || (!assoc && (*a.sub == "*" || *a.sub == "@"))) {
-      std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
-                   a.name.c_str(), a.sub->c_str());
+      sh.errorf("%s[%s]: bad array subscript\n", a.name.c_str(), a.sub->c_str());
       sh.last_status = 1;
       return;
     }
@@ -762,8 +741,7 @@ void apply_array_assign(Shell &sh, Expander &ex, const Assign &a,
     // (`a[0]=(x y)').  zsh has its own array semantics, so only enforce this
     // outside the zsh personality.
     if (a.is_array && !sh.is_zsh()) {
-      std::fprintf(stderr, "%s%s[%s]: cannot assign list to array member\n",
-                   sh.err_prefix().c_str(), a.name.c_str(), a.sub->c_str());
+      sh.errorf("%s[%s]: cannot assign list to array member\n", a.name.c_str(), a.sub->c_str());
       sh.last_status = 1;
       return;
     }
@@ -1474,8 +1452,7 @@ int Executor::run_simple(const SimpleCommand *c) {
   for (const Assign &a : pending_elem) {
     if (!argv.empty()) {
       std::string disp = a.name + "[" + (a.sub ? *a.sub : std::string()) + "]";
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
-                   disp.c_str());
+      sh_.errorf("`%s': not a valid identifier\n", disp.c_str());
     } else {
       apply_array_assign(sh_, ex, a);
     }
@@ -1537,7 +1514,7 @@ int Executor::run_simple(const SimpleCommand *c) {
         if (o[j] == 'v' || o[j] == 'V') describe = true;
         else if (o[j] == 'p') {  // default PATH; forbidden in a restricted shell
           if (sh_.opt_restricted) {
-            std::fprintf(stderr, "%scommand: -p: restricted\n", sh_.err_prefix().c_str());
+            sh_.errorf("command: -p: restricted\n");
             return (sh_.last_status = 2);
           }
         }
@@ -1609,8 +1586,7 @@ int Executor::run_simple(const SimpleCommand *c) {
   // function of that literal name would already have matched by exact name).
   if (sh_.opt_restricted && argv[0].find('/') != std::string::npos &&
       sh_.functions.find(argv[0]) == sh_.functions.end()) {
-    std::fprintf(stderr, "%s%s: restricted: cannot specify `/' in command names\n",
-                 sh_.err_prefix().c_str(), argv[0].c_str());
+    sh_.errorf("%s: restricted: cannot specify `/' in command names\n", argv[0].c_str());
     return (sh_.last_status = 126);
   }
 
@@ -1674,8 +1650,7 @@ int Executor::run_simple(const SimpleCommand *c) {
       if (nit != sh_.vars.end() && nit->second.nameref) continue;
       auto it = sh_.vars.find(sh_.deref(assigns[ai].first));
       if (it != sh_.vars.end() && it->second.readonly) {
-        std::fprintf(stderr, "%s%s: readonly variable\n", sh_.err_prefix().c_str(),
-                     assigns[ai].first.c_str());
+        sh_.errorf("%s: readonly variable\n", assigns[ai].first.c_str());
         temp_fail = true;
       }
     }
@@ -1761,8 +1736,7 @@ int Executor::run_simple(const SimpleCommand *c) {
     if (sh_.is_set("FUNCNEST")) {
       long fn_max = std::strtol(sh_.get("FUNCNEST").c_str(), nullptr, 10);
       if (fn_max > 0 && static_cast<long>(sh_.local_stack.size()) >= fn_max) {
-        std::fprintf(stderr, "%s%s: maximum function nesting level exceeded (%ld)\n",
-                     sh_.err_prefix().c_str(), argv[0].c_str(), fn_max);
+        sh_.errorf("%s: maximum function nesting level exceeded (%ld)\n", argv[0].c_str(), fn_max);
         sh_.last_status = 1;
         return 1;
       }
@@ -2050,11 +2024,10 @@ int Executor::run_simple(const SimpleCommand *c) {
       std::fflush(nullptr);
       do_exec(cargv);
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
-                     exec_file == argv[0] ? "command not found" : "not found");
+        sh_.errorf("%s: %s\n", printable_name(exec_file).c_str(),
+                   exec_file == argv[0] ? "command not found" : "not found");
       else if (!report_bad_interpreter(exec_file))
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
-                     printable_name(exec_file).c_str(), std::strerror(errno));
+        sh_.errorf("%s: %s\n", printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
     // external command, in its own process group
@@ -2086,11 +2059,10 @@ int Executor::run_simple(const SimpleCommand *c) {
       cargv.push_back(nullptr);
       do_exec(cargv);
       if (errno == ENOENT && exec_file.find('/') == std::string::npos)
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), printable_name(exec_file).c_str(),
-                     exec_file == argv[0] ? "command not found" : "not found");
+        sh_.errorf("%s: %s\n", printable_name(exec_file).c_str(),
+                   exec_file == argv[0] ? "command not found" : "not found");
       else if (!report_bad_interpreter(exec_file))
-        std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(),
-                     printable_name(exec_file).c_str(), std::strerror(errno));
+        sh_.errorf("%s: %s\n", printable_name(exec_file).c_str(), std::strerror(errno));
       _exit(errno == EACCES ? 126 : 127);
     }
     if (sh_.job_control) setpgid(pid, pid);
@@ -2155,15 +2127,14 @@ int Executor::run_coproc(const CoprocCommand *c) {
     for (char ch : c->name)
       if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) ok = false;
     if (!ok) {
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
-                   c->name.c_str());
+      sh_.errorf("`%s': not a valid identifier\n", c->name.c_str());
       return (sh_.last_status = 1);
     }
   }
   const std::string name = c->name.empty() ? std::string("COPROC") : c->name;
   int out_pipe[2], in_pipe[2];  // out: coproc->shell;  in: shell->coproc
   if (pipe(out_pipe) < 0) {
-    std::fprintf(stderr, "%scoproc: pipe: %s\n", sh_.err_prefix().c_str(), std::strerror(errno));
+    sh_.errorf("coproc: pipe: %s\n", std::strerror(errno));
     return (sh_.last_status = 1);
   }
   // bash's sh_openpipe moves each pipe end to the HIGHEST free descriptor
@@ -2183,7 +2154,7 @@ int Executor::run_coproc(const CoprocCommand *c) {
   out_pipe[0] = move_high64(out_pipe[0]);
   out_pipe[1] = move_high64(out_pipe[1]);
   if (pipe(in_pipe) < 0) {
-    std::fprintf(stderr, "%scoproc: pipe: %s\n", sh_.err_prefix().c_str(), std::strerror(errno));
+    sh_.errorf("coproc: pipe: %s\n", std::strerror(errno));
     close(out_pipe[0]); close(out_pipe[1]);
     return (sh_.last_status = 1);
   }
@@ -2341,8 +2312,7 @@ int Executor::run_for(const ForCommand *c) {
     for (char ch : c->var)
       if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) okname = false;
     if (!okname) {
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
-                   c->var.c_str());
+      sh_.errorf("`%s': not a valid identifier\n", c->var.c_str());
       // In posix mode a bad iteration-variable name is a fatal error in a
       // non-interactive shell: the shell (or subshell) exits rather than
       // continuing past the loop.
@@ -2429,13 +2399,11 @@ int Executor::run_for(const ForCommand *c) {
     auto vit = sh_.vars.find(c->var);
     if (vit != sh_.vars.end() && vit->second.nameref) {
       if (vit->second.readonly)
-        std::fprintf(stderr, "%s%s: readonly variable\n", sh_.err_prefix().c_str(),
-                     c->var.c_str());
+        sh_.errorf("%s: readonly variable\n", c->var.c_str());
       else if (!Shell::valid_nameref_target(item)) {
         // Retargeting a nameref to a non-identifier (`for r in /') is an error,
         // like `declare -n r=/'; bash aborts the loop rather than continuing.
-        std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
-                     item.c_str());
+        sh_.errorf("`%s': not a valid identifier\n", item.c_str());
         st = 1;
         break;
       } else
@@ -2478,8 +2446,7 @@ int Executor::run_select(const ForCommand *c) {
     for (char ch : c->var)
       if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) okname = false;
     if (!okname) {
-      std::fprintf(stderr, "%s`%s': not a valid identifier\n", sh_.err_prefix().c_str(),
-                   c->var.c_str());
+      sh_.errorf("`%s': not a valid identifier\n", c->var.c_str());
       if (sh_.opt_posix && !sh_.interactive) { sh_.exiting = true; sh_.exit_status = 1; }
       return (sh_.last_status = 1);
     }
@@ -2681,8 +2648,7 @@ int Executor::run_funcdef(const FunctionDef *c) {
   if (c->name.find_first_of("$'\"\\") != std::string::npos ||
       // A process-substitution-shaped name (`<(:) ()') is likewise rejected.
       ((c->name[0] == '<' || c->name[0] == '>') && c->name.size() > 1 && c->name[1] == '(')) {
-    std::fprintf(stderr, "%s`%s': not a valid identifier\n",
-                 sh_.err_prefix().c_str(), c->name.c_str());
+    sh_.errorf("`%s': not a valid identifier\n", c->name.c_str());
     return (sh_.last_status = 1);
   }
   // Posix interpretation 383: a function may not have the name of a special
@@ -2694,8 +2660,7 @@ int Executor::run_funcdef(const FunctionDef *c) {
         "exit",   "export", "readonly", "return", "set", "shift",
         "source", "times", "trap",  "unset"};
     if (kSpecialB.count(c->name)) {
-      std::fprintf(stderr, "%s`%s': is a special builtin\n", sh_.err_prefix().c_str(),
-                   c->name.c_str());
+      sh_.errorf("`%s': is a special builtin\n", c->name.c_str());
       sh_.last_status = 2;
       if (!sh_.interactive) { sh_.exiting = true; sh_.exit_status = 2; }
       return 2;
@@ -2703,8 +2668,7 @@ int Executor::run_funcdef(const FunctionDef *c) {
   }
   // A readonly function cannot be redefined.
   if (sh_.readonly_functions.count(c->name)) {
-    std::fprintf(stderr, "%s%s: readonly function\n", sh_.err_prefix().c_str(),
-                 c->name.c_str());
+    sh_.errorf("%s: readonly function\n", c->name.c_str());
     return (sh_.last_status = 1);
   }
   sh_.functions[c->name] = c->body.get();

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -746,7 +746,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.last_bg_pid == 0) {
       set = false;
       if (sh_.opt_nounset && !defaulting_op) {
-        std::fprintf(stderr, "%s!: unbound variable\n", sh_.err_prefix().c_str());
+        sh_.errorf("!: unbound variable\n");
         sh_.exiting = true;
         sh_.exit_status = 127;
       }
@@ -801,8 +801,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
     if (sh_.opt_nounset && !defaulting_op) {
       // bash names an unbound positional `$N' for the bare `$N' form but `N'
       // for the braced `${N}' form.
-      std::fprintf(stderr, "%s%s%s: unbound variable\n", sh_.err_prefix().c_str(),
-                   braced ? "" : "$", name.c_str());
+      sh_.errorf("%s%s: unbound variable\n", braced ? "" : "$", name.c_str());
       sh_.exiting = true;
       sh_.exit_status = 127;
     }
@@ -835,7 +834,7 @@ std::string Expander::param_value(const std::string &name, bool &set, bool defau
   // blame the nameref for it as well.
   if (sh_.exiting) return std::string();
   if (sh_.opt_nounset && !defaulting_op) {
-    std::fprintf(stderr, "%s%s: unbound variable\n", sh_.err_prefix().c_str(), name.c_str());
+    sh_.errorf("%s: unbound variable\n", name.c_str());
     sh_.exiting = true;
     sh_.exit_status = 127;  // bash exits a non-interactive shell with 127 here
   }
@@ -972,8 +971,7 @@ static void slice_len_error(Shell &sh, const std::string &lenx) {
   // bash quotes the length expression as WRITTEN (`$(($# - 2))'), not its
   // evaluated value, so an array slice with a negative length reproduces the
   // source text in the diagnostic.
-  std::fprintf(stderr, "%s%s: substring expression < 0\n", sh.err_prefix().c_str(),
-               lenx.c_str());
+  sh.errorf("%s: substring expression < 0\n", lenx.c_str());
   sh.arith_error = true;
   sh.arith_abort = true;  // bash unwinds the whole command list, not just this word
 }
@@ -1444,7 +1442,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
       // it a function substitution with an empty body, which is valid and
       // expands to nothing.  Only the empty body is an error.
       if (body.empty()) {
-        std::fprintf(stderr, "%s${}: bad substitution\n", sh_.err_prefix().c_str());
+        sh_.errorf("${}: bad substitution\n");
         // arith_error alone, as every other bad substitution here does: bash
         // abandons the command list for some of these and not others (not in a
         // here-document body, for one), and gnash does not model that split
@@ -1647,8 +1645,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           // parse as `${bad-var}').  An EMPTY value keeps the scalar path's
           // `invalid indirect expansion' / defaulting-operator handling.
           if (!okname && !target.empty()) {
-            std::fprintf(stderr, "%s%s: invalid variable name\n", sh_.err_prefix().c_str(),
-                         target.c_str());
+            sh_.errorf("%s: invalid variable name\n", target.c_str());
             sh_.arith_error = true;
             i = end + 1;
             return;
@@ -1683,8 +1680,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
               tset = sh_.get_if_set(target, tmpv);
             }
             if (sh_.opt_nounset && !dfl && !tset) {
-              std::fprintf(stderr, "%s!%s: unbound variable\n", sh_.err_prefix().c_str(),
-                           iname2.c_str());
+              sh_.errorf("!%s: unbound variable\n", iname2.c_str());
               sh_.exiting = true;
               sh_.exit_status = 127;
               i = end + 1;
@@ -2262,8 +2258,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
             }
             emit_values();
           } else {
-            std::fprintf(stderr, "%s%s: bad array subscript\n", sh_.err_prefix().c_str(),
-                         dispname.c_str());
+            sh_.errorf("%s: bad array subscript\n", dispname.c_str());
             sh_.exiting = true;
             sh_.exit_status = 1;
           }
@@ -2275,8 +2270,7 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
           if (empty_test) {
             std::string msg = expand_no_split(word);
             if (msg.empty()) msg = colon ? "parameter null or not set" : "parameter not set";
-            std::fprintf(stderr, "%s%s: %s\n", sh_.err_prefix().c_str(), dispname.c_str(),
-                         msg.c_str());
+            sh_.errorf("%s: %s\n", dispname.c_str(), msg.c_str());
             sh_.exiting = true;
             sh_.exit_status = 127;
           } else {
@@ -2717,8 +2711,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     else if (std::isdigit(static_cast<unsigned char>(r[0]))) {
       // `${#1xyz}': a positional reference that is not a digit run is not a
       // parameter at all, and `#' takes no such operator (more-exp.tests).
-      std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                   body.c_str());
+      sh.errorf("${%s}: bad substitution\n", body.c_str());
       sh.arith_error = true;
       return std::string();
     }
@@ -2733,8 +2726,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   if (!sh.is_zsh() && !length && b.size() == 2 &&
       !(std::isalnum(static_cast<unsigned char>(b[0])) || b[0] == '_') &&
       (b[1] == ':' || (b[0] == '#' && std::strchr("/%=^,+", b[1]) != nullptr))) {
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                 body.c_str());
+    sh.errorf("${%s}: bad substitution\n", body.c_str());
     sh.arith_error = true;
     return std::string();
   }
@@ -2764,7 +2756,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       bool op_follows = b[sp] == '@' && sp + 1 < b.size() && !pre.empty();
       bool ok = op_follows || ((pre.empty() || ident) && sp + 1 == b.size());
       if (!ok) {
-        std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+        sh.errorf("${%s}: bad substitution\n", b.c_str());
         sh.arith_error = true;
         return std::string();
       }
@@ -2805,8 +2797,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
         std::string sub = b.substr(q + 1, b.size() - q - 2);
         std::string elem = sh.array_get(sh.deref(iname), sub);
         if (elem.empty()) {
-          std::fprintf(stderr, "%s%s%s: invalid indirect expansion\n", sh.err_prefix().c_str(),
-                       iname.c_str(), b.substr(q).c_str());
+          sh.errorf("%s%s: invalid indirect expansion\n", iname.c_str(), b.substr(q).c_str());
           sh.arith_error = true;
           return std::string();
         }
@@ -2834,8 +2825,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
         // An empty subscript on the indirection target (`${!arr[]}') is a
         // bad substitution naming the whole body, as bash (issue #653).
         if (sub.empty() && !sh.is_zsh()) {
-          std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                       body.c_str());
+          sh.errorf("${%s}: bad substitution\n", body.c_str());
           sh.arith_error = true;
           return std::string();
         }
@@ -2865,8 +2855,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
             ni++;
           if (ni < tval.size() && !(tval[ni] == '[' && tval.back() == ']')) okname = false;
           if (!okname) {
-            std::fprintf(stderr, "%s%s: invalid variable name\n", sh.err_prefix().c_str(),
-                         tval.c_str());
+            sh.errorf("%s: invalid variable name\n", tval.c_str());
             sh.arith_error = true;
             return std::string();
           }
@@ -2924,8 +2913,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
           if (irest[ro] == '-') return ex.expand_no_split(irest.substr(ro + 1));
           if (irest[ro] == '+') return std::string();
         }
-        std::fprintf(stderr, "%s%s: invalid indirect expansion\n", sh.err_prefix().c_str(),
-                     iname.c_str());
+        sh.errorf("%s: invalid indirect expansion\n", iname.c_str());
         sh.arith_error = true;
         return std::string();
       }
@@ -2939,7 +2927,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   // bad substitution rather than treating the leading `$' as the PID.  (`${$}'
   // alone is still the PID.)
   if (b.size() >= 2 && b[0] == '$' && b[1] == '(') {
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), b.c_str());
+    sh.errorf("${%s}: bad substitution\n", b.c_str());
     sh.arith_error = true;
     return std::string();
   }
@@ -2965,7 +2953,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
       if (b[k] == '$' && k + 1 < b.size() && b[k + 1] == '\'') continue;
       mb += b[k];
     }
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(), mb.c_str());
+    sh.errorf("${%s}: bad substitution\n", mb.c_str());
     sh.arith_error = true;
     return std::string();
   }
@@ -3006,8 +2994,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   // for associative arrays too, rather than reading index 0 (issue #653).
   // The assignment form (`arr[]=x') has its own check in the executor.
   if (have_sub && sub.empty() && !sh.is_zsh()) {
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                 body.c_str());
+    sh.errorf("${%s}: bad substitution\n", body.c_str());
     sh.arith_error = true;
     return std::string();
   }
@@ -3023,8 +3010,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
   // any malformed `!' form was already rejected by the listing validation.)
   if (!name.empty() && name != "!" && p < b.size() && !sh.is_zsh() &&
       !std::strchr(":-+=?#%/^,@~", b[p])) {
-    std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                 have_sub ? b.c_str() : body.c_str());
+    sh.errorf("${%s}: bad substitution\n", have_sub ? b.c_str() : body.c_str());
     sh.arith_error = true;
     return std::string();
   }
@@ -3069,8 +3055,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     // text: `${#wheat[$unset]}' -> `[$unset]: bad array subscript', and the
     // command aborts (bash).
     if (assoc_sub && esub.empty() && sub != "@" && sub != "*") {
-      std::fprintf(stderr, "%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
-                   sub.c_str());
+      sh.errorf("[%s]: bad array subscript\n", sub.c_str());
       sh.arith_error = true;
       return std::string();
     }
@@ -3106,12 +3091,10 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
           // command; the VALUE form names the base and expands to empty with
           // the command still running (`echo ${c[-4]}' prints a blank line).
           if (length) {
-            std::fprintf(stderr, "%s[%s]: bad array subscript\n", sh.err_prefix().c_str(),
-                         sub.c_str());
+            sh.errorf("[%s]: bad array subscript\n", sub.c_str());
             sh.arith_error = true;
           } else {
-            std::fprintf(stderr, "%s%s: bad array subscript\n", sh.err_prefix().c_str(),
-                         name.c_str());
+            sh.errorf("%s: bad array subscript\n", name.c_str());
           }
           return std::string();
         }
@@ -3127,8 +3110,7 @@ static std::string expand_brace_body(Expander &ex, Shell &sh, const std::string 
     if (!set && sh.opt_nounset && !defaulting_op && tsub != "@" && tsub != "*") {
       // bash names the subscript as WRITTEN, not the index it evaluated to:
       // `a=() k=; "${a[k]}"' reports `a[k]', not `a[0]'.
-      std::fprintf(stderr, "%s%s[%s]: unbound variable\n", sh.err_prefix().c_str(),
-                   name.c_str(), sub.c_str());
+      sh.errorf("%s[%s]: unbound variable\n", name.c_str(), sub.c_str());
       sh.exiting = true;
       sh.exit_status = 127;
       return std::string();
@@ -3189,8 +3171,7 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
             (std::isdigit(static_cast<unsigned char>(name[0])) || name == "@" ||
              name == "*" || name == "#" || name == "?" || name == "$" ||
              name == "!" || name == "-")) {
-          std::fprintf(stderr, "%s$%s: cannot assign in this way\n", sh.err_prefix().c_str(),
-                       name.c_str());
+          sh.errorf("$%s: cannot assign in this way\n", name.c_str());
           sh.arith_error = true;
           return std::string();
         }
@@ -3242,7 +3223,7 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
       if (empty) {
         std::string msg = expand_word(word);
         if (msg.empty()) msg = colon ? "parameter null or not set" : "parameter not set";
-        std::fprintf(stderr, "%s%s: %s\n", sh.err_prefix().c_str(), name.c_str(), msg.c_str());
+        sh.errorf("%s: %s\n", name.c_str(), msg.c_str());
         sh.exiting = true;
         sh.exit_status = 127;  // bash: a fatal ${x?} / set -u error exits with 127
         return std::string();
@@ -3524,8 +3505,7 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (!set && sh.vars.find(name) == sh.vars.end()) return std::string();
     if (!valid) {
       std::string bodytxt = name + (have_sub ? "[" + sub + "]" : "") + rest;
-      std::fprintf(stderr, "%s${%s}: bad substitution\n", sh.err_prefix().c_str(),
-                   bodytxt.c_str());
+      sh.errorf("${%s}: bad substitution\n", bodytxt.c_str());
       // Unlike the other bad substitutions (DISCARD, status 1), an invalid
       // transform operator is fatal like `${x?}': bash exits a
       // non-interactive shell with 127 (issue #655).
@@ -3607,8 +3587,7 @@ static std::string apply_param_op(Expander &ex, Shell &sh, const std::string &na
     if (haslen) {
       end = (len < 0) ? n + len : (off > n - len ? n : off + len);
       if (end < off) {
-        std::fprintf(stderr, "%s%lld: substring expression < 0\n", sh.err_prefix().c_str(),
-                     len);
+        sh.errorf("%lld: substring expression < 0\n", len);
         sh.arith_error = true;
         sh.arith_abort = true;  // bash unwinds the whole command list
         return std::string();
@@ -4203,7 +4182,7 @@ std::vector<std::string> Expander::glob_field(const std::string &field, const st
     auto fg = sh_.shopt_opts.find("failglob");
     if (fg != sh_.shopt_opts.end() && fg->second) {
       if (!sh_.arith_error) {
-        std::fprintf(stderr, "%sno match: %s\n", sh_.err_prefix().c_str(), field.c_str());
+        sh_.errorf("no match: %s\n", field.c_str());
         sh_.arith_error = true;
       }
       return {};

--- a/core/src/expand.cpp
+++ b/core/src/expand.cpp
@@ -10,6 +10,7 @@
 #include "gnash/core/builtins.hpp"
 #include "gnash/core/expand.hpp"
 #include "gnash/core/lexer.hpp"
+#include "gnash/core/quote.hpp"
 #include "gnash/core/subscript.hpp"
 
 #include <algorithm>
@@ -2539,107 +2540,24 @@ void Expander::expand_dollar(const std::string &t, size_t &i, bool dq, std::stri
   for (char c : v) { out += c; mask += qm; }
 }
 
-// Parse and apply ${...} operators.
-// ${var@Q}: single-quote the value so it can be re-read as shell input, using
-// $'...' when it contains control characters.
+// The ${var@Q} transformation: single-quote the value so it can be re-read
+// as shell input, using $'...' when it holds non-printable bytes (quote.hpp
+// carries both idioms).
 static std::string atq_quote(const std::string &s) {
-  bool ctrl = false;
-  for (unsigned char c : s)
-    if (c < 32 || c == 127) { ctrl = true; break; }
-  if (ctrl) {
-    std::string r = "$'";
-    for (unsigned char c : s) {
-      switch (c) {
-        case '\n': r += "\\n"; break;
-        case '\t': r += "\\t"; break;
-        case '\r': r += "\\r"; break;
-        case '\\': r += "\\\\"; break;
-        case '\'': r += "\\'"; break;
-        default:
-          if (c < 32 || c == 127) { char b[8]; std::snprintf(b, sizeof b, "\\%03o", c); r += b; }
-          else r += static_cast<char>(c);
-      }
-    }
-    return r + "'";
-  }
-  std::string r = "'";
-  for (char c : s) {
-    if (c == '\'') r += "'\\''";
-    else r += c;
-  }
-  return r + "'";
-}
-
-// True if S contains any non-printable byte (bash's ansic_shouldquote).
-static bool kv_has_nonprint(const std::string &s) {
-  for (unsigned char c : s)
-    if (c < 32 || c == 127) return true;
-  return false;
-}
-
-// Produce a $'...' ANSI-C quotation of S (used when a kvpair key/value holds
-// non-printable bytes).
-static std::string kv_ansic_quote(const std::string &s) {
-  std::string r = "$'";
-  for (unsigned char c : s) {
-    switch (c) {
-      case '\n': r += "\\n"; break;
-      case '\t': r += "\\t"; break;
-      case '\r': r += "\\r"; break;
-      case '\\': r += "\\\\"; break;
-      case '\'': r += "\\'"; break;
-      default:
-        if (c < 32 || c == 127) { char b[8]; std::snprintf(b, sizeof b, "\\%03o", c); r += b; }
-        else r += static_cast<char>(c);
-    }
-  }
-  return r + "'";
-}
-
-// Double-quote S, backslash-escaping the characters special inside "..."
-// (bash's sh_double_quote).
-static std::string kv_double_quote(const std::string &s) {
-  std::string r = "\"";
-  for (char c : s) {
-    if (c == '"' || c == '\\' || c == '$' || c == '`') r += '\\';
-    r += c;
-  }
-  return r + "\"";
-}
-
-// True if KEY contains a shell metacharacter that forces quoting in an assoc
-// kvpair key (bash's sh_contains_shell_metas).
-static bool kv_contains_metas(const std::string &s) {
-  for (size_t i = 0; i < s.size(); i++) {
-    char c = s[i];
-    switch (c) {
-      case ' ': case '\t': case '\n': case '\'': case '"': case '\\':
-      case '|': case '&': case ';': case '(': case ')': case '<': case '>':
-      case '!': case '{': case '}': case '*': case '[': case '?': case ']':
-      case '^': case '$': case '`':
-        return true;
-      case '~':
-        if (i == 0 || s[i - 1] == '=' || s[i - 1] == ':') return true;
-        break;
-      case '#':
-        if (i == 0) return true;
-        break;
-    }
-  }
-  return false;
+  return has_nonprint(s) ? ansic_quote(s) : single_quote(s);
 }
 
 // Quote a kvpair value: $'...' if it holds non-printables, else "...".
 static std::string kv_value_quote(const std::string &v) {
   if (v.empty()) return "\"\"";
-  return kv_has_nonprint(v) ? kv_ansic_quote(v) : kv_double_quote(v);
+  return has_nonprint(v) ? ansic_quote(v) : double_quote(v);
 }
 
 // Quote an assoc kvpair key: bare unless it needs $'...'/double-quoting.
 static std::string kv_key_quote(const std::string &k) {
-  if (kv_has_nonprint(k)) return kv_ansic_quote(k);
-  if (kv_contains_metas(k)) return kv_double_quote(k);
-  if (k.size() == 1 && (k[0] == '@' || k[0] == '*')) return kv_double_quote(k);
+  if (has_nonprint(k)) return ansic_quote(k);
+  if (contains_shell_metas(k)) return double_quote(k);
+  if (k.size() == 1 && (k[0] == '@' || k[0] == '*')) return double_quote(k);
   return k;
 }
 

--- a/core/src/jobs.cpp
+++ b/core/src/jobs.cpp
@@ -246,8 +246,7 @@ void Shell::reap_coproc() {
   unset(nm + "_PID", /*force=*/true, /*noref=*/false);
   auto it = vars.find(tgt);
   if (it != vars.end() && it->second.readonly)
-    std::fprintf(stderr, "%s%s: cannot unset: readonly variable\n", err_prefix().c_str(),
-                 nm.c_str());
+    errorf("%s: cannot unset: readonly variable\n", nm.c_str());
   else
     unset(nm, false, false);
 }
@@ -484,7 +483,7 @@ void Shell::print_jobs(const std::string &spec, bool lflag, bool pflag, bool rfl
   if (!spec.empty()) {
     Job *j = job_by_spec(spec);
     if (!j) {
-      std::fprintf(stderr, "%sjobs: %s: no such job\n", err_prefix().c_str(), spec.c_str());
+      errorf("jobs: %s: no such job\n", spec.c_str());
       return;
     }
     only = j->id;

--- a/core/src/shell.cpp
+++ b/core/src/shell.cpp
@@ -460,16 +460,14 @@ bool Shell::apply_xtracefd(const char *value) {
   // bash requires the whole value to be the number AND the fd to be open.
   if (end == v.c_str() || *end != '\0' || fd < 0 || fd > INT_MAX ||
       fcntl(static_cast<int>(fd), F_GETFD) == -1) {
-    std::fprintf(stderr, "%sBASH_XTRACEFD: %s: invalid value for trace file descriptor\n",
-                 err_prefix().c_str(), v.c_str());
+    errorf("BASH_XTRACEFD: %s: invalid value for trace file descriptor\n", v.c_str());
     return false;
   }
   if (xtrace_fd == static_cast<int>(fd)) return true;  // already there
   reset();
   std::FILE *fp = fdopen(static_cast<int>(fd), "w");
   if (!fp) {
-    std::fprintf(stderr, "%sBASH_XTRACEFD: %s: cannot open as FILE\n",
-                 err_prefix().c_str(), v.c_str());
+    errorf("BASH_XTRACEFD: %s: cannot open as FILE\n", v.c_str());
     return false;
   }
   // Unbuffered: a script commonly writes the trace to a file and reads it back
@@ -733,15 +731,13 @@ std::string Shell::get(const std::string &n_in) const {
   // A chain longer than nameref_max() resolves to nothing, with bash's warning
   // naming the limit actually in force.
   if (too_deep) {
-    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
-                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    errorf("warning: %s: maximum nameref depth (%d) exceeded\n", n_in.c_str(), nameref_max());
     return std::string();
   }
   if (circular) {
     // bash warns and, at function scope, resolves the reference at global
     // scope (find_variable_nameref); at global scope it resolves to nothing.
-    std::fprintf(stderr, "%swarning: %s: circular name reference\n",
-                 err_prefix().c_str(), n_in.c_str());
+    errorf("warning: %s: circular name reference\n", n_in.c_str());
     const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
     return g ? scalar_of(*g) : std::string();
   }
@@ -961,7 +957,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   // alias, after the same name validation the alias builtin performs.
   if (n == "BASH_ALIASES" && !is_zsh()) {
     if (!valid_alias_name(sub)) {
-      std::fprintf(stderr, "%s`%s': invalid alias name\n", err_prefix().c_str(), sub.c_str());
+      errorf("`%s': invalid alias name\n", sub.c_str());
       return;
     }
     alias_remember(sub, val);
@@ -973,7 +969,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   if (n == "BASH_CMDS") {
     if (val.find('/') != std::string::npos) {
       if (opt_restricted) {
-        std::fprintf(stderr, "%s%s: restricted\n", err_prefix().c_str(), val.c_str());
+        errorf("%s: restricted\n", val.c_str());
         return;
       }
       hash_remember(sub, val);
@@ -991,7 +987,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
       p = q + 1;
     }
     if (full.empty()) {
-      std::fprintf(stderr, "%s%s: not found\n", err_prefix().c_str(), val.c_str());
+      errorf("%s: not found\n", val.c_str());
       return;
     }
     hash_remember(sub, full);
@@ -1013,7 +1009,7 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
   std::string fv = fold_case(val, v.ucase, v.lcase, v.capcase);
   if (v.kind == VarKind::Assoc) {
     if (v.readonly) {
-      std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+      errorf("%s: readonly variable\n", n.c_str());
       last_status = 1;
       return;
     }
@@ -1046,15 +1042,14 @@ void Shell::array_set(const std::string &n_in, const std::string &sub, const std
                                                                       : -1;
     k += maxi + 1;
     if (k < 0) {
-      std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", err_prefix().c_str(),
-                   n.c_str(), sub.c_str());
+      errorf("%s[%s]: bad array subscript\n", n.c_str(), sub.c_str());
       arith_abort = true;
       last_status = 1;
       return;
     }
   }
   if (v.readonly) {
-    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    errorf("%s: readonly variable\n", n.c_str());
     last_status = 1;
     return;
   }
@@ -1207,8 +1202,7 @@ void Shell::array_assign(
   // (`declare -n ref=XXX[0]; ref+=(...)') has no valid whole-array target: bash
   // rejects the resolved `XXX[0]' as not a valid identifier and assigns nothing.
   if (n.find('[') != std::string::npos) {
-    std::fprintf(stderr, "%s`%s': not a valid identifier\n", err_prefix().c_str(),
-                 n.c_str());
+    errorf("`%s': not a valid identifier\n", n.c_str());
     return;
   }
   bool existed = vars.count(n) != 0;
@@ -1216,7 +1210,7 @@ void Shell::array_assign(
   if (v.readonly) {
     // A compound assignment to a readonly variable reports and assigns
     // nothing (`readonly a=7; a=(1 2 3)' -- varenv11.sub).
-    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    errorf("%s: readonly variable\n", n.c_str());
     last_status = 1;
     return;
   }
@@ -1226,8 +1220,7 @@ void Shell::array_assign(
   // with a valid target resolves to that target above, so this never fires for
   // it.
   if (v.nameref) {
-    std::fprintf(stderr, "%swarning: %s: removing nameref attribute\n",
-                 err_prefix().c_str(), n.c_str());
+    errorf("warning: %s: removing nameref attribute\n", n.c_str());
     v.nameref = false;
   }
   v.invisible = false;  // even `b=()' makes a declared-but-unset array visible
@@ -1261,7 +1254,7 @@ void Shell::array_assign(
       // An empty key in the flat list is a bad subscript; bash reports it as
       // `"": bad array subscript' and stops the assignment (assoc11.sub).
       if (key.empty()) {
-        std::fprintf(stderr, "%s\"\": bad array subscript\n", err_prefix().c_str());
+        errorf("\"\": bad array subscript\n");
         last_status = 1;
         return;
       }
@@ -1487,15 +1480,13 @@ bool Shell::get_if_set(const std::string &n_in, std::string &out) const {
   // A chain longer than nameref_max() resolves to nothing, with bash's warning
   // naming the limit actually in force.
   if (too_deep) {
-    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
-                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    errorf("warning: %s: maximum nameref depth (%d) exceeded\n", n_in.c_str(), nameref_max());
     return false;
   }
   if (circular) {
     // Same resolution as get(): warn, and at function scope fall through to the
     // global binding; a global-scope cycle resolves to nothing (unset).
-    std::fprintf(stderr, "%swarning: %s: circular name reference\n",
-                 err_prefix().c_str(), n_in.c_str());
+    errorf("warning: %s: circular name reference\n", n_in.c_str());
     const Variable *g = in_function() ? global_var_ptr(n_in) : nullptr;
     if (!g) return false;
     if (g->kind == VarKind::Indexed) {
@@ -1585,8 +1576,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
       std::string sub = n_in.substr(lb + 1, n_in.size() - lb - 2);
       auto bit = vars.find(deref(base));
       if (bit != vars.end() && bit->second.readonly) {
-        std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
-                     base.c_str());
+        errorf("%s: readonly variable\n", base.c_str());
         return false;
       }
       array_set(base, sub, v);
@@ -1611,8 +1601,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
           size_t lb = ov.find('[');
           if (lb != std::string::npos && lb > 0 && ov.back() == ']' &&
               ov.compare(0, lb, n_in) == 0) {
-            std::fprintf(stderr, "%s`%s[%s]': not a valid identifier\n",
-                         err_prefix().c_str(), base.c_str(), sub.c_str());
+            errorf("`%s[%s]': not a valid identifier\n", base.c_str(), sub.c_str());
             return false;
           }
         }
@@ -1621,8 +1610,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
       // (`declare -n r=a[@]; r=5') has no single element to target: bash rejects
       // the `@'/`*' subscript as a bad array subscript and assigns nothing.
       if (sub == "@" || sub == "*") {
-        std::fprintf(stderr, "%s%s[%s]: bad array subscript\n", err_prefix().c_str(),
-                     base.c_str(), sub.c_str());
+        errorf("%s[%s]: bad array subscript\n", base.c_str(), sub.c_str());
         return false;
       }
       // The chain looped back to an ELEMENT of a variable that is itself a
@@ -1632,8 +1620,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
       {
         auto bv = vars.find(base);
         if (bv != vars.end() && bv->second.nameref) {
-          std::fprintf(stderr, "%swarning: %s: removing nameref attribute\n",
-                       err_prefix().c_str(), base.c_str());
+          errorf("warning: %s: removing nameref attribute\n", base.c_str());
           bv->second.nameref = false;
           bv->second.value.clear();
           bv->second.invisible = false;
@@ -1641,8 +1628,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
       }
       auto it = vars.find(base);
       if (it != vars.end() && it->second.readonly) {
-        std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
-                     base.c_str());
+        errorf("%s: readonly variable\n", base.c_str());
         return false;
       }
       array_set(base, sub, v);
@@ -1655,8 +1641,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   // Too long a chain has no variable at the end to assign to: bash warns and
   // fails the assignment, which (with no command word) abandons the list.
   if (too_deep) {
-    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (%d) exceeded\n",
-                 err_prefix().c_str(), n_in.c_str(), nameref_max());
+    errorf("warning: %s: maximum nameref depth (%d) exceeded\n", n_in.c_str(), nameref_max());
     return false;
   }
   // A circular nameref (self reference `v->v' or a longer loop).  At function
@@ -1665,20 +1650,17 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   // no persistent effect.
   if (circular) {
     if (!in_function()) {
-      std::fprintf(stderr, "%swarning: %s: circular name reference\n",
-                   err_prefix().c_str(), n_in.c_str());
+      errorf("warning: %s: circular name reference\n", n_in.c_str());
       // A cycle has nothing to assign to, so this is an assignment ERROR:
       // `x=4; echo A' warns and abandons the rest of the list.  Inside a
       // function the reference binds at global scope instead and execution
       // carries on, which is why only the global-scope branch fails.
       return false;
     }
-    std::fprintf(stderr, "%swarning: %s: maximum nameref depth (8) exceeded\n",
-                 err_prefix().c_str(), n_in.c_str());
+    errorf("warning: %s: maximum nameref depth (8) exceeded\n", n_in.c_str());
     Variable &g = global_var_ref(n_in);
     if (g.readonly) {
-      std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(),
-                   n_in.c_str());
+      errorf("%s: readonly variable\n", n_in.c_str());
       return false;
     }
     if (g.kind == VarKind::Indexed) {
@@ -1702,8 +1684,8 @@ bool Shell::set(const std::string &n_in, const std::string &v,
     if (it != vars.end() && it->second.nameref && it->second.value.empty() &&
         !valid_nameref_target(v)) {
       bool has_ctx = nameref_ctx && nameref_ctx[0];
-      std::fprintf(stderr, "%s%s%s`%s': not a valid identifier\n", err_prefix().c_str(),
-                   has_ctx ? nameref_ctx : "", has_ctx ? ": " : "", v.c_str());
+      errorf("%s%s`%s': not a valid identifier\n", has_ctx ? nameref_ctx : "", has_ctx ? ": " : "",
+             v.c_str());
       return false;
     }
   }
@@ -1728,7 +1710,7 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   }
   if (opt_restricted &&
       (n == "PATH" || n == "SHELL" || n == "ENV" || n == "BASH_ENV")) {
-    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    errorf("%s: readonly variable\n", n.c_str());
     return false;
   }
   // A computed variable carries bash's att_noassign: a scalar assignment is
@@ -1738,12 +1720,12 @@ bool Shell::set(const std::string &n_in, const std::string &v,
   // $SHELLOPTS and $BASHOPTS are readonly instead: assigning to one is an
   // error, which (having no command word) also abandons the command list.
   if (!is_zsh() && (n == "SHELLOPTS" || n == "BASHOPTS")) {
-    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    errorf("%s: readonly variable\n", n.c_str());
     return false;
   }
   Variable &var = vars[n];
   if (var.readonly) {
-    std::fprintf(stderr, "%s%s: readonly variable\n", err_prefix().c_str(), n.c_str());
+    errorf("%s: readonly variable\n", n.c_str());
     return false;
   }
   var.value = v;
@@ -2437,7 +2419,7 @@ int Shell::run_script_lines(const std::string &text) {
           using_history();
         }
         if (hr < 0) {
-          std::fprintf(stderr, "%s%s\n", err_prefix().c_str(), hv ? hv : "history expansion failed");
+          errorf("%s\n", hv ? hv : "history expansion failed");
           std::free(hv);
           st = last_status = 1;
           continue;  // the failed line is neither run nor recorded
@@ -2595,10 +2577,8 @@ int Shell::run_string(const std::string &script, const std::vector<int> *cont_li
       int nlines = static_cast<int>(std::count(script.begin(), script.end(), '\n'));
       cur_lineno = lineno_base + nlines +
                    ((!script.empty() && script.back() == '\n') ? 0 : 1);
-      std::fprintf(stderr,
-                   "%swarning: here-document at line %d delimited by end-of-file (wanted `%s')\n",
-                   err_prefix().c_str(), lineno_base + r.heredoc_eof_line,
-                   r.heredoc_eof_delim.c_str());
+      errorf("warning: here-document at line %d delimited by end-of-file (wanted `%s')\n",
+             lineno_base + r.heredoc_eof_line, r.heredoc_eof_delim.c_str());
       cur_lineno = save_ln;
     }
     size_t p0 = 0;
@@ -2666,8 +2646,8 @@ int Shell::run_string(const std::string &script, const std::vector<int> *cont_li
   if (r.comsub_unterm) {
     int save_ln = cur_lineno;
     cur_lineno = lineno_base + r.comsub_unterm_line;
-    std::fprintf(stderr, "%swarning: command substitution: %d unterminated here-document%s\n",
-                 err_prefix().c_str(), r.comsub_unterm, r.comsub_unterm > 1 ? "s" : "");
+    errorf("warning: command substitution: %d unterminated here-document%s\n", r.comsub_unterm,
+           r.comsub_unterm > 1 ? "s" : "");
     cur_lineno = save_ln;
   }
   if (r.heredoc_eof) {  // run anyway, with bash's warning
@@ -2680,10 +2660,8 @@ int Shell::run_string(const std::string &script, const std::vector<int> *cont_li
     // a new one (a file's last line is the EOF line).
     cur_lineno = lineno_base + nlines +
                  ((!script.empty() && script.back() == '\n') ? 0 : 1);
-    std::fprintf(stderr,
-                 "%swarning: here-document at line %d delimited by end-of-file (wanted `%s')\n",
-                 err_prefix().c_str(), lineno_base + r.heredoc_eof_line,
-                 r.heredoc_eof_delim.c_str());
+    errorf("warning: here-document at line %d delimited by end-of-file (wanted `%s')\n",
+           lineno_base + r.heredoc_eof_line, r.heredoc_eof_delim.c_str());
     cur_lineno = save_ln;
   }
   if (!r.command) { subshell_leaf = false; return last_status; }
@@ -2832,8 +2810,7 @@ std::string Shell::run_and_capture(const std::string &script, int *status) {
         std::string path = ex.expand_no_split(raw, /*do_glob=*/!opt_posix);
         FILE *f = std::fopen(path.c_str(), "r");
         if (!f) {
-          std::fprintf(stderr, "%s%s: %s\n", err_prefix().c_str(), path.c_str(),
-                       std::strerror(errno));
+          errorf("%s: %s\n", path.c_str(), std::strerror(errno));
           if (status) *status = 1;
           return std::string();
         }

--- a/tests/arith_test.cpp
+++ b/tests/arith_test.cpp
@@ -7,9 +7,11 @@
 
 #include "gnash/core/shell.hpp"
 
+#include "testcheck.hpp"
+
 namespace core = gnash::core;
 
-static int failures = 0;
+using gnashtest::failures;
 
 static void eq(const char *expr, long long want) {
   static core::Shell sh;
@@ -113,10 +115,5 @@ int main() {
     if (core::eval_arith(sh, "y * 2", &ok) != 42) { std::fprintf(stderr, "FAIL recursive y\n"); failures++; }
   }
 
-  if (failures == 0) {
-    std::printf("all arith tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d arith test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("arith");
 }

--- a/tests/command_complete_test.cpp
+++ b/tests/command_complete_test.cpp
@@ -15,9 +15,11 @@
 #include "gnash/core/builtins.hpp"
 #include "gnash/core/shell.hpp"
 
+#include "testcheck.hpp"
+
 namespace core = gnash::core;
 
-static int failures = 0;
+using gnashtest::failures;
 
 static bool has(const std::vector<std::string> &v, const std::string &s) {
   return std::find(v.begin(), v.end(), s) != v.end();
@@ -80,10 +82,5 @@ int main() {
   unlink(noexe.c_str());
   rmdir(dir);
 
-  if (failures == 0) {
-    std::printf("all command-completion tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d command-completion test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("command-completion");
 }

--- a/tests/glob_test.cpp
+++ b/tests/glob_test.cpp
@@ -15,17 +15,11 @@
 #include "glob.h"
 #include "strmatch.h"
 
+#include "testcheck.hpp"
+
 namespace glob = gnash::glob;
 
-static int failures = 0;
-
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 static void m(const char *pat, const char *str, int flags, bool want) {
   bool got = glob::fnmatch(pat, str, flags);
@@ -170,10 +164,5 @@ int main() {
     if (system(rm.c_str()) != 0) { /* best effort */ }
   }
 
-  if (failures == 0) {
-    std::printf("all glob tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d glob test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("glob");
 }

--- a/tests/histexpand_test.cpp
+++ b/tests/histexpand_test.cpp
@@ -14,15 +14,9 @@
 
 #include "readline/history.h"
 
-static int failures = 0;
+#include "testcheck.hpp"
 
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 // Expand SRC and assert the return code and expanded text.
 static void expect(const char *src, int want_ret, const char *want_out) {
@@ -113,10 +107,5 @@ int main() {
 
   clear_history();
 
-  if (failures == 0) {
-    std::printf("all history_expand tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d history_expand test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("history_expand");
 }

--- a/tests/history_test.cpp
+++ b/tests/history_test.cpp
@@ -14,17 +14,11 @@
 #include "gnash/history.hpp"
 #include "readline/history.h"
 
+#include "testcheck.hpp"
+
 namespace hist = gnash::history;
 
-static int failures = 0;
-
-#define CHECK(cond)                                                       \
-  do {                                                                    \
-    if (!(cond)) {                                                        \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                         \
-    }                                                                     \
-  } while (0)
+using gnashtest::failures;
 
 static std::string tmp_path(const char *name) {
   const char *dir = std::getenv("TMPDIR");
@@ -203,10 +197,5 @@ int main() {
   test_file_timestamps();
   test_c_shim();
 
-  if (failures == 0) {
-    std::printf("all history tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d history test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("history");
 }

--- a/tests/job_notify_test.cpp
+++ b/tests/job_notify_test.cpp
@@ -24,7 +24,9 @@
 #include <pty.h>
 #endif
 
-static int failures = 0;
+#include "testcheck.hpp"
+
+using gnashtest::failures;
 
 // Read everything the shell writes to the pty until it stays quiet for
 // `settle_ms', appending to `out'.  Returns false once the child hangs up.
@@ -43,14 +45,6 @@ static bool drain(int fd, std::string &out, int settle_ms) {
 static void send(int fd, const char *s, std::string &out) {
   (void)!write(fd, s, std::strlen(s));
   drain(fd, out, 400);
-}
-
-static size_t count_of(const std::string &hay, const std::string &needle) {
-  size_t n = 0;
-  for (size_t at = hay.find(needle); at != std::string::npos;
-       at = hay.find(needle, at + needle.size()))
-    n++;
-  return n;
 }
 
 int main(int argc, char **argv) {
@@ -81,7 +75,7 @@ int main(int argc, char **argv) {
 
   // The stop of a foreground job is reported exactly once (bash prints one
   // "[1]+  Stopped" line, not one at stop time and another before the prompt).
-  size_t notices = count_of(out, "Stopped");
+  size_t notices = gnashtest::count_of(out, "Stopped");
   if (notices != 1) {
     std::fprintf(stderr, "FAIL expected exactly 1 Stopped notice after ^Z, got %zu\n%s\n",
                  notices, out.c_str());

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -8,9 +8,11 @@
 
 #include "gnash/core/lexer.hpp"
 
+#include "testcheck.hpp"
+
 namespace core = gnash::core;
 
-static int failures = 0;
+using gnashtest::failures;
 
 // Render the token stream compactly: word/io text verbatim, operators by name,
 // joined with spaces (EOF omitted).
@@ -91,10 +93,5 @@ int main() {
       }
   }
 
-  if (failures == 0) {
-    std::printf("all lexer tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d lexer test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("lexer");
 }

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -8,9 +8,11 @@
 
 #include "gnash/core/parser.hpp"
 
+#include "testcheck.hpp"
+
 namespace core = gnash::core;
 
-static int failures = 0;
+using gnashtest::failures;
 
 // Parse `in`; assert it succeeds and renders to `want`.
 static void ok(const std::string &in, const char *want) {
@@ -140,10 +142,5 @@ int main() {
   alias_ok("readme.md", {}, {}, {{"md", "less"}}, "less readme.md");    // suffix
   alias_ok("a.txt b.txt", {}, {}, {{"txt", "cat"}}, "cat a.txt b.txt"); // suffix only in cmd pos
 
-  if (failures == 0) {
-    std::printf("all parser tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d parser test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("parser");
 }

--- a/tests/prompt_column_test.cpp
+++ b/tests/prompt_column_test.cpp
@@ -29,7 +29,9 @@
 #include <pty.h>
 #endif
 
-static int failures = 0;
+#include "testcheck.hpp"
+
+using gnashtest::failures;
 
 // A minimal terminal: tracks the cursor column over the shell's output and,
 // when `answer' is set, replies to `ESC [ 6 n' with `ESC [ 1 ; col R'.
@@ -88,14 +90,6 @@ static bool drain(Term &t, std::string &out, int settle_ms) {
 static void send(Term &t, const char *s, std::string &out, int settle_ms = 400) {
   (void)!write(t.fd, s, std::strlen(s));
   drain(t, out, settle_ms);
-}
-
-static size_t count_of(const std::string &hay, const std::string &needle) {
-  size_t n = 0;
-  for (size_t at = hay.find(needle); at != std::string::npos;
-       at = hay.find(needle, at + needle.size()))
-    n++;
-  return n;
 }
 
 // Run one interactive session: `printf abc', then `echo hi', then exit.
@@ -163,7 +157,7 @@ int main(int argc, char **argv) {
   //    before), and the query is sent only once per session.
   {
     std::string out = session(argv[1], /*answer=*/false);
-    size_t queries = count_of(out, "\033[6n");
+    size_t queries = gnashtest::count_of(out, "\033[6n");
     if (queries != 1) {
       std::fprintf(stderr, "FAIL expected exactly 1 unanswered query, got %zu\n%s\n", queries,
                    out.c_str());

--- a/tests/readline_bind_test.cpp
+++ b/tests/readline_bind_test.cpp
@@ -10,38 +10,9 @@
 
 #include "readline/readline.h"
 
-static int failures = 0;
+#include "readline_test_support.hpp"
 
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
-
-static char *run(const std::string &input) {
-  FILE *f = std::tmpfile();
-  if (input.size()) std::fwrite(input.data(), 1, input.size(), f);
-  std::rewind(f);
-  rl_instream = f;
-  rl_outstream = std::fopen("/dev/null", "w");
-  char *r = readline("");
-  std::fclose(f);
-  if (rl_outstream) std::fclose(rl_outstream);
-  rl_instream = nullptr;
-  rl_outstream = nullptr;
-  return r;
-}
-
-static void expect(const std::string &in, const char *want) {
-  char *r = run(in);
-  if (r == nullptr || std::strcmp(r, want) != 0) {
-    std::fprintf(stderr, "FAIL run: got \"%s\", wanted \"%s\"\n", r ? r : "(null)", want);
-    failures++;
-  }
-  std::free(r);
-}
+using gnashtest::failures;
 
 int main() {
   rl_initialize();
@@ -57,18 +28,18 @@ int main() {
     CHECK(rl_parse_and_bind(line) == 0);
   }
   // "ab" C-a (to start) then C-o (our binding -> end-of-line) then 'Z' -> "abZ"
-  expect("ab\x01\x0f"
-         "Z\n",
-         "abZ");
+  gnashtest::expect_line("ab\x01\x0f"
+                         "Z\n",
+                         "abZ");
 
   // ---- bind a multi-key sequence: ESC [ Z (back-tab) -> beginning-of-line ----
   {
     char line[] = "\"\\e[Z\": beginning-of-line";
     CHECK(rl_parse_and_bind(line) == 0);
   }
-  expect("abc\x1b[Z"
-         "X\n",
-         "Xabc");
+  gnashtest::expect_line("abc\x1b[Z"
+                         "X\n",
+                         "Xabc");
 
   // ---- vi mode via `set editing-mode vi` ----
   {
@@ -79,15 +50,15 @@ int main() {
 
   // In vi: type "hello", ESC (command mode, cursor on 'o'), '0' (line start),
   // 'i' (insert), 'X', RET -> "Xhello".
-  expect("hello\x1b"
-         "0iX\r",
-         "Xhello");
+  gnashtest::expect_line("hello\x1b"
+                         "0iX\r",
+                         "Xhello");
 
   // vi: "world", ESC, 'x' deletes char under cursor ('d'? cursor on last 'd'),
   // -> "worl", RET.
-  expect("world\x1b"
-         "x\r",
-         "worl");
+  gnashtest::expect_line("world\x1b"
+                         "x\r",
+                         "worl");
 
   // Back to emacs for any later users.
   {
@@ -96,10 +67,5 @@ int main() {
   }
   CHECK(rl_editing_mode == 1);
 
-  if (failures == 0) {
-    std::printf("all bind/vi tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d bind/vi test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("bind/vi");
 }

--- a/tests/readline_complete_test.cpp
+++ b/tests/readline_complete_test.cpp
@@ -13,15 +13,9 @@
 #include "readline/history.h"
 #include "readline/readline.h"
 
-static int failures = 0;
+#include "readline_test_support.hpp"
 
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 // ---- a fixed word list used by the custom completion hook ----------------
 static const char *kWords[] = {"foobar", "foobaz", "fizz", nullptr};
@@ -62,30 +56,6 @@ static char **sort_attempt(const char *text, int /*start*/, int /*end*/) {
   return rl_completion_matches(text, sort_generator);
 }
 
-// Feed INPUT to readline(); return the produced line.
-static char *run(const std::string &input) {
-  FILE *f = std::tmpfile();
-  if (input.size()) std::fwrite(input.data(), 1, input.size(), f);
-  std::rewind(f);
-  rl_instream = f;
-  rl_outstream = std::fopen("/dev/null", "w");
-  char *r = readline("");
-  std::fclose(f);
-  if (rl_outstream) std::fclose(rl_outstream);
-  rl_instream = nullptr;
-  rl_outstream = nullptr;
-  return r;
-}
-
-static void expect(const std::string &in, const char *want) {
-  char *r = run(in);
-  if (r == nullptr || std::strcmp(r, want) != 0) {
-    std::fprintf(stderr, "FAIL run: got \"%s\", wanted \"%s\"\n", r ? r : "(null)", want);
-    failures++;
-  }
-  std::free(r);
-}
-
 int main() {
   // -- rl_completion_matches: longest common prefix + entries --------------
   char **m = rl_completion_matches("foo", word_generator);
@@ -103,18 +73,18 @@ int main() {
   rl_attempted_completion_function = attempt;
 
   // Ambiguous: "fo" -> common prefix "fooba" (no append, no accept yet).
-  expect("fo\t\n", "fooba");
+  gnashtest::expect_line("fo\t\n", "fooba");
   // Unique: "fi" -> "fizz" + append space.
-  expect("fi\t\n", "fizz ");
+  gnashtest::expect_line("fi\t\n", "fizz ");
 
   // zsh-style menu completion: the first TAB only lists the candidates (the
   // line is unchanged); each subsequent TAB inserts the next one, cycling and
   // wrapping.  (foobar/foobaz are the two matches for "foob".)
   rl_bind_key('\t', rl_menu_complete);
-  expect("foob\t\n", "foob");          // first TAB lists; line unchanged
-  expect("foob\t\t\n", "foobar");      // second TAB inserts the first candidate
-  expect("foob\t\t\t\n", "foobaz");    // next candidate
-  expect("foob\t\t\t\t\n", "foobar");  // wraps back to the first
+  gnashtest::expect_line("foob\t\n", "foob");          // first TAB lists; line unchanged
+  gnashtest::expect_line("foob\t\t\n", "foobar");      // second TAB inserts the first candidate
+  gnashtest::expect_line("foob\t\t\t\n", "foobaz");    // next candidate
+  gnashtest::expect_line("foob\t\t\t\t\n", "foobar");  // wraps back to the first
   rl_bind_key('\t', rl_complete);      // restore the default TAB completion
 
   rl_attempted_completion_function = nullptr;
@@ -123,10 +93,10 @@ int main() {
   // the order the generator produced them (Delta, alpha, Charlie, bravo).
   rl_attempted_completion_function = sort_attempt;
   rl_bind_key('\t', rl_menu_complete);
-  expect("\t\t\n", "alpha");          // 1st TAB lists, 2nd inserts sorted[0]
-  expect("\t\t\t\n", "bravo");        // sorted[1]
-  expect("\t\t\t\t\n", "Charlie");    // sorted[2]
-  expect("\t\t\t\t\t\n", "Delta");    // sorted[3]
+  gnashtest::expect_line("\t\t\n", "alpha");          // 1st TAB lists, 2nd inserts sorted[0]
+  gnashtest::expect_line("\t\t\t\n", "bravo");        // sorted[1]
+  gnashtest::expect_line("\t\t\t\t\n", "Charlie");    // sorted[2]
+  gnashtest::expect_line("\t\t\t\t\t\n", "Delta");    // sorted[3]
   rl_bind_key('\t', rl_complete);
   rl_attempted_completion_function = nullptr;
 
@@ -184,8 +154,8 @@ int main() {
     fclose(fopen((std::string(dir) + "/subfile").c_str(), "w"));
     rl_attempted_completion_function = nullptr;  // use filename completion
     rl_bind_key('\t', rl_menu_complete);
-    expect("sub\t\t\n", "subdir/");    // 1st TAB lists, 2nd inserts subdir + `/'
-    expect("sub\t\t\t\n", "subfile");  // next candidate is a file: no slash
+    gnashtest::expect_line("sub\t\t\n", "subdir/");    // 1st TAB lists, 2nd inserts subdir + `/'
+    gnashtest::expect_line("sub\t\t\t\n", "subfile");  // next candidate is a file: no slash
     rl_bind_key('\t', rl_complete);
     unlink((std::string(dir) + "/subfile").c_str());
     rmdir((std::string(dir) + "/subdir").c_str());
@@ -195,8 +165,8 @@ int main() {
     // already carrying those escapes (`zz\ s') still matches the real name.
     fclose(fopen((std::string(dir) + "/zz s$(x).txt").c_str(), "w"));
     rl_attempted_completion_function = nullptr;
-    expect("cat zz\t\n", "cat zz\\ s\\$\\(x\\).txt ");   // escaped + trailing space
-    expect("cat zz\\ s\t\n", "cat zz\\ s\\$\\(x\\).txt ");  // re-complete an escaped word
+    gnashtest::expect_line("cat zz\t\n", "cat zz\\ s\\$\\(x\\).txt ");   // escaped + trailing space
+    gnashtest::expect_line("cat zz\\ s\t\n", "cat zz\\ s\\$\\(x\\).txt ");  // re-complete an escaped word
     unlink((std::string(dir) + "/zz s$(x).txt").c_str());
 
     if (cwd) {
@@ -215,19 +185,14 @@ int main() {
   add_history("foobaz");
   add_history("find me");
   // C-r, type "bar", RET -> matches "foobar".
-  expect("\x12"
+  gnashtest::expect_line("\x12"
          "bar\r",
          "foobar");
   // C-r, type "baz", RET -> matches "foobaz".
-  expect("\x12"
+  gnashtest::expect_line("\x12"
          "baz\r",
          "foobaz");
   clear_history();
 
-  if (failures == 0) {
-    std::printf("all completion/isearch tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d completion/isearch test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("completion/isearch");
 }

--- a/tests/readline_dispatch_test.cpp
+++ b/tests/readline_dispatch_test.cpp
@@ -12,25 +12,12 @@
 #include "readline/history.h"
 #include "readline/readline.h"
 
-static int failures = 0;
+#include "readline_test_support.hpp"
 
-// Feed INPUT as keystrokes; return the (malloc'd) line readline() produces.
-static char *run(const std::string &input) {
-  FILE *f = std::tmpfile();
-  if (input.size()) std::fwrite(input.data(), 1, input.size(), f);
-  std::rewind(f);
-  rl_instream = f;
-  rl_outstream = std::fopen("/dev/null", "w");
-  char *r = readline("");
-  std::fclose(f);
-  if (rl_outstream) std::fclose(rl_outstream);
-  rl_instream = nullptr;
-  rl_outstream = nullptr;
-  return r;
-}
+using gnashtest::failures;
 
 static void expect(const std::string &input, const char *want) {
-  char *r = run(input);
+  char *r = gnashtest::run(input);
   if (r == nullptr || std::strcmp(r, want) != 0) {
     std::fprintf(stderr, "FAIL run(%s): got \"%s\", wanted \"%s\"\n",
                  // show input with control chars escaped
@@ -54,7 +41,7 @@ static void expect(const std::string &input, const char *want) {
 }
 
 static void expect_null(const std::string &input) {
-  char *r = run(input);
+  char *r = gnashtest::run(input);
   if (r != nullptr) {
     std::fprintf(stderr, "FAIL: expected NULL (EOF), got \"%s\"\n", r);
     failures++;
@@ -100,10 +87,5 @@ int main() {
   expect("\x1b[A\x1b[B\n", "");            // Up then Down -> back to empty typed line
   clear_history();
 
-  if (failures == 0) {
-    std::printf("all readline dispatch tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d readline dispatch test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("readline dispatch");
 }

--- a/tests/readline_edit_test.cpp
+++ b/tests/readline_edit_test.cpp
@@ -12,17 +12,11 @@
 #include "gnash/readline.hpp"
 #include "readline/readline.h"
 
+#include "testcheck.hpp"
+
 namespace rl = gnash::readline;
 
-static int failures = 0;
-
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 static void check_line(const char *want) {
   if (rl::line() != want) {
@@ -121,10 +115,5 @@ int main() {
   rl_downcase_word(1, 0);
   check_line("hello");
 
-  if (failures == 0) {
-    std::printf("all readline editing tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d readline editing test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("readline editing");
 }

--- a/tests/readline_test_support.hpp
+++ b/tests/readline_test_support.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// readline_test_support.hpp -- shared helpers for the readline unit tests.
+//
+// The readline tests drive readline() from an in-memory byte stream instead
+// of a tty; this header provides that driver and the line-comparison check
+// the tests build on it.
+
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "readline/readline.h"
+
+#include "testcheck.hpp"
+
+namespace gnashtest {
+
+// Feed INPUT as keystrokes; return the (malloc'd) line readline() produces,
+// or nullptr on EOF.  Output goes to /dev/null.
+inline char *run(const std::string &input) {
+  FILE *f = std::tmpfile();
+  if (input.size()) std::fwrite(input.data(), 1, input.size(), f);
+  std::rewind(f);
+  rl_instream = f;
+  rl_outstream = std::fopen("/dev/null", "w");
+  char *r = readline("");
+  std::fclose(f);
+  if (rl_outstream) std::fclose(rl_outstream);
+  rl_instream = nullptr;
+  rl_outstream = nullptr;
+  return r;
+}
+
+// Assert that readline() over INPUT returns exactly WANT (freed afterwards).
+inline void expect_line(const std::string &in, const char *want) {
+  char *r = run(in);
+  if (r == nullptr || std::strcmp(r, want) != 0) {
+    std::fprintf(stderr, "FAIL run: got \"%s\", wanted \"%s\"\n", r ? r : "(null)", want);
+    failures++;
+  }
+  std::free(r);
+}
+
+}  // namespace gnashtest

--- a/tests/termcap_test.cpp
+++ b/tests/termcap_test.cpp
@@ -13,15 +13,9 @@
 #include "gnash/termcap.hpp"
 #include "termcap.h"
 
-static int failures = 0;
+#include "testcheck.hpp"
 
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 static bool str_is(const char *cap, const char *want) {
   char *s = tgetstr(cap, nullptr);
@@ -81,10 +75,5 @@ int main() {
   auto ce = gnash::termcap::str("ce");
   CHECK(ce && *ce == std::string("\033[K"));
 
-  if (failures == 0) {
-    std::printf("all termcap tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d termcap test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("termcap");
 }

--- a/tests/testcheck.hpp
+++ b/tests/testcheck.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brian J. Fox
+// Licensed under GPLv2 with the GPLv2-AI Exception.
+
+// testcheck.hpp -- shared scaffolding for the standalone unit-test
+// executables in this directory.
+//
+// Each test is a small program that counts failures and exits nonzero if
+// any check failed.  This header holds the pieces every test shares so they
+// are not re-pasted file by file:
+//   - failures: the shared failure counter (each test TU imports it with a
+//               `using gnashtest::failures;' right after the include)
+//   - CHECK:    assert a condition, printing file:line and counting it
+//   - count_of: count non-overlapping occurrences of a needle in a string
+//   - finish:   print the pass/fail summary and return the exit status
+
+#pragma once
+
+#include <cstdio>
+#include <string>
+
+namespace gnashtest {
+
+// The test's failure counter.
+inline int failures = 0;
+
+// Print the per-test summary and return the process exit status.  LABEL is
+// the test's noun: finish("tilde") prints "all tilde tests passed" or
+// "<n> tilde test(s) failed".
+inline int finish(const char *label) {
+  if (failures == 0) {
+    std::printf("all %s tests passed\n", label);
+    return 0;
+  }
+  std::fprintf(stderr, "%d %s test(s) failed\n", failures, label);
+  return 1;
+}
+
+// Count non-overlapping occurrences of NEEDLE in HAY.
+inline size_t count_of(const std::string &hay, const std::string &needle) {
+  size_t n = 0;
+  for (size_t at = hay.find(needle); at != std::string::npos;
+       at = hay.find(needle, at + needle.size()))
+    n++;
+  return n;
+}
+
+}  // namespace gnashtest
+
+// Report a failed condition with file:line context and count it in the
+// shared `failures' counter (imported into the test's global scope).
+#define CHECK(cond)                                                       \
+  do {                                                                    \
+    if (!(cond)) {                                                        \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      failures++;                                                         \
+    }                                                                     \
+  } while (0)

--- a/tests/tilde_test.cpp
+++ b/tests/tilde_test.cpp
@@ -14,15 +14,9 @@
 #include "gnash/tilde.hpp"
 #include "readline/tilde.h"
 
-static int failures = 0;
+#include "testcheck.hpp"
 
-#define CHECK(cond)                                                        \
-  do {                                                                     \
-    if (!(cond)) {                                                         \
-      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
-      failures++;                                                          \
-    }                                                                      \
-  } while (0)
+using gnashtest::failures;
 
 static void expect(const char *in, const char *want) {
   char *r = tilde_expand(in);
@@ -58,10 +52,5 @@ int main() {
   CHECK(gnash::tilde::expand("~/z") == "/test/home/z");
   CHECK(gnash::tilde::expand_word("~") == "/test/home");
 
-  if (failures == 0) {
-    std::printf("all tilde tests passed\n");
-    return 0;
-  }
-  std::fprintf(stderr, "%d tilde test(s) failed\n", failures);
-  return 1;
+  return gnashtest::finish("tilde");
 }


### PR DESCRIPTION
### Summary                                                                                                           
                                                                                                                       
 This PR is a pure-refactor ~26 files (+1605 / −1903). All four commits are behavior-preserving; no user-visible output or shell semantics change.                                                                        
                                                                                                                       
 ### Changes                                                                                           
                                                                                                                       
 1. Extract inlined builtins from run_builtin into bi_* functions (26da16f)                                            
 - run_builtin was a 922-line if/else chain with 13 builtins (shift, exit, return, break/continue, eval, source/.,     
   wait, jobs, fg, bg, disown, command, exec) implemented inline rather than as bi_* functions like every other        
   builtin.                                                                                                            
 - Each is now a file-local bi_* function with a byte-identical body; plain builtins dispatch through a name→handler   
   table.                                                                                                              
 - run_builtin is down to 81 lines: the no-ops, multi-name aliases, declare family, and table lookup.                  
                                                                                                                       
 2. Consolidate duplicated quoting idioms into quote.hpp (eca2b89)                                                     
 - Single-quote, double-quote, sh_contains_shell_metas, non-printable test, and byte-oriented $'...' quoting loops     
   were copy-pasted across builtins.cpp, ast.cpp, and expand.cpp (7, 4, 2, 2, and 2 copies respectively).              
 - Moved into shared inline helpers in core/include/gnash/core/quote.hpp; all call sites are behavior-preserving       
   one-line substitutions.                                                                                             
                                                                                                                       
 3. Print runtime errors via a new Shell::errorf (ed29369)                                                             
 - Adds Shell::errorf(fmt, ...), which prepends err_prefix() and writes to stderr.                                     
 - Converts all 351 error call sites from std::fprintf(stderr, "%s...", X.err_prefix().c_str(), ...) to X.errorf(...). 
                                                                                                                       
 4. Share scaffolding via common test headers (24ceb88)                                                                
 - Extracts the duplicated failure counter, CHECK macro, pass/fail summary, and readline driver helpers into           
   tests/testcheck.hpp and tests/readline_test_support.hpp.                                                            
                                                                                                                       
 ### Verification                                                                                                      
                                                                                                                       
 - Output verified against the baseline binary on 450+ scripts (commit 3).                               
 - Full ctest suite passes.                                                                                            
                                                                                                                       
 ### Motivation                                                                                                        
                                                                                                                       
 Removes ~300 lines of duplication, makes all builtins uniformly structured, and gives error reporting a single API.